### PR TITLE
add tracking transferID for archival service

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -113,14 +113,26 @@ struct QuTransfer
     m256i sourcePublicKey;
     m256i destinationPublicKey;
     long long amount;
-
+#if LOG_QU_TRANSFERS && LOG_QU_TRANSFERS_TRACK_TRANSFER_ID
+    long long transferId;
+#endif
     char _terminator; // Only data before "_terminator" are logged
 };
+
+#if LOG_QU_TRANSFERS && LOG_QU_TRANSFERS_TRACK_TRANSFER_ID
+long long CurrentTransferId = 0;
+static volatile char CurrentTransferIdLock = 0;
+#endif
 
 template <typename T>
 static void logQuTransfer(T message)
 {
 #if LOG_QU_TRANSFERS
+#if LOG_QU_TRANSFERS_TRACK_TRANSFER_ID
+    ACQUIRE(CurrentTransferIdLock);
+    message.transferId = CurrentTransferId++;
+    RELEASE(CurrentTransferIdLock);
+#endif
     logMessage(offsetof(T, _terminator), QU_TRANSFER, &message);
 #endif
 }

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -18,6 +18,7 @@ static const unsigned char knownPublicPeers[][4] = {
 
 #define LOG_BUFFER_SIZE 16777200 // Must be less or equal to 16777200
 #define LOG_QU_TRANSFERS 0 // "0" disables logging, "1" enables it
+#define LOG_QU_TRANSFERS_TRACK_TRANSFER_ID 0
 #define LOG_ASSET_ISSUANCES 0
 #define LOG_ASSET_OWNERSHIP_CHANGES 0
 #define LOG_ASSET_POSSESSION_CHANGES 0

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -2428,6 +2428,10 @@ static void beginEpoch1of2()
     if (solutionThreshold[system.epoch] <= 0 || solutionThreshold[system.epoch] > DATA_LENGTH) { // invalid threshold
         solutionThreshold[system.epoch] = SOLUTION_THRESHOLD_DEFAULT;
     }
+
+#if LOG_QU_TRANSFERS && LOG_QU_TRANSFERS_TRACK_TRANSFER_ID
+    CurrentTransferId = 0;
+#endif
 }
 
 static void beginEpoch2of2()


### PR DESCRIPTION
This change aims to solve the corner case for 3rd party archival services that track Qubic based on Log system.
`transferID` will make it more intuitive and easier to distinguish between transfers, especially when a smart contract (SC) transfers the same amount of Qu to the same address multiple times in 1 invocation.
@philippwerner 