### PR TITLE
Make sure transaction digest look up reset at begin of epoch.

### DIFF
--- a/src/tick_storage.h
+++ b/src/tick_storage.h
@@ -599,6 +599,8 @@ public:
             oldTickBegin = 0;
             oldTickEnd = 0;
         }
+        // Transaction digest look up need to reset at the begining of epoch for pointing to valid current epoch transaction
+        setMem((void*)tickTransactionsDigestPtr, tickTransactionOffsetsLengthCurrentEpoch * sizeof(TransactionsDigestAccess::HashMapEntry), 0);
 
         tickBegin = newInitialTick;
         tickEnd = newInitialTick + MAX_NUMBER_OF_TICKS_PER_EPOCH;


### PR DESCRIPTION
Thank @Franziska-Mueller for pointing it out.

Without this set, seamless transition will make tx hash map point to invalid tx.
