### PR TITLE
Allow score test data from both cmd and project.

### DIFF
--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -42,7 +42,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /E /I /Y  "$(ProjectDir)data" "$(TargetDir)test_data"</Command>
+      <Command>xcopy /E /I /Y  "$(ProjectDir)data" "$(TargetDir)data"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -65,7 +65,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /E /I /Y  "$(ProjectDir)data" "$(TargetDir)test_data"</Command>
+      <Command>xcopy /E /I /Y  "$(ProjectDir)data" "$(TargetDir)data"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR changes the copy destination with the same path in the code. So we can launch the test from both Visual Studio UI and in binary folder.

Currently it can only access when running directly from Visual Studio UI.

cc: @philippwerner 