### PR TITLE
Debug Log Filesystem Check 

### DIFF
--- a/src/platform/debugging.h
+++ b/src/platform/debugging.h
@@ -113,7 +113,9 @@ static void addDebugMessage(const CHAR16* msg)
     RELEASE(debugLogLock);
     if (debugLogOnlyMainProcessorRunning)
     {
+        debugLogOnlyMainProcessorRunning = false;
         printDebugMessages();
+        debugLogOnlyMainProcessorRunning = true;
     }
 }
 
@@ -134,7 +136,9 @@ static void addDebugMessageAssert(const CHAR16* message, const CHAR16* file, con
     RELEASE(debugLogLock);
     if (debugLogOnlyMainProcessorRunning)
     {
+        debugLogOnlyMainProcessorRunning = false;
         printDebugMessages();
+        debugLogOnlyMainProcessorRunning = true;
     }
 }
 

--- a/src/platform/debugging.h
+++ b/src/platform/debugging.h
@@ -35,7 +35,11 @@ static void printDebugMessages()
     // Open debug log file and seek to the end of file for appending
     EFI_STATUS status;
     EFI_FILE_PROTOCOL* file = nullptr;
-    if (status = root->Open(root, (void**)&file, (CHAR16*)L"debug.log", EFI_FILE_MODE_READ | EFI_FILE_MODE_WRITE | EFI_FILE_MODE_CREATE, 0))
+    if (!root)
+    {
+        logToConsole(L"printDebugMessages() called before filesystem init");
+    }
+    else if (status = root->Open(root, (void**)&file, (CHAR16*)L"debug.log", EFI_FILE_MODE_READ | EFI_FILE_MODE_WRITE | EFI_FILE_MODE_CREATE, 0))
     {
         logStatusToConsole(L"EFI_FILE_PROTOCOL.Open() fails", status, __LINE__);
         file = nullptr;

--- a/src/platform/debugging.h
+++ b/src/platform/debugging.h
@@ -16,7 +16,6 @@ static void addDebugMessage(const CHAR16* msg)
 #elif defined(NDEBUG)
 
 // static void addDebugMessage(const CHAR16* msg){} // empty impl
-
 #else
 
 static CHAR16 debugMessage[128][16384];

--- a/src/platform/debugging.h
+++ b/src/platform/debugging.h
@@ -22,6 +22,7 @@ static void addDebugMessage(const CHAR16* msg)
 static CHAR16 debugMessage[128][16384];
 static int debugMessageCount = 0;
 static char volatile debugLogLock = 0;
+static bool volatile debugLogOnlyMainProcessorRunning = true;
 
 #define WRITE_DEBUG_MESSAGES_TO_FILE 1
 
@@ -110,6 +111,10 @@ static void addDebugMessage(const CHAR16* msg)
         ++debugMessageCount;
     }
     RELEASE(debugLogLock);
+    if (debugLogOnlyMainProcessorRunning)
+    {
+        printDebugMessages();
+    }
 }
 
 // Add a assert message for logging from arbitrary thread
@@ -127,6 +132,10 @@ static void addDebugMessageAssert(const CHAR16* message, const CHAR16* file, con
         ++debugMessageCount;
     }
     RELEASE(debugLogLock);
+    if (debugLogOnlyMainProcessorRunning)
+    {
+        printDebugMessages();
+    }
 }
 
 #endif

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5641,6 +5641,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
 
                     bs->CreateEvent(EVT_NOTIFY_SIGNAL, TPL_CALLBACK, shutdownCallback, NULL, &processors[numberOfProcessors].event);
                     mpServicesProtocol->StartupThisAP(mpServicesProtocol, Processor::runFunction, i, processors[numberOfProcessors].event, 0, &processors[numberOfProcessors], NULL);
+                    debugLogOnlyMainProcessorRunning = false;
 
                     if (!solutionProcessorFlags[i % NUMBER_OF_SOLUTION_PROCESSORS]
                         && !solutionProcessorFlags[i])

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5641,7 +5641,10 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
 
                     bs->CreateEvent(EVT_NOTIFY_SIGNAL, TPL_CALLBACK, shutdownCallback, NULL, &processors[numberOfProcessors].event);
                     mpServicesProtocol->StartupThisAP(mpServicesProtocol, Processor::runFunction, i, processors[numberOfProcessors].event, 0, &processors[numberOfProcessors], NULL);
+
+                    #if !defined(NDEBUG)
                     debugLogOnlyMainProcessorRunning = false;
+                    #endif
 
                     if (!solutionProcessorFlags[i % NUMBER_OF_SOLUTION_PROCESSORS]
                         && !solutionProcessorFlags[i])


### PR DESCRIPTION
## Overview
Add filesystem initialization check for debug logging preventing long waiting times for console logging in debug build

## Solution
- Add root filesystem null check before debug log operations
- Introduce `debugLogOnlyMainProcessorRunning` flag for processor state tracking
