### PR TITLE
Correctly update computer digest when state of contract 0 is changed

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1475,6 +1475,7 @@ static long long __burn(long long amount)
     {
         Contract0State* contract0State = (Contract0State*)contractStates[0];
         contract0State->contractFeeReserves[executedContractIndex] += amount;
+        contractStateChangeFlags[0] |= 1ULL;
 
         const Burning burning = { currentContract , amount };
         logBurning(burning);
@@ -2795,6 +2796,7 @@ static void endEpoch()
             }
 
             contract0State->contractFeeReserves[contractIndex] = finalPrice * NUMBER_OF_COMPUTORS;
+            contractStateChangeFlags[0] |= 1ULL;
         }
     }
 


### PR DESCRIPTION
When contract 0 state is changed, set flag for updating digest.

This fixes an issue that led to misalignment between nodes that survived the seamless epoch transition at April 3, 2024 (no full update of computer digest) and nodes that were restarted (forced full computing of computer digest after reloading contract files).