### PR TITLE
Improve the score computation and update setting neuron number = 16384, duration = 4096.

### DIFF
--- a/src/kangaroo_twelve.h
+++ b/src/kangaroo_twelve.h
@@ -2490,14 +2490,14 @@ static void KangarooTwelve64To32(const void* input, void* output)
     KangarooTwelve64To32((const unsigned char*)input, (unsigned char*)output);
 }
 
-static void random(const unsigned char* publicKey, const unsigned char* nonce, unsigned char* output, unsigned int outputSize)
+static void random(const unsigned char* publicKey, const unsigned char* nonce, unsigned char* output, unsigned long long outputSize)
 {
     unsigned char state[200];
     *((__m256i*) & state[0]) = *((__m256i*)publicKey);
     *((__m256i*) & state[32]) = *((__m256i*)nonce);
     setMem(&state[64], sizeof(state) - 64, 0);
 
-    for (unsigned int i = 0; i < outputSize / sizeof(state); i++)
+    for (unsigned long long i = 0; i < outputSize / sizeof(state); i++)
     {
         KeccakP1600_Permute_12rounds(state);
         copyMem(output, state, sizeof(state));

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -68,10 +68,10 @@ static unsigned short CONTRACT_FILE_NAME[] = L"contract????.???";
 static unsigned short REVENUE_FILE_NAME[] = L"revenueScore"; // TODO: for testing purpose, will delete at epoch 111
 
 #define DATA_LENGTH 256
-#define NUMBER_OF_INPUT_NEURONS 32768
-#define NUMBER_OF_OUTPUT_NEURONS 32768
-#define MAX_INPUT_DURATION 256
-#define MAX_OUTPUT_DURATION 256
+#define NUMBER_OF_INPUT_NEURONS 16384
+#define NUMBER_OF_OUTPUT_NEURONS 16384
+#define MAX_INPUT_DURATION 4096
+#define MAX_OUTPUT_DURATION 4096
 #define NEURON_VALUE_LIMIT 1LL
 #define SOLUTION_THRESHOLD_DEFAULT 44
 

--- a/src/score.h
+++ b/src/score.h
@@ -26,12 +26,14 @@ struct ScoreFunction
 {
     static constexpr const int inNeuronsCount = numberOfInputNeurons + dataLength;
     static constexpr const int maxNeuronsCount = inNeuronsCount;
-    static constexpr const int allParamsCount = dataLength + numberOfInputNeurons + dataLength;
+    static constexpr const unsigned long long allParamsCount = dataLength + numberOfInputNeurons + dataLength;
+    static constexpr unsigned long long synapseInputSize =inNeuronsCount * allParamsCount;
     long long miningData[dataLength];
     struct synapseStruct
     {
-        char inputLength[inNeuronsCount * allParamsCount];
-    } *_synapses;
+        char* inputLength = nullptr;
+    };
+    synapseStruct *_synapses;
 
     struct queueItem {
         unsigned int tick;
@@ -189,6 +191,26 @@ struct ScoreFunction
         }
     }
 
+    ~ScoreFunction()
+    {
+        freeMemory();
+    }
+
+    void freeMemory()
+    {
+        if (_synapses)
+        {
+            for (unsigned int i = 0; i < solutionBufferCount; i++)
+            {
+                if (_synapses[i].inputLength)
+                {
+                    freePool(_synapses[i].inputLength);
+                }
+            }
+            freePool(_synapses);
+        }
+    }
+
     bool initMemory()
     {
         // TODO: call freePool() for buffers allocated below
@@ -197,6 +219,15 @@ struct ScoreFunction
             {
                 logToConsole(L"Failed to allocate memory for score solution buffer!");
                 return false;
+            }
+
+            for (unsigned int i = 0; i < solutionBufferCount; i++)
+            {
+                if (!allocatePool(synapseInputSize, (void**)&(_synapses[i].inputLength)))
+                {
+                    logToConsole(L"Failed to allocate memory for synapses input length!");
+                    return false;
+                }
             }
         }
         if (_computeBuffer == nullptr) {
@@ -225,7 +256,8 @@ struct ScoreFunction
         }
 
         for (int i = 0; i < solutionBufferCount; i++) {
-            setMem(&_synapses[i], sizeof(synapseStruct), 0);
+            //setMem(&_synapses[i], sizeof(synapseStruct), 0);
+            setMem(_synapses[i].inputLength, synapseInputSize, 0);
             setMem(&_computeBuffer[i].neurons, sizeof(_computeBuffer[i].neurons), 0);            
             _computeBuffer[i].inputLength = nullptr;
             setMem(_computeBuffer[i].indicePos[0], sizeof(unsigned int) * allParamsCount * maxNeuronsCount, 0); // it's continuous memory region
@@ -439,7 +471,7 @@ struct ScoreFunction
         const int outNrIdx) {
         char v = 0;
         for (int i = 0; i < neurBefore; i++) {
-            int idx = neuronIdx * allParamsCount + i;
+            unsigned long long idx = neuronIdx * allParamsCount + i;
             const char s = sy[idx];
             if (s == 1 || s == -1 && pNr[i])
             {
@@ -489,7 +521,7 @@ struct ScoreFunction
             }
             if (!cb.isGeneratedSynapse[idx])
             {
-                continueGeneratingSynapseFromCkp(cb.sckpInput[idx][0], (unsigned char*)cb.inputLength + idx * allParamsCount, allParamsCount);
+                continueGeneratingSynapseFromCkp(cb.sckpInput[idx][0], (unsigned char*)cb.inputLength + idx * (unsigned long long)allParamsCount, allParamsCount);
                 zeroOutSynapses(cb.inputLength + idx * allParamsCount, idx);
                 cb.isGeneratedSynapse[idx] = true;
             }

--- a/src/score.h
+++ b/src/score.h
@@ -161,11 +161,10 @@ struct ScoreFunction
     } *_computeBuffer = nullptr;
     unsigned int* _indiceBigBuffer = nullptr;
 
-    static_assert(maxInputDuration <= 256, "Need to regenerate mod num table");
     // _totalModNum[i]: total of divisible numbers of i
-    unsigned char _totalModNum[257];
+    unsigned char _totalModNum[maxInputDuration + 1];
     // i is divisible by _modNum[i][j], j < _totalModNum[i]
-    unsigned char _modNum[257][129];
+    unsigned char _modNum[maxInputDuration + 1][129];
 
     m256i initialRandomSeed;
 
@@ -188,7 +187,7 @@ struct ScoreFunction
         setMem(_modNum, sizeof(_modNum), 0);
 
         // init the divisible table
-        for (int i = 1; i <= 256; i++) {
+        for (int i = 1; i <= maxInputDuration; i++) {
             for (int j = 1; j <= 127; j++) { // exclude 128
                 if (j && i % j == 0) {
                     _modNum[i][_totalModNum[i]++] = j;

--- a/src/score.h
+++ b/src/score.h
@@ -30,6 +30,7 @@ struct ScoreFunction
     static constexpr unsigned long long priorSynapsesLength = 3200;
     static constexpr unsigned long long priorSynapsesOffset = allParamsCount - priorSynapsesLength;
     static constexpr unsigned int numberOfCheckPoints = 2;
+    static constexpr unsigned int maxNumMods = 48;
 
     long long miningData[dataLength];
     struct synapseStruct
@@ -148,11 +149,12 @@ struct ScoreFunction
         bool isGeneratedBucketOffset[inNeuronsCount];
 
         static_assert((allParamsCount) % 8 == 0, "need to check this packed synapse");
+        static_assert(maxInputDuration <= 4096, "need to check this maxInputDuration and adjust maxNumMods");
 
         queueItem queue[allParamsCount * 2];
         bool isProcessing[allParamsCount * 2];
         queueState state[allParamsCount * 2];
-        unsigned int _maxIndexBuffer[allParamsCount * 2][32];
+        unsigned int _maxIndexBuffer[allParamsCount * 2][maxNumMods];
         int buffer[256];
         K12EngineX1 k12;
         synapseCheckpoint sckpInput[(numberOfInputNeurons + dataLength)][numberOfCheckPoints];

--- a/test/score.cpp
+++ b/test/score.cpp
@@ -46,6 +46,7 @@ struct ScoreTester
         memset(score, 0, sizeof(ScoreFuncOpt));
         memset(score_ref_impl, 0, sizeof(ScoreFuncRef));
         EXPECT_TRUE(score->initMemory());
+        score_ref_impl->initMemory();
         score->initMiningData(_mm256_setzero_si256());
         score_ref_impl->initMiningData();
     }

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -50,6 +50,10 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This PR changes as below

- Support the bigger of number of neurons
- Speed up the score computation
- Decrease the number of neurons to **16384**
- Increase the duration to **4096**
 
The performance is about 0.43s on Ryzen 9 7950x.

All unit-tests in https://github.com/qubic/core/blob/main/test/score.cpp#L88-L117 is passed. 

cc: @krypdkat 