### PR TITLE
Add white list IPs preserved slots.

### DIFF
--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -25,7 +25,7 @@
 #define RESPONSE_QUEUE_LENGTH 65536 // Must be 65536
 #define NUMBER_OF_PUBLIC_PEERS_TO_KEEP 10
 #define NUMBER_OF_WHITE_LIST_PEERS sizeof(whiteListPeers) / sizeof(whiteListPeers[0])
-#define NUMBER_OF_PRESERVE_SLOTS_WHITE_LIST_IPS 16
+#define NUMBER_OF_INCOMING_CONNECTIONS_RESERVED_FOR_WHITELIST_IPS 16
 static_assert((NUMBER_OF_INCOMING_CONNECTIONS / NUMBER_OF_OUTGOING_CONNECTIONS) >= 11, "Number of incoming connections must be x11+ number of outgoing connections to keep healthy network");
 
 static volatile bool listOfPeersIsStatic = false;
@@ -466,7 +466,7 @@ static bool peerConnectionNewlyEstablished(unsigned int i)
                     else
                     {
                         // Out of slot for preserse IPs. Only accept white list IPs
-                        if (NUMBER_OF_INCOMING_CONNECTIONS - numberOfAcceptedIncommingConnection < NUMBER_OF_PRESERVE_SLOTS_WHITE_LIST_IPS)
+                        if (NUMBER_OF_INCOMING_CONNECTIONS - numberOfAcceptedIncommingConnection < NUMBER_OF_INCOMING_CONNECTIONS_RESERVED_FOR_WHITELIST_IPS)
                         {
                             EFI_TCP4_CONFIG_DATA tcp4ConfigData;
                             if (peers[i].tcp4Protocol 

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -120,13 +120,6 @@ static void closePeer(Peer* peer)
 {
     if (((unsigned long long)peer->tcp4Protocol) > 1)
     {
-        // Decrease the accepted counter
-        if (peer->isConnectedAccepted && peer->isIncommingConnection)
-        {
-            numberOfAcceptedIncommingConnection--;
-            ASSERT(numberOfAcceptedIncommingConnection >= 0);
-        }
-
         if (!peer->isClosing)
         {
             EFI_STATUS status;
@@ -147,10 +140,18 @@ static void closePeer(Peer* peer)
                 logStatusToConsole(L"EFI_TCP4_SERVICE_BINDING_PROTOCOL.DestroyChild() fails", status, __LINE__);
             }
 
+            // Decrease the accepted counter
+            if (peer->isConnectedAccepted && peer->isIncommingConnection)
+            {
+                numberOfAcceptedIncommingConnection--;
+                ASSERT(numberOfAcceptedIncommingConnection >= 0);
+            }
+
             peer->isConnectedAccepted = FALSE;
             peer->exchangedPublicPeers = FALSE;
             peer->isClosing = FALSE;
             peer->tcp4Protocol = NULL;
+
         }
     }
 }

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -15,6 +15,9 @@ static unsigned char computorSeeds[][55 + 1] = {
 static const unsigned char knownPublicPeers[][4] = {
     {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
 };
+static const unsigned char whiteListPeers[][4] = {
+     {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
+};
 
 #define LOG_BUFFER_SIZE 16777200 // Must be less or equal to 16777200
 #define LOG_QU_TRANSFERS 0 // "0" disables logging, "1" enables it

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -15,6 +15,9 @@ static unsigned char computorSeeds[][55 + 1] = {
 static const unsigned char knownPublicPeers[][4] = {
     {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
 };
+
+// Enter static IPs that shall be prioritized in incoming connection
+// There are a connection slots reserved for those whitelist IPs
 static const unsigned char whiteListPeers[][4] = {
      {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
 };

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4589,6 +4589,16 @@ static bool initialize()
         peers[i].receiveToken.Packet.RxData = &peers[i].receiveData;
         peers[i].transmitToken.CompletionToken.Status = -1;
         peers[i].transmitToken.Packet.TxData = &peers[i].transmitData;
+
+        // Init the connection type as 
+        if (i < NUMBER_OF_OUTGOING_CONNECTIONS)
+        {
+            peers[i].isIncommingConnection = FALSE;
+        }
+        else
+        {
+            peers[i].isIncommingConnection = TRUE;
+        }
     }
 
     // add knownPublicPeers to list of peers (all with verified status)


### PR DESCRIPTION
This PR try to preserve slots for white list IPs. Still get a crashing issue when I simulate ~200 incoming connection and likely crash at  [this line](https://github.com/qubic/core/compare/develop...cyber-pc:qubic-core:priority-ips-white-list?expand=1#diff-1e4db860dc6d80eb1bf96bfbe3bbadf76d945cf498219a375db7f5c8fd6877e3R463)

@philippwerner can you help me review the dropping connection part. It is quite simple but not sure why the crash happens.