### PR TITLE
Hotfix for autosave: improve topology

### DIFF
--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -50,7 +50,7 @@
 
 #define VERSION_A 1
 #define VERSION_B 225
-#define VERSION_C 0
+#define VERSION_C 1
 
 // Epoch and initial tick for node startup
 #define EPOCH 133

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5933,6 +5933,13 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                 }
                 if (requestPersistingNodeState == 1 && persistingNodeStateTickProcWaiting == 1)
                 {
+                    // Saving node state takes a lot of time -> Close peer connections before to signal that
+                    // the peers should connect to another node.
+                    for (unsigned int i = 0; i < NUMBER_OF_OUTGOING_CONNECTIONS + NUMBER_OF_INCOMING_CONNECTIONS; i++)
+                    {
+                        closePeer(&peers[i]);
+                    }
+
                     logToConsole(L"Saving node state...");
                     saveAllNodeStates();
                     requestPersistingNodeState = 0;


### PR DESCRIPTION
Reduce the risk of simultaneous auto-save and bad topology problems:
- Instead of relying on operators to set different auto-save periods, we shift the phase by a tick offset that is selected randomly at node startup to make the save triggers equally distributed across time
- The auto-save trigger follows a rigid schedule, that is, the phase and period are kept, independently of switching between MAIN and AUX modes (save is skipped in MAIN, but switching to AUX does not leads to instant save anymore to prevent that simultaneous switching of mode leads to syncing the auto-save trigger times)
- All connections are closed before the auto-save to disk is started, because saving takes very long without calling networking code. Ideally, closing connections should cause the other nodes to reconnect to a node that isn't auto-saving at this moment, fixing potential topology problems.
- If auto-save is enabled at compile time, the auto-save schedule is printed on F2 key