### PR TITLE
Feature/2024 08 09 contract system proc revision

### DIFF
--- a/src/Qubic.vcxproj
+++ b/src/Qubic.vcxproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ClInclude Include="addons\tx_status_request.h" />
     <ClInclude Include="assets.h" />
+    <ClInclude Include="contracts\EmptyTemplate.h" />
     <ClInclude Include="contracts\math_lib.h" />
     <ClInclude Include="contracts\MyLastMatch.h" />
     <ClInclude Include="contracts\qpi.h" />

--- a/src/Qubic.vcxproj.filters
+++ b/src/Qubic.vcxproj.filters
@@ -142,6 +142,9 @@
       <Filter>contract_core</Filter>
     </ClInclude>
     <ClInclude Include="vote_counter.h" />
+    <ClInclude Include="contracts\EmptyTemplate.h">
+      <Filter>contracts</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="platform">

--- a/src/contract_core/contract_def.h
+++ b/src/contract_core/contract_def.h
@@ -17,7 +17,7 @@ namespace QPI
 }
 
 // TODO: add option for having locals to SYSTEM and EXPAND procedures
-typedef void (*SYSTEM_PROCEDURE)(const QPI::QpiContextProcedureCall&, void* state, void* input, void* output);
+typedef void (*SYSTEM_PROCEDURE)(const QPI::QpiContextProcedureCall&, void* state, void* input, void* output, void* locals);
 typedef void (*EXPAND_PROCEDURE)(const QPI::QpiContextFunctionCall&, void*, void*); // cannot not change anything except state
 typedef void (*USER_FUNCTION)(const QPI::QpiContextFunctionCall&, void* state, void* input, void* output, void* locals);
 typedef void (*USER_PROCEDURE)(const QPI::QpiContextProcedureCall&, void* state, void* input, void* output, void* locals);
@@ -191,19 +191,29 @@ enum MoreProcedureIDs
 };
 
 static SYSTEM_PROCEDURE contractSystemProcedures[contractCount][contractSystemProcedureCount];
+static unsigned short contractSystemProcedureLocalsSizes[contractCount][contractSystemProcedureCount];
 
 
 #define REGISTER_CONTRACT_FUNCTIONS_AND_PROCEDURES(contractName)\
 if (!contractName::__initializeEmpty) contractSystemProcedures[contractIndex][INITIALIZE] = (SYSTEM_PROCEDURE)contractName::__initialize;\
+contractSystemProcedureLocalsSizes[contractIndex][INITIALIZE] = contractName::__initializeLocalsSize; \
 if (!contractName::__beginEpochEmpty) contractSystemProcedures[contractIndex][BEGIN_EPOCH] = (SYSTEM_PROCEDURE)contractName::__beginEpoch;\
+contractSystemProcedureLocalsSizes[contractIndex][BEGIN_EPOCH] = contractName::__beginEpochLocalsSize; \
 if (!contractName::__endEpochEmpty) contractSystemProcedures[contractIndex][END_EPOCH] = (SYSTEM_PROCEDURE)contractName::__endEpoch;\
+contractSystemProcedureLocalsSizes[contractIndex][END_EPOCH] = contractName::__endEpochLocalsSize; \
 if (!contractName::__beginTickEmpty) contractSystemProcedures[contractIndex][BEGIN_TICK] = (SYSTEM_PROCEDURE)contractName::__beginTick;\
+contractSystemProcedureLocalsSizes[contractIndex][BEGIN_TICK] = contractName::__beginTickLocalsSize; \
 if (!contractName::__endTickEmpty) contractSystemProcedures[contractIndex][END_TICK] = (SYSTEM_PROCEDURE)contractName::__endTick;\
-if (!contractName::__expandEmpty) contractExpandProcedures[contractIndex] = (EXPAND_PROCEDURE)contractName::__expand;\
+contractSystemProcedureLocalsSizes[contractIndex][END_TICK] = contractName::__endTickLocalsSize; \
 if (!contractName::__preAcquireSharesEmpty) contractSystemProcedures[contractIndex][PRE_ACQUIRE_SHARES] = (SYSTEM_PROCEDURE)contractName::__preAcquireShares;\
+contractSystemProcedureLocalsSizes[contractIndex][PRE_ACQUIRE_SHARES] = contractName::__preAcquireSharesSize; \
 if (!contractName::__preReleaseSharesEmpty) contractSystemProcedures[contractIndex][PRE_RELEASE_SHARES] = (SYSTEM_PROCEDURE)contractName::__preReleaseShares;\
+contractSystemProcedureLocalsSizes[contractIndex][PRE_RELEASE_SHARES] = contractName::__preReleaseSharesSize; \
 if (!contractName::__postAcquireSharesEmpty) contractSystemProcedures[contractIndex][POST_ACQUIRE_SHARES] = (SYSTEM_PROCEDURE)contractName::__postAcquireShares;\
+contractSystemProcedureLocalsSizes[contractIndex][POST_ACQUIRE_SHARES] = contractName::__postAcquireSharesSize; \
 if (!contractName::__postReleaseSharesEmpty) contractSystemProcedures[contractIndex][POST_RELEASE_SHARES] = (SYSTEM_PROCEDURE)contractName::__postReleaseShares;\
+contractSystemProcedureLocalsSizes[contractIndex][POST_RELEASE_SHARES] = contractName::__postReleaseSharesSize; \
+if (!contractName::__expandEmpty) contractExpandProcedures[contractIndex] = (EXPAND_PROCEDURE)contractName::__expand;\
 ((contractName*)contractState)->__registerUserFunctionsAndProcedures(qpi);
 
 

--- a/src/contract_core/contract_def.h
+++ b/src/contract_core/contract_def.h
@@ -194,16 +194,16 @@ static SYSTEM_PROCEDURE contractSystemProcedures[contractCount][contractSystemPr
 
 
 #define REGISTER_CONTRACT_FUNCTIONS_AND_PROCEDURES(contractName)\
-contractSystemProcedures[contractIndex][INITIALIZE] = (SYSTEM_PROCEDURE)contractName::__initialize;\
-contractSystemProcedures[contractIndex][BEGIN_EPOCH] = (SYSTEM_PROCEDURE)contractName::__beginEpoch;\
-contractSystemProcedures[contractIndex][END_EPOCH] = (SYSTEM_PROCEDURE)contractName::__endEpoch;\
-contractSystemProcedures[contractIndex][BEGIN_TICK] = (SYSTEM_PROCEDURE)contractName::__beginTick;\
-contractSystemProcedures[contractIndex][END_TICK] = (SYSTEM_PROCEDURE)contractName::__endTick;\
-contractSystemProcedures[contractIndex][PRE_RELEASE_SHARES] = (SYSTEM_PROCEDURE)contractName::__preReleaseShares;\
-contractSystemProcedures[contractIndex][PRE_ACQUIRE_SHARES] = (SYSTEM_PROCEDURE)contractName::__preAcquireShares;\
-contractSystemProcedures[contractIndex][POST_RELEASE_SHARES] = (SYSTEM_PROCEDURE)contractName::__postReleaseShares;\
-contractSystemProcedures[contractIndex][POST_ACQUIRE_SHARES] = (SYSTEM_PROCEDURE)contractName::__postAcquireShares;\
-contractExpandProcedures[contractIndex] = (EXPAND_PROCEDURE)contractName::__expand;\
+if (!contractName::__initializeEmpty) contractSystemProcedures[contractIndex][INITIALIZE] = (SYSTEM_PROCEDURE)contractName::__initialize;\
+if (!contractName::__beginEpochEmpty) contractSystemProcedures[contractIndex][BEGIN_EPOCH] = (SYSTEM_PROCEDURE)contractName::__beginEpoch;\
+if (!contractName::__endEpochEmpty) contractSystemProcedures[contractIndex][END_EPOCH] = (SYSTEM_PROCEDURE)contractName::__endEpoch;\
+if (!contractName::__beginTickEmpty) contractSystemProcedures[contractIndex][BEGIN_TICK] = (SYSTEM_PROCEDURE)contractName::__beginTick;\
+if (!contractName::__endTickEmpty) contractSystemProcedures[contractIndex][END_TICK] = (SYSTEM_PROCEDURE)contractName::__endTick;\
+if (!contractName::__expandEmpty) contractExpandProcedures[contractIndex] = (EXPAND_PROCEDURE)contractName::__expand;\
+if (!contractName::__preAcquireSharesEmpty) contractSystemProcedures[contractIndex][PRE_ACQUIRE_SHARES] = (SYSTEM_PROCEDURE)contractName::__preAcquireShares;\
+if (!contractName::__preReleaseSharesEmpty) contractSystemProcedures[contractIndex][PRE_RELEASE_SHARES] = (SYSTEM_PROCEDURE)contractName::__preReleaseShares;\
+if (!contractName::__postAcquireSharesEmpty) contractSystemProcedures[contractIndex][POST_ACQUIRE_SHARES] = (SYSTEM_PROCEDURE)contractName::__postAcquireShares;\
+if (!contractName::__postReleaseSharesEmpty) contractSystemProcedures[contractIndex][POST_RELEASE_SHARES] = (SYSTEM_PROCEDURE)contractName::__postReleaseShares;\
 ((contractName*)contractState)->__registerUserFunctionsAndProcedures(qpi);
 
 

--- a/src/contracts/EmptyTemplate.h
+++ b/src/contracts/EmptyTemplate.h
@@ -1,0 +1,41 @@
+using namespace QPI;
+
+struct CNAME2
+{
+};
+
+struct CNAME : public ContractBase
+{
+	REGISTER_USER_FUNCTIONS_AND_PROCEDURES
+	_
+
+	INITIALIZE
+	_
+
+	BEGIN_EPOCH
+	_
+
+	END_EPOCH
+	_
+
+	BEGIN_TICK
+	_
+
+	END_TICK
+	_
+
+	PRE_ACQUIRE_SHARES
+	_
+
+	POST_ACQUIRE_SHARES
+	_
+
+	PRE_RELEASE_SHARES
+	_
+
+	POST_RELEASE_SHARES
+	_
+
+	EXPAND
+	_
+};

--- a/src/contracts/MyLastMatch.h
+++ b/src/contracts/MyLastMatch.h
@@ -4,38 +4,8 @@ struct MLM2
 {
 };
 
-struct MLM
+struct MLM : public ContractBase
 {
 	REGISTER_USER_FUNCTIONS_AND_PROCEDURES
-	_
-
-	INITIALIZE
-	_
-
-	BEGIN_EPOCH
-	_
-
-	END_EPOCH
-	_
-
-	BEGIN_TICK
-	_
-
-	END_TICK
-	_
-
-	PRE_ACQUIRE_SHARES
-	_
-
-	POST_ACQUIRE_SHARES
-	_
-
-	PRE_RELEASE_SHARES
-	_
-
-	POST_RELEASE_SHARES
-	_
-
-	EXPAND
 	_
 };

--- a/src/contracts/QUtil.h
+++ b/src/contracts/QUtil.h
@@ -33,7 +33,7 @@ struct QUTIL2
 {
 };
 
-struct QUTIL
+struct QUTIL : public ContractBase
 {
 private:
     // registers, logger and other buffer
@@ -312,35 +312,5 @@ public:
 
         REGISTER_USER_PROCEDURE(SendToManyV1, 1);
         REGISTER_USER_PROCEDURE(BurnQubic, 2);
-    _
-
-    INITIALIZE
-    _
-
-    BEGIN_EPOCH
-    _
-
-    END_EPOCH
-    _
-
-    BEGIN_TICK
-    _
-
-    END_TICK
-    _
-
-    PRE_ACQUIRE_SHARES
-    _
-
-    POST_ACQUIRE_SHARES
-    _
-
-    PRE_RELEASE_SHARES
-    _
-
-    POST_RELEASE_SHARES
-    _
-
-    EXPAND
     _
 };

--- a/src/contracts/Quottery.h
+++ b/src/contracts/Quottery.h
@@ -50,7 +50,7 @@ struct QUOTTERY2
 {
 };
 
-struct QUOTTERY
+struct QUOTTERY : public ContractBase
 {
 public:
     /**************************************/
@@ -1230,9 +1230,6 @@ public:
         REGISTER_USER_PROCEDURE(publishResult, 4);
     _
 
-    INITIALIZE
-    _
-
     BEGIN_EPOCH
         state.mFeePerSlotPerHour = QUOTTERY_FEE_PER_SLOT_PER_HOUR;
         state.mMinAmountPerBetSlot = QUOTTERY_MIN_AMOUNT_PER_BET_SLOT_;
@@ -1240,29 +1237,5 @@ public:
         state.mGameOperatorFee = QUOTTERY_GAME_OPERATOR_FEE_;
         state.mBurnFee = QUOTTERY_BURN_FEE_;
         state.mGameOperatorId = id(0x63a7317950fa8886ULL, 0x4dbdf78085364aa7ULL, 0x21c6ca41e95bfa65ULL, 0xcbc1886b3ea8e647ULL);
-    _
-
-    EMPTY_END_EPOCH
-    _
-
-    EMPTY_BEGIN_TICK
-    _
-
-    EMPTY_END_TICK
-    _
-
-    PRE_ACQUIRE_SHARES
-    _
-
-    POST_ACQUIRE_SHARES
-    _
-
-    PRE_RELEASE_SHARES
-    _
-
-    POST_RELEASE_SHARES
-    _
-
-    EXPAND
     _
 };

--- a/src/contracts/Qx.h
+++ b/src/contracts/Qx.h
@@ -4,7 +4,7 @@ struct QX2
 {
 };
 
-struct QX
+struct QX : public ContractBase
 {
 public:
 	struct Fees_input
@@ -1052,18 +1052,6 @@ private:
 		state._tradeFee = 5000000; // 0.5%
 	_
 
-	EMPTY_BEGIN_EPOCH
-	_
-
-	EMPTY_END_EPOCH
-	_
-
-	EMPTY_BEGIN_TICK
-	_
-
-	EMPTY_END_TICK
-	_
-
 	PRE_ACQUIRE_SHARES
 	_
 
@@ -1074,9 +1062,6 @@ private:
 	_
 
 	POST_RELEASE_SHARES
-	_
-
-	EXPAND
 	_
 };
 

--- a/src/contracts/Random.h
+++ b/src/contracts/Random.h
@@ -4,7 +4,7 @@ struct RANDOM2
 {
 };
 
-struct RANDOM
+struct RANDOM : public ContractBase
 {
 public:
 	struct RevealAndCommit_input
@@ -36,32 +36,5 @@ private:
 	INITIALIZE
 
 		state._bitFee = 1000;
-	_
-
-	BEGIN_EPOCH
-	_
-
-	END_EPOCH
-	_
-
-	BEGIN_TICK
-	_
-
-	END_TICK
-	_
-
-	PRE_ACQUIRE_SHARES
-	_
-
-	POST_ACQUIRE_SHARES
-	_
-
-	PRE_RELEASE_SHARES
-	_
-
-	POST_RELEASE_SHARES
-	_
-
-	EXPAND
 	_
 };

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -6132,10 +6132,7 @@ namespace QPI
 	};
 
 	// Used if no locals, input, or output is needed in a procedure or function
-	struct NoData {
-		bool isEmpty; // a flag to mark if the procedure do nothing => no need to mark the SC state change flag => no need to recompute K12 of the whole state, K12 the whole SC state is expensive!
-		// TODO: consider changing NoData to something else meaningful
-	};
+	struct NoData {};
 
 	// Management rights transfer: pre-transfer input
 	struct PreManagementRightsTransfer_input
@@ -6166,36 +6163,60 @@ namespace QPI
 #endif
 
 	//////////
+	
+	struct ContractBase
+	{
+		enum { __initializeEmpty = 1 };
+		static void __initialize(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __beginEpochEmpty = 1 };
+		static void __beginEpoch(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __endEpochEmpty = 1 };
+		static void __endEpoch(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __beginTickEmpty = 1 };
+		static void __beginTick(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __endTickEmpty = 1 };
+		static void __endTick(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __expandEmpty = 1 };
+		static void __expand(const QpiContextProcedureCall& qpi, void*, void*) {}
+		enum { __preAcquireSharesEmpty = 1 };
+		static void __preAcquireShares(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __preReleaseSharesEmpty = 1 };
+		static void __preReleaseShares(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __postAcquireSharesEmpty = 1 };
+		static void __postAcquireShares(const QpiContextProcedureCall&, void*, void*, void*) {}
+		enum { __postReleaseSharesEmpty = 1 };
+		static void __postReleaseShares(const QpiContextProcedureCall&, void*, void*, void*) {}
+	};
 
-	#define INITIALIZE public: static void __initialize(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller; input.isEmpty = false;
+	#define INITIALIZE public: enum { __initializeEmpty = 0 }; \
+		static void __initialize(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define BEGIN_EPOCH public: static void __beginEpoch(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller; input.isEmpty = false;
+	#define BEGIN_EPOCH public: enum { __beginEpochEmpty = 0 }; \
+		static void __beginEpoch(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define END_EPOCH public: static void __endEpoch(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller; input.isEmpty = false;
+	#define END_EPOCH public: enum { __endEpochEmpty = 0 }; \
+		static void __endEpoch(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define BEGIN_TICK public: static void __beginTick(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller; input.isEmpty = false;
+	#define BEGIN_TICK public: enum { __beginTickEmpty = 0 }; \
+		static void __beginTick(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define END_TICK public: static void __endTick(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller; input.isEmpty = false;
+	#define END_TICK public: enum { __endTickEmpty = 0 }; \
+		static void __endTick(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define EMPTY_INITIALIZE public: static void __initialize(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { input.isEmpty = true;
+	#define EXPAND public: enum { __expandEmpty = 0 }; \
+		static void __expand(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, CONTRACT_STATE2_TYPE& state2) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define EMPTY_BEGIN_EPOCH public: static void __beginEpoch(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { input.isEmpty = true;
+	#define PRE_ACQUIRE_SHARES public: enum { __preAcquireSharesEmpty = 0 }; \
+		static void __preAcquireShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PreManagementRightsTransfer_input& input, PreManagementRightsTransfer_output& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define EMPTY_END_EPOCH public: static void __endEpoch(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { input.isEmpty = true;
+	#define PRE_RELEASE_SHARES public: enum { __preReleaseSharesEmpty = 0 }; \
+		 static void __preReleaseShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PreManagementRightsTransfer_input& input, PreManagementRightsTransfer_output& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define EMPTY_BEGIN_TICK public: static void __beginTick(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { input.isEmpty = true;
+	#define POST_ACQUIRE_SHARES public: enum { __postAcquireSharesEmpty = 0 }; \
+		 static void __postAcquireShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PostManagementRightsTransfer_input& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
-	#define EMPTY_END_TICK public: static void __endTick(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, NoData& input, NoData& output) { input.isEmpty = true;
-
-	#define EXPAND public: static void __expand(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, CONTRACT_STATE2_TYPE& state2, NoData& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
-
-	#define PRE_ACQUIRE_SHARES public: static void __preAcquireShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PreManagementRightsTransfer_input& input, PreManagementRightsTransfer_output& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
-
-	#define PRE_RELEASE_SHARES public: static void __preReleaseShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PreManagementRightsTransfer_input& input, PreManagementRightsTransfer_output& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
-
-	#define POST_ACQUIRE_SHARES public: static void __postAcquireShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PostManagementRightsTransfer_input& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
-
-	#define POST_RELEASE_SHARES public: static void __postReleaseShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PostManagementRightsTransfer_input& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
+	#define POST_RELEASE_SHARES public: enum { __postReleaseSharesEmpty = 0 }; \
+		 static void __postReleaseShares(const QPI::QpiContextProcedureCall& qpi, CONTRACT_STATE_TYPE& state, PostManagementRightsTransfer_input& input, NoData& output) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller;
 
 
 	#define LOG_DEBUG(message) __logContractDebugMessage(CONTRACT_INDEX, message);

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1669,7 +1669,7 @@ unsigned short QPI::QpiContextFunctionCall::epoch() const
     return system.epoch;
 }
 
-bool QPI::QpiContextFunctionCall::getEntity(const m256i& id, ::Entity& entity) const
+bool QPI::QpiContextFunctionCall::getEntity(const m256i& id, Entity& entity) const
 {
     int index = spectrumIndex(id);
     if (index < 0)
@@ -4620,6 +4620,7 @@ static bool initialize()
         contractStates[contractIndex] = NULL;
     }
     bs->SetMem(contractSystemProcedures, sizeof(contractSystemProcedures), 0);
+    bs->SetMem(contractSystemProcedureLocalsSizes, sizeof(contractSystemProcedureLocalsSizes), 0);
     bs->SetMem(contractUserFunctions, sizeof(contractUserFunctions), 0);
     bs->SetMem(contractUserProcedures, sizeof(contractUserProcedures), 0);
     bs->SetMem(contractUserFunctionInputSizes, sizeof(contractUserFunctionInputSizes), 0);

--- a/test/qpi.cpp
+++ b/test/qpi.cpp
@@ -8,6 +8,15 @@ static void* __scratchpad()
     return __scratchpadBuffer;
 }
 
+namespace QPI
+{
+    struct QpiContextProcedureCall;
+    struct QpiContextFunctionCall;
+}
+
+typedef void (*USER_FUNCTION)(const QPI::QpiContextFunctionCall&, void* state, void* input, void* output, void* locals);
+typedef void (*USER_PROCEDURE)(const QPI::QpiContextProcedureCall&, void* state, void* input, void* output, void* locals);
+
 #include "../src/contracts/qpi.h"
 
 #include <vector>


### PR DESCRIPTION
- contracts should have base class ContractBase, then empty system proc can/should be removed from the implementation (speedup, because change flag is not set every epoch)
- system procedures now can have locals