### PR TITLE
Add github workflow for Debug build, and Release test.

### DIFF
--- a/.github/workflows/efi-build-develop.yml
+++ b/.github/workflows/efi-build-develop.yml
@@ -15,17 +15,16 @@ env:
   # Path to the solution file relative to the root of the project.
   SOLUTION_FILE_PATH: .
 
-  # Configuration type to build.
-  # You can convert this to a build matrix if you need coverage of multiple configuration types.
-  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Release
-
 permissions:
   contents: read
 
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+        matrix:
+            configuration: [Release, Debug]
+            platform: [x64]
 
     steps:
     - uses: actions/checkout@v3
@@ -41,4 +40,10 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{matrix.configuration}} /p:Platform=${{matrix.platform}} ${{env.SOLUTION_FILE_PATH}}
+    
+    # Run test on Release only
+    - name: Test
+      working-directory: ${{env.SOLUTION_FILE_PATH}}/${{matrix.platform}}/${{matrix.configuration}}
+      if: matrix.configuration == 'Release'
+      run: .\test.exe --gtest_break_on_failure


### PR DESCRIPTION
Add some nice-to-have additional github workflow

- Allow build for both Release and Debug configuration.
- Allow run unit-test for Release mode.

Currently according to https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners, we will have a instance with 4 cores, 16GB for public repository.