### PR TITLE
 Combine allocPool with error logging in one function

### DIFF
--- a/src/Qubic.vcxproj
+++ b/src/Qubic.vcxproj
@@ -85,6 +85,7 @@
     <ClInclude Include="score.h" />
     <ClInclude Include="platform\m256.h" />
     <ClInclude Include="platform\memory.h" />
+    <ClInclude Include="platform\memory-util.h" />
     <ClInclude Include="score_cache.h" />
     <ClInclude Include="spectrum.h" />
     <ClInclude Include="system.h" />

--- a/src/addons/tx_status_request.h
+++ b/src/addons/tx_status_request.h
@@ -74,10 +74,10 @@ static RespondTxStatus* tickTxStatusStorage = NULL;
 static bool initTxStatusRequestAddOn()
 {
     // Allocate pool to store confirmed TX's
-    if (!allocPoolWithErrorLog(L"confirmedTx", confirmedTxLength * sizeof(ConfirmedTx), (void**)&confirmedTx))
+    if (!allocPoolWithErrorLog(L"confirmedTx", confirmedTxLength * sizeof(ConfirmedTx), (void**)&confirmedTx, __LINE__))
         return false;
     // allocate tickTxStatus responses storage
-    if (!allocPoolWithErrorLog(L"tickTxStatusStorage", MAX_NUMBER_OF_PROCESSORS * sizeof(RespondTxStatus), (void**)&tickTxStatusStorage))
+    if (!allocPoolWithErrorLog(L"tickTxStatusStorage", MAX_NUMBER_OF_PROCESSORS * sizeof(RespondTxStatus), (void**)&tickTxStatusStorage, __LINE__))
         return false;
     txStatusData.confirmedTxPreviousEpochBeginTick = 0;
     txStatusData.confirmedTxCurrentEpochBeginTick = 0;

--- a/src/addons/tx_status_request.h
+++ b/src/addons/tx_status_request.h
@@ -6,7 +6,7 @@
 
 #include "../platform/m256.h"
 #include "../platform/debugging.h"
-#include "../platform/memory.h"
+#include "../platform/memory_util.h"
 
 #include "../network_messages/header.h"
 
@@ -74,10 +74,10 @@ static RespondTxStatus* tickTxStatusStorage = NULL;
 static bool initTxStatusRequestAddOn()
 {
     // Allocate pool to store confirmed TX's
-    if (!allocatePool(confirmedTxLength * sizeof(ConfirmedTx), (void**)&confirmedTx))
+    if (!allocPoolWithErrorLog(L"confirmedTx", confirmedTxLength * sizeof(ConfirmedTx), (void**)&confirmedTx))
         return false;
     // allocate tickTxStatus responses storage
-    if (!allocatePool(MAX_NUMBER_OF_PROCESSORS * sizeof(RespondTxStatus), (void**)&tickTxStatusStorage))
+    if (!allocPoolWithErrorLog(L"tickTxStatusStorage", MAX_NUMBER_OF_PROCESSORS * sizeof(RespondTxStatus), (void**)&tickTxStatusStorage))
         return false;
     txStatusData.confirmedTxPreviousEpochBeginTick = 0;
     txStatusData.confirmedTxCurrentEpochBeginTick = 0;

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -159,9 +159,9 @@ static unsigned int issuanceIndex(const m256i& issuer, unsigned long long assetN
 
 static bool initAssets()
 {
-    if (!allocPoolWithErrorLog(L"assets", ASSETS_CAPACITY * sizeof(Asset), (void**)&assets)
-        || !allocPoolWithErrorLog(L"assetDigests", assetDigestsSizeInBytes, (void**)&assetDigests)
-        || !allocPoolWithErrorLog(L"assetChangeFlags", ASSETS_CAPACITY / 8, (void**)&assetChangeFlags))
+    if (!allocPoolWithErrorLog(L"assets", ASSETS_CAPACITY * sizeof(Asset), (void**)&assets, __LINE__)
+        || !allocPoolWithErrorLog(L"assetDigests", assetDigestsSizeInBytes, (void**)&assetDigests, __LINE__)
+        || !allocPoolWithErrorLog(L"assetChangeFlags", ASSETS_CAPACITY / 8, (void**)&assetChangeFlags, __LINE__))
     {
         return false;
     }

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -163,7 +163,6 @@ static bool initAssets()
         || !allocPoolWithErrorLog(L"assetDigests", assetDigestsSizeInBytes, (void**)&assetDigests)
         || !allocPoolWithErrorLog(L"assetChangeFlags", ASSETS_CAPACITY / 8, (void**)&assetChangeFlags))
     {
-        logToConsole(L"Failed to allocate asset buffers!");
         return false;
     }
     setMem(assetChangeFlags, ASSETS_CAPACITY / 8, 0xFF);

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -159,9 +159,9 @@ static unsigned int issuanceIndex(const m256i& issuer, unsigned long long assetN
 
 static bool initAssets()
 {
-    if (!allocatePool(ASSETS_CAPACITY * sizeof(Asset), (void**)&assets)
-        || !allocatePool(assetDigestsSizeInBytes, (void**)&assetDigests)
-        || !allocatePool(ASSETS_CAPACITY / 8, (void**)&assetChangeFlags))
+    if (!allocPoolWithErrorLog(L"assets", ASSETS_CAPACITY * sizeof(Asset), (void**)&assets)
+        || !allocPoolWithErrorLog(L"assetDigests", assetDigestsSizeInBytes, (void**)&assetDigests)
+        || !allocPoolWithErrorLog(L"assetChangeFlags", ASSETS_CAPACITY / 8, (void**)&assetChangeFlags))
     {
         logToConsole(L"Failed to allocate asset buffers!");
         return false;

--- a/src/common_buffers.h
+++ b/src/common_buffers.h
@@ -18,7 +18,7 @@ static bool initCommonBuffers()
 {
     // TODO: check that max contract state size does not exceed size of spectrum or universe
     constexpr unsigned long long reorgBufferSize = (spectrumSizeInBytes >= universeSizeInBytes) ? spectrumSizeInBytes : universeSizeInBytes;
-    if (!allocPoolWithErrorLog(L"reorgBuffer", reorgBufferSize, (void**)&reorgBuffer))
+    if (!allocPoolWithErrorLog(L"reorgBuffer", reorgBufferSize, (void**)&reorgBuffer, __LINE__))
     {
         return false;
     }

--- a/src/common_buffers.h
+++ b/src/common_buffers.h
@@ -20,7 +20,6 @@ static bool initCommonBuffers()
     constexpr unsigned long long reorgBufferSize = (spectrumSizeInBytes >= universeSizeInBytes) ? spectrumSizeInBytes : universeSizeInBytes;
     if (!allocPoolWithErrorLog(L"reorgBuffer", reorgBufferSize, (void**)&reorgBuffer))
     {
-        logToConsole(L"Failed to allocate common buffers!");
         return false;
     }
 

--- a/src/common_buffers.h
+++ b/src/common_buffers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "platform/global_var.h"
-#include "platform/memory.h"
+#include "platform/memory_util.h"
 
 #include "network_messages/entity.h"
 #include "network_messages/assets.h"
@@ -18,7 +18,7 @@ static bool initCommonBuffers()
 {
     // TODO: check that max contract state size does not exceed size of spectrum or universe
     constexpr unsigned long long reorgBufferSize = (spectrumSizeInBytes >= universeSizeInBytes) ? spectrumSizeInBytes : universeSizeInBytes;
-    if (!allocatePool(reorgBufferSize, (void**)&reorgBuffer))
+    if (!allocPoolWithErrorLog(L"reorgBuffer", reorgBufferSize, (void**)&reorgBuffer))
     {
         logToConsole(L"Failed to allocate common buffers!");
         return false;

--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -81,7 +81,7 @@ static bool initContractExec()
         contractStateLock[i].reset();
     }
 
-    if (!allocPoolWithErrorLog(L"contractStateChangeFlags", MAX_NUMBER_OF_CONTRACTS / 8, (void**)&contractStateChangeFlags))
+    if (!allocPoolWithErrorLog(L"contractStateChangeFlags", MAX_NUMBER_OF_CONTRACTS / 8, (void**)&contractStateChangeFlags, __LINE__))
     {
         return false;
     }

--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -83,7 +83,6 @@ static bool initContractExec()
 
     if (!allocPoolWithErrorLog(L"contractStateChangeFlags", MAX_NUMBER_OF_CONTRACTS / 8, (void**)&contractStateChangeFlags))
     {
-        logToConsole(L"Failed to allocate contractStateChangeFlags!");
         return false;
     }
     setMem(contractStateChangeFlags, MAX_NUMBER_OF_CONTRACTS / 8, 0xFF);

--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -81,7 +81,7 @@ static bool initContractExec()
         contractStateLock[i].reset();
     }
 
-    if (!allocatePool(MAX_NUMBER_OF_CONTRACTS / 8, (void**)&contractStateChangeFlags))
+    if (!allocPoolWithErrorLog(L"contractStateChangeFlags", MAX_NUMBER_OF_CONTRACTS / 8, (void**)&contractStateChangeFlags))
     {
         logToConsole(L"Failed to allocate contractStateChangeFlags!");
         return false;

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -444,7 +444,7 @@ public:
 #if ENABLED_LOGGING
         if (logBuffer == NULL)
         {
-            if (!allocPoolWithErrorLog(L"logBuffer", LOG_BUFFER_SIZE, (void**)&logBuffer))
+            if (!allocPoolWithErrorLog(L"logBuffer", LOG_BUFFER_SIZE, (void**)&logBuffer, __LINE__))
             {
                 return false;
             }
@@ -452,7 +452,7 @@ public:
 
         if (mapTxToLogId == NULL)
         {
-            if (!allocPoolWithErrorLog(L"mapTxToLogId", LOG_TX_INFO_STORAGE * sizeof(BlobInfo), (void**)&mapTxToLogId))
+            if (!allocPoolWithErrorLog(L"mapTxToLogId", LOG_TX_INFO_STORAGE * sizeof(BlobInfo), (void**)&mapTxToLogId, __LINE__))
             {
                 return false;
             }
@@ -460,7 +460,7 @@ public:
 
         if (mapLogIdToBufferIndex == NULL)
         {
-            if (!allocPoolWithErrorLog(L"mapLogIdToBufferIndex", LOG_MAX_STORAGE_ENTRIES * sizeof(BlobInfo), (void**)&mapLogIdToBufferIndex))
+            if (!allocPoolWithErrorLog(L"mapLogIdToBufferIndex", LOG_MAX_STORAGE_ENTRIES * sizeof(BlobInfo), (void**)&mapLogIdToBufferIndex, __LINE__))
             {
                 return false;
             }

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -446,8 +446,6 @@ public:
         {
             if (!allocPoolWithErrorLog(L"logBuffer", LOG_BUFFER_SIZE, (void**)&logBuffer))
             {
-                logToConsole(L"Failed to allocate logging buffer!");
-
                 return false;
             }
         }
@@ -456,8 +454,6 @@ public:
         {
             if (!allocPoolWithErrorLog(L"mapTxToLogId", LOG_TX_INFO_STORAGE * sizeof(BlobInfo), (void**)&mapTxToLogId))
             {
-                logToConsole(L"Failed to allocate logging buffer!");
-
                 return false;
             }
         }
@@ -466,8 +462,6 @@ public:
         {
             if (!allocPoolWithErrorLog(L"mapLogIdToBufferIndex", LOG_MAX_STORAGE_ENTRIES * sizeof(BlobInfo), (void**)&mapLogIdToBufferIndex))
             {
-                logToConsole(L"Failed to allocate logging buffer!");
-
                 return false;
             }
         }

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -3,7 +3,7 @@
 #include "platform/m256.h"
 #include "platform/concurrency.h"
 #include "platform/time.h"
-#include "platform/memory.h"
+#include "platform/memory_util.h"
 #include "platform/debugging.h"
 
 #include "network_messages/header.h"
@@ -444,7 +444,7 @@ public:
 #if ENABLED_LOGGING
         if (logBuffer == NULL)
         {
-            if (!allocatePool(LOG_BUFFER_SIZE, (void**)&logBuffer))
+            if (!allocPoolWithErrorLog(L"logBuffer", LOG_BUFFER_SIZE, (void**)&logBuffer))
             {
                 logToConsole(L"Failed to allocate logging buffer!");
 
@@ -454,7 +454,7 @@ public:
 
         if (mapTxToLogId == NULL)
         {
-            if (!allocatePool(LOG_TX_INFO_STORAGE * sizeof(BlobInfo), (void**)&mapTxToLogId))
+            if (!allocPoolWithErrorLog(L"mapTxToLogId", LOG_TX_INFO_STORAGE * sizeof(BlobInfo), (void**)&mapTxToLogId))
             {
                 logToConsole(L"Failed to allocate logging buffer!");
 
@@ -464,7 +464,7 @@ public:
 
         if (mapLogIdToBufferIndex == NULL)
         {
-            if (!allocatePool(LOG_MAX_STORAGE_ENTRIES * sizeof(BlobInfo), (void**)&mapLogIdToBufferIndex))
+            if (!allocPoolWithErrorLog(L"mapLogIdToBufferIndex", LOG_MAX_STORAGE_ENTRIES * sizeof(BlobInfo), (void**)&mapLogIdToBufferIndex))
             {
                 logToConsole(L"Failed to allocate logging buffer!");
 

--- a/src/platform/custom_stack.h
+++ b/src/platform/custom_stack.h
@@ -30,7 +30,7 @@ public:
     {
         free();
 
-        if (!allocPoolWithErrorLog(L"stackBottom", size, (void**)&stackBottom))
+        if (!allocPoolWithErrorLog(L"stackBottom", size, (void**)&stackBottom, __LINE__))
             return false;
 
         stackTop = stackBottom + size;

--- a/src/platform/custom_stack.h
+++ b/src/platform/custom_stack.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "memory.h"
+#include "memory_util.h"
 #include "debugging.h"
 
 typedef unsigned int CustomStackSizeType;
 typedef EFI_AP_PROCEDURE CustomStackProcessorFunc;
 
-// Function call stack with custom size that can be used for running a function on it. Memory is allocated with allocatePool().
+// Function call stack with custom size that can be used for running a function on it. Memory is allocated with allocPoolWithErrorLog().
 class CustomStack
 {
 public:
@@ -30,7 +30,7 @@ public:
     {
         free();
 
-        if (!allocatePool(size, (void**)&stackBottom))
+        if (!allocPoolWithErrorLog(L"stackBottom", size, (void**)&stackBottom))
             return false;
 
         stackTop = stackBottom + size;

--- a/src/platform/memory_util.h
+++ b/src/platform/memory_util.h
@@ -1,17 +1,31 @@
 #include "console_logging.h"
+#include "platform/uefi.h"
 
 #if defined(NO_UEFI)
 
-static bool allocPoolWithErrorLog(const EFI_MEMORY_TYPE poolType, const CHAR16* name, const unsigned long long size, void** buffer)
+#include <cstdlib>
+#include <cstdbool>
+#include <cstdio>
+
+static bool allocPoolWithErrorLog(const wchar_t* name, const unsigned long long size, void** buffer) 
+{
+    *buffer = malloc(size);
+    if (*buffer == NULL) {
+        printf("Memory allocation failed for %ls\n", name);
+        return false;
+    }
+    return true;
+}
 
 #else
 
 #include "memory.h"
 
 
-static bool allocPoolWithErrorLog(const EFI_MEMORY_TYPE poolType, const CHAR16* name, const unsigned long long size, void** buffer)
+static bool allocPoolWithErrorLog(const CHAR16* name, const unsigned long long size, void** buffer)
     {
     EFI_STATUS status;
+    const EFI_MEMORY_TYPE poolType = EfiRuntimeServicesData;
     if (status = bs->AllocatePool(poolType, size, buffer))
     {
         setText(message, L"EFI_BOOT_SERVICES.AllocatePool() fails for ");

--- a/src/platform/memory_util.h
+++ b/src/platform/memory_util.h
@@ -28,7 +28,8 @@ static bool allocPoolWithErrorLog(const CHAR16* name, const unsigned long long s
     EFI_STATUS status;
     CHAR16 message[512];
     constexpr EFI_MEMORY_TYPE poolType = EfiRuntimeServicesData;
-    if (status = bs->AllocatePool(poolType, size, buffer))
+    status = bs->AllocatePool(poolType, size, buffer);
+    if (status != EFI_SUCCESS)
     {
         setText(message, L"EFI_BOOT_SERVICES.AllocatePool() fails for ");
         appendText(message, name);
@@ -37,6 +38,15 @@ static bool allocPoolWithErrorLog(const CHAR16* name, const unsigned long long s
         logStatusAndMemInfoToConsole(message, status, __LINE__, size);
         return false;
     }
+#if !defined(NDEBUG)
+    else {
+        setText(message, L"EFI_BOOT_SERVICES.AllocatePool() completed for ");
+        appendText(message, name);
+        appendText(message, L" with size ");
+        appendNumber(message, size, TRUE);
+        logStatusAndMemInfoToConsole(message, status, __LINE__, size);
+            }
+#endif
     return true;
 }
 

--- a/src/platform/memory_util.h
+++ b/src/platform/memory_util.h
@@ -1,0 +1,27 @@
+#include "console_logging.h"
+
+#if defined(NO_UEFI)
+
+static bool allocPoolWithErrorLog(const EFI_MEMORY_TYPE poolType, const CHAR16* name, const unsigned long long size, void** buffer)
+
+#else
+
+#include "memory.h"
+
+
+static bool allocPoolWithErrorLog(const EFI_MEMORY_TYPE poolType, const CHAR16* name, const unsigned long long size, void** buffer)
+    {
+    EFI_STATUS status;
+    if (status = bs->AllocatePool(poolType, size, buffer))
+    {
+        setText(message, L"EFI_BOOT_SERVICES.AllocatePool() fails for ");
+        appendText(message, name);
+        appendText(message, L" with size ");
+        appendNumber(message, size, TRUE);
+        logStatusAndMemInfoToConsole(message, status, __LINE__, size);
+        return false;
+    }
+    return true;
+}
+
+#endif

--- a/src/platform/memory_util.h
+++ b/src/platform/memory_util.h
@@ -1,5 +1,8 @@
+#pragma once
+
 #include "console_logging.h"
 #include "platform/uefi.h"
+#include "memory.h"
 
 #if defined(NO_UEFI)
 
@@ -10,7 +13,8 @@
 static bool allocPoolWithErrorLog(const wchar_t* name, const unsigned long long size, void** buffer) 
 {
     *buffer = malloc(size);
-    if (*buffer == NULL) {
+    if (*buffer == nullptr)
+    {
         printf("Memory allocation failed for %ls\n", name);
         return false;
     }
@@ -19,13 +23,11 @@ static bool allocPoolWithErrorLog(const wchar_t* name, const unsigned long long 
 
 #else
 
-#include "memory.h"
-
-
 static bool allocPoolWithErrorLog(const CHAR16* name, const unsigned long long size, void** buffer)
     {
     EFI_STATUS status;
-    const EFI_MEMORY_TYPE poolType = EfiRuntimeServicesData;
+    CHAR16 message[512];
+    constexpr EFI_MEMORY_TYPE poolType = EfiRuntimeServicesData;
     if (status = bs->AllocatePool(poolType, size, buffer))
     {
         setText(message, L"EFI_BOOT_SERVICES.AllocatePool() fails for ");

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4480,14 +4480,14 @@ static bool initialize()
     {
         if (!ts.init())
             return false;
-        if (!allocPoolWithErrorLog(L"entityPendingTransaction buffer", SPECTRUM_CAPACITY * MAX_TRANSACTION_SIZE,(void**)&entityPendingTransactions) ||
-            !allocPoolWithErrorLog(L"entityPendingTransaction buffer", SPECTRUM_CAPACITY * 32ULL,(void**)&entityPendingTransactionDigests ))
+        if (!allocPoolWithErrorLog(L"entityPendingTransaction buffer", SPECTRUM_CAPACITY * MAX_TRANSACTION_SIZE,(void**)&entityPendingTransactions, __LINE__) ||
+            !allocPoolWithErrorLog(L"entityPendingTransaction buffer", SPECTRUM_CAPACITY * 32ULL,(void**)&entityPendingTransactionDigests , __LINE__))
         {
             return false;
         }
 
-        if (!allocPoolWithErrorLog(L"computorPendingTransactions buffer", NUMBER_OF_COMPUTORS * MAX_NUMBER_OF_PENDING_TRANSACTIONS_PER_COMPUTOR * MAX_TRANSACTION_SIZE, (void**)&computorPendingTransactions) ||
-            !allocPoolWithErrorLog(L"computorPendingTransactions buffer", NUMBER_OF_COMPUTORS * MAX_NUMBER_OF_PENDING_TRANSACTIONS_PER_COMPUTOR * 32ULL, (void**)&computorPendingTransactionDigests))
+        if (!allocPoolWithErrorLog(L"computorPendingTransactions buffer", NUMBER_OF_COMPUTORS * MAX_NUMBER_OF_PENDING_TRANSACTIONS_PER_COMPUTOR * MAX_TRANSACTION_SIZE, (void**)&computorPendingTransactions, __LINE__) ||
+            !allocPoolWithErrorLog(L"computorPendingTransactions buffer", NUMBER_OF_COMPUTORS * MAX_NUMBER_OF_PENDING_TRANSACTIONS_PER_COMPUTOR * 32ULL, (void**)&computorPendingTransactionDigests, __LINE__))
         {
             return false;
         }
@@ -4509,20 +4509,20 @@ static bool initialize()
         for (unsigned int contractIndex = 0; contractIndex < contractCount; contractIndex++)
         {
             unsigned long long size = contractDescriptions[contractIndex].stateSize;
-            if (!allocPoolWithErrorLog(L"contractStates",  size, (void**)&contractStates[contractIndex]))
+            if (!allocPoolWithErrorLog(L"contractStates",  size, (void**)&contractStates[contractIndex], __LINE__))
             {
                 return false;
             }
         }
 
-        if (!allocPoolWithErrorLog(L"score", sizeof(*score), (void**)&score))
+        if (!allocPoolWithErrorLog(L"score", sizeof(*score), (void**)&score, __LINE__))
         {
             return false;
         }
         setMem(score, sizeof(*score), 0);
 
         bs->SetMem(solutionThreshold, sizeof(int) * MAX_NUMBER_EPOCH, 0);
-        if (!allocPoolWithErrorLog(L"minserSolutionFlag", NUMBER_OF_MINER_SOLUTION_FLAGS / 8, (void**)&minerSolutionFlags))
+        if (!allocPoolWithErrorLog(L"minserSolutionFlag", NUMBER_OF_MINER_SOLUTION_FLAGS / 8, (void**)&minerSolutionFlags, __LINE__))
         {
             return false;
         }
@@ -4668,16 +4668,16 @@ static bool initialize()
     score->loadScoreCache(system.epoch);
 
     logToConsole(L"Allocating buffers ...");
-    if ((!allocPoolWithErrorLog(L"dejavu0", 536870912, (void**)&dejavu0)) ||
-        (!allocPoolWithErrorLog(L"dejavu1", 536870912, (void**)&dejavu1)))
+    if ((!allocPoolWithErrorLog(L"dejavu0", 536870912, (void**)&dejavu0, __LINE__)) ||
+        (!allocPoolWithErrorLog(L"dejavu1", 536870912, (void**)&dejavu1, __LINE__)))
     {
         return false;
     }
     bs->SetMem((void*)dejavu0, 536870912, 0);
     bs->SetMem((void*)dejavu1, 536870912, 0);
 
-    if ((!allocPoolWithErrorLog(L"requestQueueBuffer", REQUEST_QUEUE_BUFFER_SIZE, (void**)&requestQueueBuffer)) ||
-        (!allocPoolWithErrorLog(L"respondQueueBuffer", RESPONSE_QUEUE_BUFFER_SIZE, (void**)&responseQueueBuffer)))
+    if ((!allocPoolWithErrorLog(L"requestQueueBuffer", REQUEST_QUEUE_BUFFER_SIZE, (void**)&requestQueueBuffer, __LINE__)) ||
+        (!allocPoolWithErrorLog(L"respondQueueBuffer", RESPONSE_QUEUE_BUFFER_SIZE, (void**)&responseQueueBuffer, __LINE__)))
     {
         return false;
     }
@@ -4686,9 +4686,9 @@ static bool initialize()
     {
         peers[i].receiveData.FragmentCount = 1;
         peers[i].transmitData.FragmentCount = 1;
-        if ((!allocPoolWithErrorLog(L"receiveBuffer", BUFFER_SIZE, &peers[i].receiveBuffer))  ||
-            (!allocPoolWithErrorLog(L"FragmentBuffer", BUFFER_SIZE, &peers[i].transmitData.FragmentTable[0].FragmentBuffer)) ||
-            (!allocPoolWithErrorLog(L"dataToTransmit", BUFFER_SIZE, (void**)&peers[i].dataToTransmit)))
+        if ((!allocPoolWithErrorLog(L"receiveBuffer", BUFFER_SIZE, &peers[i].receiveBuffer, __LINE__))  ||
+            (!allocPoolWithErrorLog(L"FragmentBuffer", BUFFER_SIZE, &peers[i].transmitData.FragmentTable[0].FragmentBuffer, __LINE__)) ||
+            (!allocPoolWithErrorLog(L"dataToTransmit", BUFFER_SIZE, (void**)&peers[i].dataToTransmit, __LINE__)))
         {
             return false;
         }
@@ -5570,7 +5570,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
             mpServicesProtocol->GetProcessorInfo(mpServicesProtocol, i, &processorInformation);
             if (processorInformation.StatusFlag == (PROCESSOR_ENABLED_BIT | PROCESSOR_HEALTH_STATUS_BIT))
             {
-                if (!allocPoolWithErrorLog(L"processor[i]", BUFFER_SIZE, &processors[numberOfProcessors].buffer))
+                if (!allocPoolWithErrorLog(L"processor[i]", BUFFER_SIZE, &processors[numberOfProcessors].buffer, __LINE__))
                 {
                     numberOfProcessors = 0;
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4424,6 +4424,24 @@ static bool saveSystem(CHAR16* directory)
     return false;
 }
 
+
+
+static bool allocPoolWithErrorLog(const EFI_MEMORY_TYPE poolType, const CHAR16* name, const unsigned long long size, void** buffer)
+    {
+    EFI_STATUS status;
+    if (status = bs->AllocatePool(poolType, size, buffer))
+    {
+        setText(message, L"EFI_BOOT_SERVICES.AllocatePool() fails for ");
+        appendText(message, name);
+        appendText(message, L" with size ");
+        appendNumber(message, size, TRUE);
+        logStatusAndMemInfoToConsole(message, status, __LINE__, size);
+        return false;
+    }
+    return true;
+}
+
+
 static bool initialize()
 {
     enableAVX();

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5570,11 +5570,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
             mpServicesProtocol->GetProcessorInfo(mpServicesProtocol, i, &processorInformation);
             if (processorInformation.StatusFlag == (PROCESSOR_ENABLED_BIT | PROCESSOR_HEALTH_STATUS_BIT))
             {
-                CHAR16 errMsg[60];
-                setText(errMsg, L"processor[");
-                appendNumber(errMsg, i, false);
-                appendText(errMsg, L"].buffer");
-                if (!allocPoolWithErrorLog(errMsg, BUFFER_SIZE, &processors[numberOfProcessors].buffer))
+                if (!allocPoolWithErrorLog(L"processor[i]", BUFFER_SIZE, &processors[numberOfProcessors].buffer))
                 {
                     numberOfProcessors = 0;
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4481,7 +4481,7 @@ static bool initialize()
         if (!ts.init())
             return false;
         if (!allocPoolWithErrorLog(L"entityPendingTransaction buffer", SPECTRUM_CAPACITY * MAX_TRANSACTION_SIZE,(void**)&entityPendingTransactions) ||
-            !allocPoolWithErrorLog(L"entityPendingTransaction buffer", SPECTRUM_CAPACITY * 32ULL,(void**)&entityPendingTransactions))
+            !allocPoolWithErrorLog(L"entityPendingTransaction buffer", SPECTRUM_CAPACITY * 32ULL,(void**)&entityPendingTransactionDigests ))
         {
             return false;
         }

--- a/src/score.h
+++ b/src/score.h
@@ -278,7 +278,7 @@ struct ScoreFunction
     {
         if (_computeBuffer == nullptr)
         {
-            if (!allocPoolWithErrorLog(L"computeBuffer (score solution buffer)", sizeof(computeBuffer) * solutionBufferCount, (void**)&_computeBuffer))
+            if (!allocPoolWithErrorLog(L"computeBuffer (score solution buffer)", sizeof(computeBuffer) * solutionBufferCount, (void**)&_computeBuffer, __LINE__))
             {
                 return false;
             }
@@ -287,42 +287,42 @@ struct ScoreFunction
             {
                 auto& cb = _computeBuffer[bufId];
 
-                if (!allocPoolWithErrorLog(L"poolRandom2Buffer (score pool buffer)", RANDOM2_POOL_SIZE, (void**)&(cb._poolRandom2Buffer)))
+                if (!allocPoolWithErrorLog(L"poolRandom2Buffer (score pool buffer)", RANDOM2_POOL_SIZE, (void**)&(cb._poolRandom2Buffer), __LINE__))
                 {
                     return false;
                 }
 
-                if (!allocPoolWithErrorLog(L"neurons.input", allNeuronsCount, (void**)&(cb._neurons.input)))
+                if (!allocPoolWithErrorLog(L"neurons.input", allNeuronsCount, (void**)&(cb._neurons.input), __LINE__))
                 {
                     return false;
                 }
 
-                if (!allocPoolWithErrorLog(L"synapses.signs", synapseSignsCount * sizeof(unsigned long long), (void**)&(cb._synapses.signs)))
+                if (!allocPoolWithErrorLog(L"synapses.signs", synapseSignsCount * sizeof(unsigned long long), (void**)&(cb._synapses.signs), __LINE__))
                 {
                     return false;
                 }
 
-                if (!allocPoolWithErrorLog(L"poolSynapseData", RANDOM2_POOL_SIZE * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseData)))
+                if (!allocPoolWithErrorLog(L"poolSynapseData", RANDOM2_POOL_SIZE * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseData), __LINE__))
                 {
                     return false;
                 }
 
-                if (!allocPoolWithErrorLog(L"poolSynapseTickData", maxDuration * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseTickData)))
+                if (!allocPoolWithErrorLog(L"poolSynapseTickData", maxDuration * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseTickData), __LINE__))
                 {
                     return false;
                 }
 
-                if (!allocPoolWithErrorLog(L"skipTicks", numberOfOptimizationSteps * sizeof(long long), (void**)&(cb._skipTicks)))
+                if (!allocPoolWithErrorLog(L"skipTicks", numberOfOptimizationSteps * sizeof(long long), (void**)&(cb._skipTicks), __LINE__))
                 {
                     return false;
                 }
 
-                if (!allocPoolWithErrorLog(L"ticksNumbers", maxDuration * sizeof(long long), (void**)&(cb._ticksNumbers)))
+                if (!allocPoolWithErrorLog(L"ticksNumbers", maxDuration * sizeof(long long), (void**)&(cb._ticksNumbers), __LINE__))
                 {
                     return false;
                 }
 
-                if (!allocPoolWithErrorLog(L"skipTicksMap", maxDuration, (void**)&(cb._skipTicksMap)))
+                if (!allocPoolWithErrorLog(L"skipTicksMap", maxDuration, (void**)&(cb._skipTicksMap), __LINE__))
                 {
                     return false;
                 }

--- a/src/score.h
+++ b/src/score.h
@@ -2,7 +2,7 @@
 #ifdef NO_UEFI
 unsigned long long top_of_stack;
 #endif
-#include "platform/memory.h"
+#include "platform/memory_util.h"
 #include "platform/m256.h"
 #include "platform/concurrency.h"
 #include "public_settings.h"
@@ -278,7 +278,7 @@ struct ScoreFunction
     {
         if (_computeBuffer == nullptr)
         {
-            if (!allocatePool(sizeof(computeBuffer) * solutionBufferCount, (void**)&_computeBuffer))
+            if (!allocPoolWithErrorLog(L"computeBuffer", sizeof(computeBuffer) * solutionBufferCount, (void**)&_computeBuffer))
             {
                 logToConsole(L"Failed to allocate memory for score solution buffer!");
                 return false;
@@ -288,25 +288,25 @@ struct ScoreFunction
             {
                 auto& cb = _computeBuffer[bufId];
 
-                if (!allocatePool(RANDOM2_POOL_SIZE, (void**)&(cb._poolRandom2Buffer)))
+                if (!allocPoolWithErrorLog(L"poolRandom2Buffer", RANDOM2_POOL_SIZE, (void**)&(cb._poolRandom2Buffer)))
                 {
                     logToConsole(L"Failed to allocate memory for score pool buffer!");
                     return false;
                 }
 
-                if (!allocatePool(allNeuronsCount, (void**)&(cb._neurons.input)))
+                if (!allocPoolWithErrorLog(L"neurons.input", allNeuronsCount, (void**)&(cb._neurons.input)))
                 {
                     logToConsole(L"Failed to allocate memory for neurons! Try to allocated ");
                     return false;
                 }
 
-                if (!allocatePool(synapseSignsCount * sizeof(unsigned long long), (void**)&(cb._synapses.signs)))
+                if (!allocPoolWithErrorLog(L"synapses.signs", synapseSignsCount * sizeof(unsigned long long), (void**)&(cb._synapses.signs)))
                 {
                     logToConsole(L"Failed to allocate memory for synapses! Try to allocated ");
                     return false;
                 }
 
-                if (!allocatePool(RANDOM2_POOL_SIZE * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseData)))
+                if (!allocPoolWithErrorLog(L"poolSynapseData", RANDOM2_POOL_SIZE * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseData)))
                 {
                     logToConsole(L"Failed to allocate memory for pool synapse data!");
                     return false;

--- a/src/score.h
+++ b/src/score.h
@@ -278,9 +278,8 @@ struct ScoreFunction
     {
         if (_computeBuffer == nullptr)
         {
-            if (!allocPoolWithErrorLog(L"computeBuffer", sizeof(computeBuffer) * solutionBufferCount, (void**)&_computeBuffer))
+            if (!allocPoolWithErrorLog(L"computeBuffer (score solution buffer)", sizeof(computeBuffer) * solutionBufferCount, (void**)&_computeBuffer))
             {
-                logToConsole(L"Failed to allocate memory for score solution buffer!");
                 return false;
             }
 
@@ -288,51 +287,43 @@ struct ScoreFunction
             {
                 auto& cb = _computeBuffer[bufId];
 
-                if (!allocPoolWithErrorLog(L"poolRandom2Buffer", RANDOM2_POOL_SIZE, (void**)&(cb._poolRandom2Buffer)))
+                if (!allocPoolWithErrorLog(L"poolRandom2Buffer (score pool buffer)", RANDOM2_POOL_SIZE, (void**)&(cb._poolRandom2Buffer)))
                 {
-                    logToConsole(L"Failed to allocate memory for score pool buffer!");
                     return false;
                 }
 
                 if (!allocPoolWithErrorLog(L"neurons.input", allNeuronsCount, (void**)&(cb._neurons.input)))
                 {
-                    logToConsole(L"Failed to allocate memory for neurons! Try to allocated ");
                     return false;
                 }
 
                 if (!allocPoolWithErrorLog(L"synapses.signs", synapseSignsCount * sizeof(unsigned long long), (void**)&(cb._synapses.signs)))
                 {
-                    logToConsole(L"Failed to allocate memory for synapses! Try to allocated ");
                     return false;
                 }
 
                 if (!allocPoolWithErrorLog(L"poolSynapseData", RANDOM2_POOL_SIZE * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseData)))
                 {
-                    logToConsole(L"Failed to allocate memory for pool synapse data!");
                     return false;
                 }
 
-                if (!allocatePool(maxDuration * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseTickData)))
+                if (!allocPoolWithErrorLog(L"poolSynapseTickData", maxDuration * sizeof(PoolSynapseData), (void**)&(cb._poolSynapseTickData)))
                 {
-                    logToConsole(L"Failed to allocate memory for pool synapse data!");
                     return false;
                 }
 
-                if (!allocatePool(numberOfOptimizationSteps * sizeof(long long), (void**)&(cb._skipTicks)))
+                if (!allocPoolWithErrorLog(L"skipTicks", numberOfOptimizationSteps * sizeof(long long), (void**)&(cb._skipTicks)))
                 {
-                    logToConsole(L"Failed to allocate memory for skip ticks buffer!");
                     return false;
                 }
 
-                if (!allocatePool(maxDuration * sizeof(long long), (void**)&(cb._ticksNumbers)))
+                if (!allocPoolWithErrorLog(L"ticksNumbers", maxDuration * sizeof(long long), (void**)&(cb._ticksNumbers)))
                 {
-                    logToConsole(L"Failed to allocate memory for ticks number buffer!");
                     return false;
                 }
 
-                if (!allocatePool(maxDuration, (void**)&(cb._skipTicksMap)))
+                if (!allocPoolWithErrorLog(L"skipTicksMap", maxDuration, (void**)&(cb._skipTicksMap)))
                 {
-                    logToConsole(L"Failed to allocate memory for ticks map buffer!");
                     return false;
                 }
 

--- a/src/spectrum.h
+++ b/src/spectrum.h
@@ -410,8 +410,8 @@ static bool saveSpectrum(const CHAR16* fileName = SPECTRUM_FILE_NAME, const CHAR
 
 static bool initSpectrum()
 {
-    if (!allocPoolWithErrorLog(L"spectrum", spectrumSizeInBytes, (void**)&spectrum)
-        || !allocPoolWithErrorLog(L"spectrumDigests", spectrumDigestsSizeInByte, (void**)&spectrumDigests))
+    if (!allocPoolWithErrorLog(L"spectrum", spectrumSizeInBytes, (void**)&spectrum, __LINE__)
+        || !allocPoolWithErrorLog(L"spectrumDigests", spectrumDigestsSizeInByte, (void**)&spectrumDigests, __LINE__))
     {
         return false;
     }

--- a/src/spectrum.h
+++ b/src/spectrum.h
@@ -413,7 +413,6 @@ static bool initSpectrum()
     if (!allocPoolWithErrorLog(L"spectrum", spectrumSizeInBytes, (void**)&spectrum)
         || !allocPoolWithErrorLog(L"spectrumDigests", spectrumDigestsSizeInByte, (void**)&spectrumDigests))
     {
-        logToConsole(L"Failed to allocate spectrum memory!");
         return false;
     }
 

--- a/src/spectrum.h
+++ b/src/spectrum.h
@@ -410,8 +410,8 @@ static bool saveSpectrum(const CHAR16* fileName = SPECTRUM_FILE_NAME, const CHAR
 
 static bool initSpectrum()
 {
-    if (!allocatePool(spectrumSizeInBytes, (void**)&spectrum)
-        || !allocatePool(spectrumDigestsSizeInByte, (void**)&spectrumDigests))
+    if (!allocPoolWithErrorLog(L"spectrum", spectrumSizeInBytes, (void**)&spectrum)
+        || !allocPoolWithErrorLog(L"spectrumDigests", spectrumDigestsSizeInByte, (void**)&spectrumDigests))
     {
         logToConsole(L"Failed to allocate spectrum memory!");
         return false;

--- a/src/tick_storage.h
+++ b/src/tick_storage.h
@@ -442,11 +442,11 @@ public:
     static bool init()
     {
         // TODO: allocate everything with one continuous buffer
-        if (!allocPoolWithErrorLog(L"tickDataPtr ", tickDataSize, (void**)&tickDataPtr)
-             || !allocPoolWithErrorLog(L"tickPtr", ticksSize, (void**)&ticksPtr)
-             || !allocPoolWithErrorLog(L"tickTransactionPtr", tickTransactionsSize, (void**)&tickTransactionsPtr)
-             || !allocPoolWithErrorLog(L"tickTransactionOffset", tickTransactionOffsetsSize, (void**)&tickTransactionOffsetsPtr)
-             || !allocPoolWithErrorLog(L"tickTransactionsDigestPtr", tickTransactionOffsetsLengthCurrentEpoch * sizeof(TransactionsDigestAccess::HashMapEntry), (void**)&tickTransactionsDigestPtr))
+        if (!allocPoolWithErrorLog(L"tickDataPtr ", tickDataSize, (void**)&tickDataPtr, __LINE__)
+            || !allocPoolWithErrorLog(L"tickPtr", ticksSize, (void**)&ticksPtr, __LINE__)
+            || !allocPoolWithErrorLog(L"tickTransactionPtr", tickTransactionsSize, (void**)&tickTransactionsPtr, __LINE__)
+            || !allocPoolWithErrorLog(L"tickTransactionOffset", tickTransactionOffsetsSize, (void**)&tickTransactionOffsetsPtr, __LINE__)
+            || !allocPoolWithErrorLog(L"tickTransactionsDigestPtr", tickTransactionOffsetsLengthCurrentEpoch * sizeof(TransactionsDigestAccess::HashMapEntry), (void**)&tickTransactionsDigestPtr, __LINE__))
         {
             return false;
         }

--- a/src/tick_storage.h
+++ b/src/tick_storage.h
@@ -448,7 +448,6 @@ public:
              || !allocPoolWithErrorLog(L"tickTransactionOffset", tickTransactionOffsetsSize, (void**)&tickTransactionOffsetsPtr)
              || !allocPoolWithErrorLog(L"tickTransactionsDigestPtr", tickTransactionOffsetsLengthCurrentEpoch * sizeof(TransactionsDigestAccess::HashMapEntry), (void**)&tickTransactionsDigestPtr))
         {
-            logToConsole(L"Failed to allocate tick storage memory!");
             return false;
         }
 

--- a/src/tick_storage.h
+++ b/src/tick_storage.h
@@ -3,7 +3,7 @@
 #include "network_messages/tick.h"
 #include "network_messages/transactions.h"
 
-#include "platform/memory.h"
+#include "platform/memory_util.h"
 #include "platform/concurrency.h"
 #include "platform/console_logging.h"
 #include "platform/debugging.h"
@@ -442,11 +442,11 @@ public:
     static bool init()
     {
         // TODO: allocate everything with one continuous buffer
-        if (!allocatePool(tickDataSize, (void**)&tickDataPtr)
-            || !allocatePool(ticksSize, (void**)&ticksPtr)
-            || !allocatePool(tickTransactionsSize, (void**)&tickTransactionsPtr)
-            || !allocatePool(tickTransactionOffsetsSize, (void**)&tickTransactionOffsetsPtr)
-            || !allocatePool(tickTransactionOffsetsLengthCurrentEpoch * sizeof(TransactionsDigestAccess::HashMapEntry), (void**)&tickTransactionsDigestPtr))
+        if (!allocPoolWithErrorLog(L"tickDataPtr ", tickDataSize, (void**)&tickDataPtr)
+             || !allocPoolWithErrorLog(L"tickPtr", ticksSize, (void**)&ticksPtr)
+             || !allocPoolWithErrorLog(L"tickTransactionPtr", tickTransactionsSize, (void**)&tickTransactionsPtr)
+             || !allocPoolWithErrorLog(L"tickTransactionOffset", tickTransactionOffsetsSize, (void**)&tickTransactionOffsetsPtr)
+             || !allocPoolWithErrorLog(L"tickTransactionsDigestPtr", tickTransactionOffsetsLengthCurrentEpoch * sizeof(TransactionsDigestAccess::HashMapEntry), (void**)&tickTransactionsDigestPtr))
         {
             logToConsole(L"Failed to allocate tick storage memory!");
             return false;

--- a/test/score_reference.h
+++ b/test/score_reference.h
@@ -55,18 +55,18 @@ struct ScoreReferenceImplementation
     {
         for (int i = 0; i < solutionBufferCount; i++)
         {
-            allocPoolWithErrorLog(L"poolBuffer", RANDOM2_POOL_SIZE, (void**)&(_poolBuffer[i]));
+            allocPoolWithErrorLog(L"poolBuffer", RANDOM2_POOL_SIZE, (void**)&(_poolBuffer[i]), __LINE__);
 
-            allocPoolWithErrorLog(L"neurons[i].input", sizeof(long long) * neuronsCount, (void**)(&(_neurons[i].input)));
+            allocPoolWithErrorLog(L"neurons[i].input", sizeof(long long) * neuronsCount, (void**)(&(_neurons[i].input)), __LINE__);
 
-            allocPoolWithErrorLog(L"synapses[i].data", sizeof(unsigned long long) * synapseInputCount, (void**)(&(_synapses[i].data)));
+            allocPoolWithErrorLog(L"synapses[i].data", sizeof(unsigned long long) * synapseInputCount, (void**)(&(_synapses[i].data)), __LINE__);
             _synapses[i].signs = _synapses[i].data;
             _synapses[i].sequence = _synapses[i].data + synapseSignsCount;
             _synapses[i].skipTicksNumber = _synapses[i].data + synapseSignsCount + maxDuration;
 
 
-            allocPoolWithErrorLog(L"skipTicks[i]", sizeof(long long) * numberOfOptimizationSteps, (void**)&(_skipTicks[i]));
-            allocPoolWithErrorLog(L"ticksNumbers[i]", sizeof(long long) * maxDuration, (void**)&(_ticksNumbers[i]));
+            allocPoolWithErrorLog(L"skipTicks[i]", sizeof(long long) * numberOfOptimizationSteps, (void**)&(_skipTicks[i]), __LINE__);
+            allocPoolWithErrorLog(L"ticksNumbers[i]", sizeof(long long) * maxDuration, (void**)&(_ticksNumbers[i]), __LINE__);
         }
 
         static_assert(synapseInputCount * sizeof(*(_synapses->data)) % 8 == 0, "Random2 require output size is a multiplier of 8");

--- a/test/score_reference.h
+++ b/test/score_reference.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../src/platform/memory.h"
+#include "../src/platform/memory_util.h"
 #include "../src/four_q.h"
 
 ////////// Original (reference) scoring algorithm \\\\\\\\\\
@@ -55,11 +56,11 @@ struct ScoreReferenceImplementation
     {
         for (int i = 0; i < solutionBufferCount; i++)
         {
-            allocatePool(RANDOM2_POOL_SIZE, (void**)&(_poolBuffer[i]));
+            allocPoolWithErrorLog(L"poolBuffer", RANDOM2_POOL_SIZE, (void**)&(_poolBuffer[i]));
 
-            allocatePool(sizeof(long long) * neuronsCount, (void**)(&(_neurons[i].input)));
+            allocPoolWithErrorLog(L"neurons[i].input", sizeof(long long) * neuronsCount, (void**)(&(_neurons[i].input)));
 
-            allocatePool(sizeof(unsigned long long) * synapseInputCount, (void**)(&(_synapses[i].data)));
+            allocPoolWithErrorLog(L"synapses[i].data", sizeof(unsigned long long) * synapseInputCount, (void**)(&(_synapses[i].data)));
             _synapses[i].signs = _synapses[i].data;
             _synapses[i].sequence = _synapses[i].data + synapseSignsCount;
             _synapses[i].skipTicksNumber = _synapses[i].data + synapseSignsCount + maxDuration;

--- a/test/score_reference.h
+++ b/test/score_reference.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../src/platform/memory.h"
 #include "../src/platform/memory_util.h"
 #include "../src/four_q.h"
 
@@ -65,9 +64,9 @@ struct ScoreReferenceImplementation
             _synapses[i].sequence = _synapses[i].data + synapseSignsCount;
             _synapses[i].skipTicksNumber = _synapses[i].data + synapseSignsCount + maxDuration;
 
-            
-            allocatePool(sizeof(long long) * numberOfOptimizationSteps, (void**)&(_skipTicks[i]));
-            allocatePool(sizeof(long long) * maxDuration, (void**)&(_ticksNumbers[i]));
+
+            allocPoolWithErrorLog(L"skipTicks[i]", sizeof(long long) * numberOfOptimizationSteps, (void**)&(_skipTicks[i]));
+            allocPoolWithErrorLog(L"ticksNumbers[i]", sizeof(long long) * maxDuration, (void**)&(_ticksNumbers[i]));
         }
 
         static_assert(synapseInputCount * sizeof(*(_synapses->data)) % 8 == 0, "Random2 require output size is a multiplier of 8");


### PR DESCRIPTION
## Overview
Refactors calls to `bs->allocPool()`and `allocPool()` in [qubic.cpp](src/qubic.cpp) with an error message to a function that combines allocation and logging `allocPoolWithErrorLog()`. 

## Considerations
As function is implemented in qubic.cpp it is not available for other files (e.g., `spectrum.h`, `tick_storage.h`). Function depends on `console_logging.h` and `uefi.h` but function does not really match their responsibilities. Open for suggestion to move function to different file.

Also change is not of high priority.

## Testing
Testing is still pending, hence do not merge yet!