### PR TITLE
Add siblings for respond assets.

### DIFF
--- a/src/assets.h
+++ b/src/assets.h
@@ -13,8 +13,6 @@
 #include "kangaroo_twelve.h"
 #include "four_q.h"
 
-#define ASSETS_CAPACITY 0x1000000ULL // Must be 2^N
-#define ASSETS_DEPTH 24 // Is derived from ASSETS_CAPACITY (=N)
 
 
 
@@ -306,6 +304,8 @@ iteration:
         {
             bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(Asset));
             response.tick = system.tick;
+            response.universeIndex = universeIndex;
+            getSiblings<ASSETS_DEPTH>(response.universeIndex, assetDigests, response.siblings);
 
             enqueueResponse(peer, sizeof(response), RespondIssuedAssets::type, header->dejavu(), &response);
         }
@@ -342,6 +342,8 @@ iteration:
             bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(Asset));
             bs->CopyMem(&response.issuanceAsset, &assets[assets[universeIndex].varStruct.ownership.issuanceIndex], sizeof(Asset));
             response.tick = system.tick;
+            response.universeIndex = universeIndex;
+            getSiblings<ASSETS_DEPTH>(response.universeIndex, assetDigests, response.siblings);
 
             enqueueResponse(peer, sizeof(response), RespondOwnedAssets::type, header->dejavu(), &response);
         }
@@ -379,6 +381,8 @@ iteration:
             bs->CopyMem(&response.ownershipAsset, &assets[assets[universeIndex].varStruct.possession.ownershipIndex], sizeof(Asset));
             bs->CopyMem(&response.issuanceAsset, &assets[assets[assets[universeIndex].varStruct.possession.ownershipIndex].varStruct.ownership.issuanceIndex], sizeof(Asset));
             response.tick = system.tick;
+            response.universeIndex = universeIndex;
+            getSiblings<ASSETS_DEPTH>(response.universeIndex, assetDigests, response.siblings);
 
             enqueueResponse(peer, sizeof(response), RespondPossessedAssets::type, header->dejavu(), &response);
         }

--- a/src/network_messages/assets.h
+++ b/src/network_messages/assets.h
@@ -74,7 +74,8 @@ struct RespondIssuedAssets
 {
     Asset asset;
     unsigned int tick;
-    // TODO: Add siblings
+    unsigned int universeIndex;
+    m256i siblings[ASSETS_DEPTH];
 
     enum {
         type = 37,
@@ -99,7 +100,8 @@ struct RespondOwnedAssets
     Asset asset;
     Asset issuanceAsset;
     unsigned int tick;
-    // TODO: Add siblings
+    unsigned int universeIndex;
+    m256i siblings[ASSETS_DEPTH];
 
     enum {
         type = 39,
@@ -125,7 +127,8 @@ struct RespondPossessedAssets
     Asset ownershipAsset;
     Asset issuanceAsset;
     unsigned int tick;
-    // TODO: Add siblings
+    unsigned int universeIndex;
+    m256i siblings[ASSETS_DEPTH];
 
     enum {
         type = 41,

--- a/src/network_messages/common_def.h
+++ b/src/network_messages/common_def.h
@@ -57,7 +57,9 @@ static inline bool operator!=(const IPv4Address& a, const IPv4Address& b)
 {
     return a.u32 != b.u32;
 }
-// Compute the siblings array of each level of tree
+
+// Compute the siblings array of each level of tree. This function is not thread safe
+// make sure resource protection is handled outside
 template <unsigned int depth>
 static void getSiblings(int digestIndex, const m256i* digests, m256i siblings[depth])
 {

--- a/src/network_messages/common_def.h
+++ b/src/network_messages/common_def.h
@@ -7,6 +7,9 @@
 #define NUMBER_OF_EXCHANGED_PEERS 4
 #define SPECTRUM_DEPTH 24 // Defines SPECTRUM_CAPACITY (1 << SPECTRUM_DEPTH)
 
+#define ASSETS_CAPACITY 0x1000000ULL // Must be 2^N
+#define ASSETS_DEPTH 24 // Is derived from ASSETS_CAPACITY (=N)
+
 #define MAX_INPUT_SIZE 1024ULL
 #define ISSUANCE_RATE 1000000000000LL
 #define MAX_AMOUNT (ISSUANCE_RATE * 1000ULL)
@@ -53,4 +56,18 @@ static inline bool operator==(const IPv4Address& a, const IPv4Address& b)
 static inline bool operator!=(const IPv4Address& a, const IPv4Address& b)
 {
     return a.u32 != b.u32;
+}
+// Compute the siblings array of each level of tree
+template <unsigned int depth>
+static void getSiblings(int digestIndex, const m256i* digests, m256i siblings[depth])
+{
+    const unsigned int capacity = (1ULL << depth);
+    int siblingIndex = digestIndex;
+    unsigned int digestOffset = 0;
+    for (unsigned int j = 0; j < depth; j++)
+    {
+        siblings[j] = digests[digestOffset + (siblingIndex ^ 1)];
+        digestOffset += (capacity >> j);
+        siblingIndex >>= 1;
+    }
 }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1011,14 +1011,7 @@ static void processRequestEntity(Peer* peer, RequestResponseHeader* header)
     {
         bs->CopyMem(&respondedEntity.entity, &spectrum[respondedEntity.spectrumIndex], sizeof(::Entity));
 
-        int sibling = respondedEntity.spectrumIndex;
-        unsigned int spectrumDigestInputOffset = 0;
-        for (unsigned int j = 0; j < SPECTRUM_DEPTH; j++)
-        {
-            respondedEntity.siblings[j] = spectrumDigests[spectrumDigestInputOffset + (sibling ^ 1)];
-            spectrumDigestInputOffset += (SPECTRUM_CAPACITY >> j);
-            sibling >>= 1;
-        }
+        getSiblings<SPECTRUM_DEPTH>(respondedEntity.spectrumIndex, spectrumDigests, respondedEntity.siblings);
     }
 
     enqueueResponse(peer, sizeof(respondedEntity), RESPOND_ENTITY, header->dejavu(), &respondedEntity);


### PR DESCRIPTION
This PR add support for respond asset with the siblings.
The example result is as below
```
./qubic-cli -nodeip <IP> -getasset IUSERMFNNDLCYBFJRARDDEZWNFOBDKBXXPZQYOZIAACDZEYQOOJPXEGDXKEE
======== OWNERSHIP ========
Asset issuer: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFXIB
Asset name: QX
Managing contract index: 1
Issuance Index: 1
Number Of Units: 68
Asset Digest: 46285cb31737544ed56c9b8ac9500bfec425e642d7e276a571f73088fb6a458c
Tick: 13820031
Asset issuer: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFXIB
Asset name: RANDOM
Managing contract index: 1
Issuance Index: 0
Number Of Units: 68
Asset Digest: 46285cb31737544ed56c9b8ac9500bfec425e642d7e276a571f73088fb6a458c
Tick: 13820031
======== POSSESSION ========
Asset issuer: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFXIB
Asset name: QX
Managing contract index: 1
Owner index: 13011080
Owner ID: IUSERMFNNDLCYBFJRARDDEZWNFOBDKBXXPZQYOZIAACDZEYQOOJPXEGDXKEE
Number Of Units: 68
Asset Digest: 46285cb31737544ed56c9b8ac9500bfec425e642d7e276a571f73088fb6a458c
Tick: 13820031
Asset issuer: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFXIB
Asset name: RANDOM
Managing contract index: 1
Owner index: 13011082
Owner ID: IUSERMFNNDLCYBFJRARDDEZWNFOBDKBXXPZQYOZIAACDZEYQOOJPXEGDXKEE
Number Of Units: 68
Asset Digest: 46285cb31737544ed56c9b8ac9500bfec425e642d7e276a571f73088fb6a458c
Tick: 13820031

####################################################
./qubic-cli -nodeip <IP> -getquorumtick ./computorlist.txt 13820031
Received 479 quorum tick #13820031 (votes)
Received 473 quorum tick #13820032 (votes)
Performing salt check...
ALL votes PASSED salts check
Number of unique votes: 1
Vote #0 (voted by 479 computors ID) Epoch: 108
Tick: 13820031
Time: 2024-05-08 12:20:44.0000
prevResourceTestingDigest: a99c15250fc377bb
prevSpectrumDigest: 804d96d95920db88fcb06cd6fae3ef65c295f71917e6ffdf76b90a885e7f0a20
prevUniverseDigest: 46285cb31737544ed56c9b8ac9500bfec425e642d7e276a571f73088fb6a458c
prevComputerDigest: a7cfad48b1151df81db03fc8b0c521de76d1f4e3d48528aff33f0b456c6be597
transactionDigest: d75fbd22f5ed6f67a08cfbb07972227579e406ea3303c354f46b8e4e47eded82
expectedNextTickTransactionDigest: 88e4b84fa018bd7337b6c118c6523424df3ca06bafc27e6edb81965db5b02ac6
```