### PR TITLE
feat: added new functions to get the Stats of QVAULT SC

### DIFF
--- a/src/contract_core/contract_def.h
+++ b/src/contract_core/contract_def.h
@@ -213,7 +213,7 @@ constexpr struct ContractDescription
     {"SWATCH", 123, 10000, sizeof(IPO)},
     {"CCF", 127, 10000, sizeof(CCF)}, // proposal in epoch 125, IPO in 126, construction and first use in 127
     {"QEARN", 137, 10000, sizeof(QEARN)}, // proposal in epoch 135, IPO in 136, construction in 137 / first donation after END_EPOCH, first round in epoch 138
-    {"QVAULT", 138, 10000, sizeof(IPO)}, // proposal in epoch 136, IPO in 137, construction and first use in 138
+    {"QVAULT", 138, 10000, sizeof(QVAULT)}, // proposal in epoch 136, IPO in 137, construction and first use in 138
 };
 
 constexpr unsigned int contractCount = sizeof(contractDescriptions) / sizeof(contractDescriptions[0]);

--- a/src/contracts/QVAULT.h
+++ b/src/contracts/QVAULT.h
@@ -214,7 +214,7 @@ public:
     struct getNumberOfAsset_input
     {
         uint64 assetName;
-	    id issuer;
+	id issuer;
         uint32 ownershipManagingContractIndex;
     };
 

--- a/src/contracts/QVAULT.h
+++ b/src/contracts/QVAULT.h
@@ -214,7 +214,7 @@ public:
     struct getNumberOfAsset_input
     {
         uint64 assetName;
-		id issuer;
+	    id issuer;
         uint32 ownershipManagingContractIndex;
     };
 
@@ -712,7 +712,7 @@ protected:
             locals.paymentForReinvest = QVAULT_MAX_REINVEST_AMOUNT;
         }
 
-        qpi.distributeDividends(div(locals.paymentForShareholders, 676ULL));
+        qpi.distributeDividends(div(locals.paymentForShareholders, NUMBER_OF_COMPUTORS * 1ULL));
         qpi.transfer(state.adminAddress, locals.paymentForDevelopment);
         qpi.transfer(state.reinvestingAddress, locals.paymentForReinvest);
         qpi.burn(locals.amountOfBurn);
@@ -728,7 +728,7 @@ protected:
         locals.statsOfEpoch.revenueOfQcapHolders = locals.paymentForQCAPHolders;
         locals.statsOfEpoch.revenueOfOneQcap = div(locals.paymentForQCAPHolders, locals.circulatedSupply);
         locals.statsOfEpoch.revenueOfQvaultHolders = locals.paymentForShareholders;
-        locals.statsOfEpoch.revenueOfOneQvault = div(locals.paymentForShareholders, 676ULL);
+        locals.statsOfEpoch.revenueOfOneQvault = div(locals.paymentForShareholders, NUMBER_OF_COMPUTORS * 1ULL);
         locals.statsOfEpoch.revenueOfDevTeam = locals.paymentForDevelopment;
         locals.statsOfEpoch.revenueOfReinvesting = locals.paymentForReinvest;
 


### PR DESCRIPTION
1. Adding the new functions to get the Stats

- `getNumberOfAsset` - we can get the number of assets that QVAULT holds using this function.
- `getStatsPerEpoch` - we can get the Stats of QVUALT SC in special epoch using this function.

These functions are already tested on testnet with qubic-cli and also I have added the gtest.

2. Changing the sizeof(IPO) to sizeof(QVAULT) in contract.def
- The IPO of QVAULT is finished and we need to update the size of QVAULT SC to use the below sturct to save the Stats data.
`struct StatsInfo
    {
        uint64 totalRevenue;
        uint64 revenueOfQcapHolders;
        uint64 revenueOfOneQcap;
        uint64 revenueOfQvaultHolders;
        uint64 revenueOfOneQvault;
        uint64 revenueOfReinvesting;
        uint64 revenueOfDevTeam;
    };

    array<StatsInfo, QVAULT_MAX_EPOCHS> _allEpochStats;`