### PR TITLE
Add initialTick to currentTickInfo

### DIFF
--- a/src/network_messages/tick.h
+++ b/src/network_messages/tick.h
@@ -140,5 +140,6 @@ struct CurrentTickInfo
     unsigned int tick;
     unsigned short numberOfAlignedVotes;
     unsigned short numberOfMisalignedVotes;
+    unsigned short initialTick;
 };
 

--- a/src/network_messages/tick.h
+++ b/src/network_messages/tick.h
@@ -140,6 +140,6 @@ struct CurrentTickInfo
     unsigned int tick;
     unsigned short numberOfAlignedVotes;
     unsigned short numberOfMisalignedVotes;
-    unsigned short initialTick;
+    unsigned int initialTick;
 };
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -934,6 +934,7 @@ static void processRequestCurrentTickInfo(Peer* peer, RequestResponseHeader* hea
         currentTickInfo.tick = system.tick;
         currentTickInfo.numberOfAlignedVotes = tickNumberOfComputors;
         currentTickInfo.numberOfMisalignedVotes = (tickTotalNumberOfComputors - tickNumberOfComputors);
+        currentTickInfo.initialTick = system.initialTick;
     }
     else
     {


### PR DESCRIPTION
" I need system.initialTick from a network request in order to be able to make the API service do seamless epoch transitions. cannot find any request with that data. Can we add initialTick to struct CurrentTickInfo?"

https://discord.com/channels/768887649540243497/1087017597133922474/1195012474253086854
"Yes, add it" from Come-from-Beyond

My idea is to check time for new epoch, then to stop processing until a new epoch computors list is validated. All the epoch processing is using a hard coded start to the epoch and this currently requires a recompile with new value. By making this value accessible from a network request, the hardcoded value can be replace with a variable that is updated on-the-fly on epoch transitions