### PR TITLE
Allow request tx in current epoch by using its digest.

### DIFF
--- a/src/network_messages/transactions.h
+++ b/src/network_messages/transactions.h
@@ -63,3 +63,9 @@ struct RequestedTickTransactions
     unsigned char transactionFlags[NUMBER_OF_TRANSACTIONS_PER_TICK / 8];
 };
 
+#define REQUEST_TRANSACTION_INFO 26
+struct RequestedTransactionInfo
+{
+    m256i txDigest;
+};
+

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -853,15 +853,10 @@ static void processBroadcastTransaction(Peer* peer, RequestResponseHeader* heade
                             {
                                 tsReqTickTransactionOffsets[i] = ts.nextTickTransactionOffset;
                                 bs->CopyMem(ts.tickTransactions(ts.nextTickTransactionOffset), request, transactionSize);
-
-                                // Record the tx with digest
-                                ts.transactionsDigestAccess.insertTransaction(digest, ts.tickTransactions(ts.nextTickTransactionOffset));
-
                                 ts.nextTickTransactionOffset += transactionSize;
                             }
                         }
                         ts.tickTransactions.releaseLock();
-
                         break;
                     }
                 }
@@ -2133,6 +2128,11 @@ static void processTickTransaction(const Transaction* transaction, const m256i& 
     ASSERT(transaction->checkValidity());
     ASSERT(transaction->tick == system.tick);
 
+    // Record the tx with digest
+    ts.transactionsDigestAccess.acquireLock();
+    ts.transactionsDigestAccess.insertTransaction(transactionDigest, transaction);
+    ts.transactionsDigestAccess.releaseLock();
+
     const int spectrumIndex = ::spectrumIndex(transaction->sourcePublicKey);
     if (spectrumIndex >= 0)
     {
@@ -2497,10 +2497,6 @@ static void processTick(unsigned long long processorNumber)
                                     ts.tickTransactionOffsets(pendingTransaction->tick, j) = ts.nextTickTransactionOffset;
                                     bs->CopyMem(ts.tickTransactions(ts.nextTickTransactionOffset), (void*)pendingTransaction, transactionSize);
                                     broadcastedFutureTickData.tickData.transactionDigests[j] = &computorPendingTransactionDigests[entityPendingTransactionIndices[index] * 32ULL];
-
-                                    // Record the tx with digest
-                                    ts.transactionsDigestAccess.insertTransaction(broadcastedFutureTickData.tickData.transactionDigests[j], ts.tickTransactions(ts.nextTickTransactionOffset));
-
                                     j++;
                                     ts.nextTickTransactionOffset += transactionSize;
                                 }
@@ -2532,10 +2528,6 @@ static void processTick(unsigned long long processorNumber)
                                     ts.tickTransactionOffsets(pendingTransaction->tick, j) = ts.nextTickTransactionOffset;
                                     bs->CopyMem(ts.tickTransactions(ts.nextTickTransactionOffset), (void*)pendingTransaction, transactionSize);
                                     broadcastedFutureTickData.tickData.transactionDigests[j] = &entityPendingTransactionDigests[entityPendingTransactionIndices[index] * 32ULL];
-
-                                    // Record the tx with digest
-                                    ts.transactionsDigestAccess.insertTransaction(broadcastedFutureTickData.tickData.transactionDigests[j], ts.tickTransactions(ts.nextTickTransactionOffset));
-
                                     j++;
                                     ts.nextTickTransactionOffset += transactionSize;
                                 }
@@ -3784,10 +3776,6 @@ static void tickProcessor(void*)
                                                     {
                                                         tsPendingTransactionOffsets[j] = ts.nextTickTransactionOffset;
                                                         bs->CopyMem(ts.tickTransactions(ts.nextTickTransactionOffset), pendingTransaction, transactionSize);
-
-                                                        // Record the tx with digest
-                                                        ts.transactionsDigestAccess.insertTransaction(nextTickData.transactionDigests[j], ts.tickTransactions(ts.nextTickTransactionOffset));
-
                                                         ts.nextTickTransactionOffset += transactionSize;
                                                     }
                                                 }
@@ -3827,10 +3815,6 @@ static void tickProcessor(void*)
                                                     {
                                                         tsPendingTransactionOffsets[j] = ts.nextTickTransactionOffset;
                                                         bs->CopyMem(ts.tickTransactions(ts.nextTickTransactionOffset), pendingTransaction, transactionSize);
-
-                                                        // Record the tx with digest
-                                                        ts.transactionsDigestAccess.insertTransaction(nextTickData.transactionDigests[j], ts.tickTransactions(ts.nextTickTransactionOffset));
-
                                                         ts.nextTickTransactionOffset += transactionSize;
                                                     }
                                                 }


### PR DESCRIPTION
How to use,
- Compiled https://github.com/qubic/qubic-cli/pull/36
- Run ` ./qubic-cli -nodeip <IP>  -port <PORT> -gettxinfo <tx hash>`

How to verify,
- Launch this PR with VM
- Get some tx hash from https://explorer.qubic.org/network
- Run the qubic cli and double check it

Example,
```
// Access https://explorer.qubic.org/network/tick/16500004

// Run the cli tool
./qubic-cli -nodeip <IP>  -port 21841 -gettxinfo nzfzpfvfwwuwveysag
fdnmrotlkcmrcgxukvjfecobfokfnvnuqfcpgcyrsn

// Result
~~~~~RECEIPT~~~~~
TxHash: nzfzpfvfwwuwveysagfdnmrotlkcmrcgxukvjfecobfokfnvnuqfcpgcyrsn
From: KYOTVPIQLCIEYEMCCOEFEHZYMRICSVXVFFBPHVNPAGYYFMLEFVXEJOHGXTQC
To: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFXIB
Input type: 2
Amount: 1000000
Tick: 16500004
Extra data size: 64
MoneyFlew: N/A
~~~~~END-RECEIPT~~~~~
```