### PR TITLE
Add async save/load file ability.

### DIFF
--- a/src/platform/concurrency.h
+++ b/src/platform/concurrency.h
@@ -10,3 +10,7 @@
 
 // Release lock
 #define RELEASE(lock) lock = 0
+
+#define ATOMIC_STORE8(target, val) _InterlockedExchange8(&target, val)
+#define ATOMIC_INC64(target) _InterlockedIncrement64(&target)
+#define ATOMIC_AND64(target, val) _InterlockedAnd64(&target, val)

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -21,7 +21,7 @@
 
 // Size of buffer for non-blocking save, this size will divided into ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS.
 // Can set by zeros to save memory and don't use non-block save
-static constexpr unsigned long long ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE = 8 * 1024 * 1024 * 1024ULL; // Set 0 if don't need non-blocking save
+static constexpr unsigned long long ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE = 0;//8 * 1024 * 1024 * 1024ULL; // Set 0 if don't need non-blocking save
 static constexpr int ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS_2FACTOR = 10;
 static constexpr int ASYNC_FILE_IO_MAX_QUEUE_ITEMS_2FACTOR = 4;
 static constexpr int ASYNC_FILE_IO_MAX_FILE_NAME = 64;

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -23,7 +23,7 @@
 // Can set by zeros to save memory and don't use non-block save
 static constexpr unsigned long long ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE = 8 * 1024 * 1024 * 1024ULL; // Set 0 if don't need non-blocking save
 static constexpr int ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS_2FACTOR = 10;
-static constexpr int ASYNC_FILE_IO_MAX_QUEUE_ITEMS_2FACTOR = 3;
+static constexpr int ASYNC_FILE_IO_MAX_QUEUE_ITEMS_2FACTOR = 4;
 static constexpr int ASYNC_FILE_IO_MAX_FILE_NAME = 64;
 static constexpr int ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS = (1ULL << ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS_2FACTOR);
 static constexpr int ASYNC_FILE_IO_MAX_QUEUE_ITEMS = (1ULL << ASYNC_FILE_IO_MAX_QUEUE_ITEMS_2FACTOR);
@@ -739,11 +739,9 @@ static long long asyncLoad(const CHAR16* fileName, unsigned long long totalSize,
     return 0;
 }
 
-static bool initFilesystem(EFI_MP_SERVICES_PROTOCOL* pServiceProtocol = NULL)
+static bool initFilesystem()
 {
 #ifdef NO_UEFI
-    allocatePool(sizeof(AsyncFileIO), (void**)(&gAsyncFileIO));
-    gAsyncFileIO->init(pServiceProtocol, ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE);
     return true;
 #else
     EFI_SIMPLE_FILE_SYSTEM_PROTOCOL* simpleFileSystemProtocol = NULL;
@@ -852,15 +850,15 @@ static bool initFilesystem(EFI_MP_SERVICES_PROTOCOL* pServiceProtocol = NULL)
         return false;
     }
 
-    if (NULL != pServiceProtocol)
-    {
-        allocatePool(sizeof(AsyncFileIO), (void**)(&gAsyncFileIO));
-        gAsyncFileIO->init(pServiceProtocol, ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE);
-    }
-
-
     return true;
 #endif
+}
+
+static void registerAsynFileIO(EFI_MP_SERVICES_PROTOCOL* pServiceProtocol)
+{
+    allocatePool(sizeof(AsyncFileIO), (void**)(&gAsyncFileIO));
+    setMem(gAsyncFileIO, sizeof(AsyncFileIO), 0);
+    gAsyncFileIO->init(pServiceProtocol, ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE);
 }
 
 #pragma optimize("", off)

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -304,6 +304,8 @@ static long long save(const CHAR16* fileName, unsigned long long totalSize, cons
 #endif
 }
 
+#pragma optimize("", off)
+
 struct FileItem
 {
     enum ItemState
@@ -702,6 +704,8 @@ private:
     LoadFileItemStorage<ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS> mFileBlockingReadQueue;
 };
 
+#pragma optimize("", on)
+
 // Asynchorous save file
 // This function can be called from any thread and have blocking and non blocking mode
 // - Blocking mode: to avoid lock and the actual save happen, flushAsyncFileIOBuffer must be called in main thread
@@ -859,6 +863,8 @@ static bool initFilesystem(EFI_MP_SERVICES_PROTOCOL* pServiceProtocol = NULL)
 #endif
 }
 
+#pragma optimize("", off)
+
 static void deInitFileSystem()
 {
     if (gAsyncFileIO)
@@ -876,6 +882,7 @@ static void flushAsyncFileIOBuffer()
         gAsyncFileIO->flush();
     }
 }
+#pragma optimize("", on)
 
 // add epoch number as an extension to a filename
 static void addEpochToFileName(unsigned short* filename, int nameSize, short epoch)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4471,10 +4471,7 @@ static bool initialize()
     requestedTickTransactions.header.setType(REQUEST_TICK_TRANSACTIONS);
     requestedTickTransactions.requestedTickTransactions.tick = 0;
 
-    EFI_GUID mpServiceProtocolGuid = EFI_MP_SERVICES_PROTOCOL_GUID;
-    bs->LocateProtocol(&mpServiceProtocolGuid, NULL, (void**)&mpServicesProtocol);
-
-    if (!initFilesystem(mpServicesProtocol))
+    if (!initFilesystem())
         return false;
 
     EFI_STATUS status;
@@ -5580,9 +5577,13 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
         EFI_STATUS status;
 
         unsigned int computingProcessorNumber;
+        EFI_GUID mpServiceProtocolGuid = EFI_MP_SERVICES_PROTOCOL_GUID;
+        bs->LocateProtocol(&mpServiceProtocolGuid, NULL, (void**)&mpServicesProtocol);
         unsigned long long numberOfAllProcessors, numberOfEnabledProcessors;
         mpServicesProtocol->GetNumberOfProcessors(mpServicesProtocol, &numberOfAllProcessors, &numberOfEnabledProcessors);
         mpServicesProtocol->WhoAmI(mpServicesProtocol, &mainThreadProcessorID); // get the proc Id of main thread (for later use)
+
+        registerAsynFileIO(mpServicesProtocol);
         
         // Initialize resource management
         // ASSUMPTION: - each processor (CPU core) is bound to different functional thread.

--- a/test/file_io.cpp
+++ b/test/file_io.cpp
@@ -1,0 +1,612 @@
+#define NO_UEFI
+
+#include "gtest/gtest.h"
+
+
+#include <iostream>
+#include <thread>
+#include <mutex>
+#include <fstream>
+
+#include "../src/platform/file_io.h"
+
+static constexpr unsigned long long THREAD_COUNT = 8;
+static constexpr unsigned long long MEM_BUFFER_SIZE = 52ULL * 1024ULL * 1024ULL;
+std::mutex gMessageLock;
+
+// For testing the scheduler save file
+struct FragmentData
+{
+    // Reserve memories
+    unsigned int memBuffer[MEM_BUFFER_SIZE];
+
+    // Randomly parition of data for writing
+    unsigned long long dataPos[4][2];
+};
+
+static std::vector<FragmentData> threadData;
+static FragmentData buffer;
+static unsigned char threadFinish[THREAD_COUNT];
+
+inline static unsigned int random(const unsigned int range)
+{
+    unsigned int value;
+    _rdrand32_step(&value);
+
+    return value % range;
+}
+
+inline static unsigned long long random64(const unsigned long long range)
+{
+    unsigned long long value;
+    _rdrand64_step(&value);
+
+    return (value % range);
+}
+
+class FileSystemWrapper
+{
+public:
+    FileSystemWrapper()
+    {
+        bool sts = initFilesystem(NULL);
+    }
+    ~FileSystemWrapper()
+    {
+        deInitFileSystem();
+    }
+
+    bool initTestData()
+    {
+        memset(threadFinish, 1, THREAD_COUNT);
+
+        threadData.resize(THREAD_COUNT);
+        for (int id = 0; id < THREAD_COUNT; id++)
+        {
+            // randomly generate a chunk of data
+            for (unsigned long long i = 0; i < MEM_BUFFER_SIZE; i++)
+            {
+                threadData[id].memBuffer[i] = random(4096) * ((int)i + 1);
+            }
+            // Randomly pick some part of data for writing out
+            unsigned long long remainedData = MEM_BUFFER_SIZE;
+            for (int i = 0; i < sizeof(threadData[id].dataPos) / sizeof(threadData[id].dataPos[0]); i++)
+            {
+                // Start of the data
+                threadData[id].dataPos[i][0] = random64(MEM_BUFFER_SIZE - 1);
+
+                // Size of the data. Make sure we limit all small files in size of total MEM_BUFFER_SIZE
+                unsigned long long dataSize = random64(MEM_BUFFER_SIZE - threadData[id].dataPos[i][0]);
+                dataSize = dataSize > remainedData ? remainedData : dataSize;
+                remainedData = remainedData - dataSize;
+
+                if (dataSize == 0)
+                {
+                    dataSize = 1;
+                }
+
+                threadData[id].dataPos[i][1] = dataSize;
+            }
+        }
+        return true;
+    }
+};
+
+static FileSystemWrapper fileSystem;
+
+long long loadFile(CHAR16* fileName, unsigned long long totalSize, char* buffer)
+{
+    FILE* file = nullptr;
+    if (_wfopen_s(&file, fileName, L"rb") != 0 || !file)
+    {
+        wprintf(L"Error opening file %s!\n", fileName);
+        return -1;
+    }
+    if (fread(buffer, 1, totalSize, file) != totalSize)
+    {
+        wprintf(L"Error reading %llu bytes from %s!\n", totalSize, fileName);
+        return -1;
+    }
+    fclose(file);
+    return totalSize;
+}
+
+long long saveFile(CHAR16* fileName, unsigned long long totalSize, const char* buffer)
+{
+    FILE* file = nullptr;
+    if (_wfopen_s(&file, fileName, L"wb") != 0 || !file)
+    {
+        wprintf(L"Error opening file %s!\n", fileName);
+        return -1;
+    }
+    if (fwrite(buffer, 1, totalSize, file) != totalSize)
+    {
+        wprintf(L"Error saving %llu bytes from %s!\n", totalSize, fileName);
+        return -1;
+    }
+    fclose(file);
+    return totalSize;
+}
+
+bool runAsyncSaveFile(int id, bool blocking = true, bool largeFile = false)
+{
+    bool sts = true;
+    CHAR16 fileName[32];
+    setText(fileName, L"file_");
+    appendNumber(fileName, id, false);
+
+    if (largeFile)
+    {
+        long long sts = asyncSaveLargeFile(fileName, MEM_BUFFER_SIZE * sizeof(unsigned int), (unsigned char*)&(threadData[id].memBuffer[0]), NULL, false, blocking);
+        if (sts <= 0)
+        {
+            std::lock_guard<std::mutex> lock(gMessageLock);
+            std::cout << "saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+            sts = false;
+        }
+    }
+    else
+    {
+        // Try to save the files
+        for (int i = 0; i < sizeof(threadData[id].dataPos) / sizeof(threadData[id].dataPos[0]); i++)
+        {
+            unsigned long long dataStart = threadData[id].dataPos[i][0];
+            unsigned long long dataCount = threadData[id].dataPos[i][1];
+
+            CHAR16 partionFileName[256];
+            setText(partionFileName, fileName);
+            appendText(partionFileName, L".");
+            appendNumber(partionFileName, i, false);
+
+            long long sts = asyncSave(partionFileName, dataCount * sizeof(unsigned int), (unsigned char*)&(threadData[id].memBuffer[dataStart]), NULL, blocking);
+            if (sts <= 0)
+            {
+                std::lock_guard<std::mutex> lock(gMessageLock);
+                std::cout << "saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                sts = false;
+                break;
+            }
+        }
+    }
+
+    threadFinish[id] = 1;
+    return sts;
+}
+
+bool prepareAsyncLoadFile(bool largeFile = false)
+{
+    bool sts = true;
+    fileSystem.initTestData();
+
+    for (int id = 0; id < THREAD_COUNT; id++)
+    {
+        CHAR16 fileName[32];
+        setText(fileName, L"file_");
+        appendNumber(fileName, id, false);
+
+        if (largeFile)
+        {
+            long long sts = saveLargeFile(fileName, MEM_BUFFER_SIZE * sizeof(unsigned int), (unsigned char*)&(threadData[id].memBuffer[0]), NULL, false);
+            if (sts <= 0)
+            {
+                std::lock_guard<std::mutex> lock(gMessageLock);
+                std::cout << "saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                sts = false;
+            }
+        }
+        else
+        {
+            // Try to save the files
+            for (int i = 0; i < sizeof(threadData[id].dataPos) / sizeof(threadData[id].dataPos[0]); i++)
+            {
+                unsigned long long dataStart = threadData[id].dataPos[i][0];
+                unsigned long long dataCount = threadData[id].dataPos[i][1];
+
+                CHAR16 partionFileName[256];
+                setText(partionFileName, fileName);
+                appendText(partionFileName, L".");
+                appendNumber(partionFileName, i, false);
+
+                long long sts = save(partionFileName, dataCount * sizeof(unsigned int), (unsigned char*)&(threadData[id].memBuffer[dataStart]), NULL);
+                if (sts <= 0)
+                {
+                    std::lock_guard<std::mutex> lock(gMessageLock);
+                    std::cout << "saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                    sts = false;
+                    break;
+                }
+            }
+        }
+    }
+    return sts;
+}
+
+bool runAsyncLoadFile(int id, bool largeFile = false)
+{
+    bool sts = true;
+    CHAR16 fileName[32];
+    setText(fileName, L"file_");
+    appendNumber(fileName, id, false);
+
+    if (largeFile)
+    {
+        long long sts = asyncLoadLargeFile(fileName, MEM_BUFFER_SIZE * sizeof(unsigned int), (unsigned char*)&(threadData[id].memBuffer[0]), NULL);
+        if (sts <= 0)
+        {
+            std::lock_guard<std::mutex> lock(gMessageLock);
+            std::cout << "saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+            sts = false;
+        }
+    }
+    else
+    {
+        // Try to save the files
+        for (int i = 0; i < sizeof(threadData[id].dataPos) / sizeof(threadData[id].dataPos[0]); i++)
+        {
+            unsigned long long dataStart = threadData[id].dataPos[i][0];
+            unsigned long long dataCount = threadData[id].dataPos[i][1];
+
+            CHAR16 partionFileName[256];
+            setText(partionFileName, fileName);
+            appendText(partionFileName, L".");
+            appendNumber(partionFileName, i, false);
+
+            long long sts = asyncLoad(partionFileName, dataCount * sizeof(unsigned int), (unsigned char*)&(threadData[id].memBuffer[dataStart]), NULL);
+            if (sts <= 0)
+            {
+                std::lock_guard<std::mutex> lock(gMessageLock);
+                std::cout << "saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                sts = false;
+                break;
+            }
+        }
+    }
+
+    threadFinish[id] = 1;
+    return sts;
+}
+
+
+bool verifyResult(int id, bool largeFile = false)
+{
+    bool testPass = false;
+    CHAR16 fileName[32];
+    setText(fileName, L"file_");
+    appendNumber(fileName, id, false);
+
+    if (largeFile)
+    {
+        long long sts = loadLargeFile(fileName, MEM_BUFFER_SIZE * sizeof(unsigned int), (unsigned char*)buffer.memBuffer, NULL);
+        unsigned char* originalData = (unsigned char*)&(threadData[id].memBuffer[0]);
+        unsigned char* loadedData = (unsigned char*)&(buffer.memBuffer[0]);
+        int result = memcmp(originalData, loadedData, MEM_BUFFER_SIZE * sizeof(unsigned int));
+        testPass = (result == 0);
+    }
+    else
+    {
+        int matchCount = 0;
+        int numberOfFiles = sizeof(threadData[id].dataPos) / sizeof(threadData[id].dataPos[0]);
+        for (int i = 0; i < numberOfFiles; i++)
+        {
+            unsigned long long dataStart = threadData[id].dataPos[i][0];
+            unsigned long long dataCount = threadData[id].dataPos[i][1];
+
+            CHAR16 partionFileName[256];
+            setText(partionFileName, fileName);
+            appendText(partionFileName, L".");
+            appendNumber(partionFileName, i, false);
+
+            long long sts = loadFile(partionFileName, dataCount * sizeof(unsigned int), (char*)buffer.memBuffer);
+
+            if (sts != dataCount * sizeof(unsigned int))
+            {
+                std::cout << "verifyResult failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                return false;
+            }
+
+            unsigned char* originalData = (unsigned char*)&(threadData[id].memBuffer[dataStart]);
+            unsigned char* loadedData = (unsigned char*)&(buffer.memBuffer[0]);
+
+            int result = memcmp(originalData, loadedData, dataCount * sizeof(unsigned int));
+            if (result == 0)
+            {
+                matchCount++;
+            }
+        }
+        testPass = (matchCount == numberOfFiles);
+    }
+
+    return testPass;
+}
+
+TEST(TestAsyncFileIO, AsyncSaveFile)
+{
+    fileSystem.initTestData();
+
+    // Run the test
+    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        threadFinish[i] = 0;
+        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, false, false));
+    }
+
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (threadVec[i]->joinable())
+        {
+            threadVec[i]->join();
+        }
+    }
+    // Actually write happen here
+    flushAsyncFileIOBuffer();
+
+    // Verify result
+    int testPass = 0;
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (verifyResult(i))
+        {
+            testPass++;
+        }
+    }
+    EXPECT_EQ(testPass, THREAD_COUNT);
+}
+
+TEST(TestAsyncFileIO, AsyncSaveLargeFile)
+{
+    fileSystem.initTestData();
+
+    // Run the test
+    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        threadFinish[i] = 0;
+        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, false, true));
+    }
+
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (threadVec[i]->joinable())
+        {
+            threadVec[i]->join();
+        }
+    }
+    // Actually write happen here
+    flushAsyncFileIOBuffer();
+
+    // Verify result
+    int testPass = 0;
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (verifyResult(i, true))
+        {
+            testPass++;
+        }
+    }
+    EXPECT_EQ(testPass, THREAD_COUNT);
+}
+
+TEST(TestAsyncFileIO, AsyncBlockingSaveFile)
+{
+    fileSystem.initTestData();
+
+    // Run the test
+    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        threadFinish[i] = 0;
+        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, true, false));
+    }
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+    int readyCount = 0;
+    while (readyCount < THREAD_COUNT)
+    {
+        // Don't flush right away. Wait sometimes for simulate
+        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
+        if (waitingTimeInMs > 10000)
+        {
+            startTime = std::chrono::high_resolution_clock::now();
+            flushAsyncFileIOBuffer();
+        }
+
+        readyCount = 0;
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            char readyFlag = 0;
+            readyFlag = threadFinish[i];
+            if (readyFlag)
+            {
+                readyCount++;
+            }
+        }
+    }
+
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (threadVec[i]->joinable())
+        {
+            threadVec[i]->join();
+        }
+    }
+
+    // Verify result
+    int testPass = 0;
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (verifyResult(i))
+        {
+            testPass++;
+        }
+    }
+    EXPECT_EQ(testPass, THREAD_COUNT);
+}
+
+TEST(TestAsyncFileIO, AsyncBlockingSaveLargeFile)
+{
+    fileSystem.initTestData();
+
+    // Run the test
+    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        threadFinish[i] = 0;
+        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, true, true));
+    }
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+    int readyCount = 0;
+    while (readyCount < THREAD_COUNT)
+    {
+        // Don't flush right away. Wait sometimes for simulate
+        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
+        if (waitingTimeInMs > 10000)
+        {
+            startTime = std::chrono::high_resolution_clock::now();
+            flushAsyncFileIOBuffer();
+        }
+
+        readyCount = 0;
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            char readyFlag = 0;
+            readyFlag = threadFinish[i];
+            if (readyFlag)
+            {
+                readyCount++;
+            }
+        }
+    }
+
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (threadVec[i]->joinable())
+        {
+            threadVec[i]->join();
+        }
+    }
+
+    // Verify result
+    int testPass = 0;
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (verifyResult(i, true))
+        {
+            testPass++;
+        }
+    }
+    EXPECT_EQ(testPass, THREAD_COUNT);
+}
+
+TEST(TestAsyncFileIO, AsyncLoadFile)
+{
+    prepareAsyncLoadFile(false);
+
+    // Run the test
+    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        threadFinish[i] = 0;
+        threadVec[i].reset(new std::thread(runAsyncLoadFile, i, false));
+    }
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+    int readyCount = 0;
+    while (readyCount < THREAD_COUNT)
+    {
+        // Don't flush right away. Wait sometimes for simulate
+        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
+        if (waitingTimeInMs > 10000)
+        {
+            startTime = std::chrono::high_resolution_clock::now();
+            flushAsyncFileIOBuffer();
+        }
+
+        readyCount = 0;
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            char readyFlag = 0;
+            readyFlag = threadFinish[i];
+            if (readyFlag)
+            {
+                readyCount++;
+            }
+        }
+    }
+
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (threadVec[i]->joinable())
+        {
+            threadVec[i]->join();
+        }
+    }
+
+    // Verify result
+    int testPass = 0;
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (verifyResult(i))
+        {
+            testPass++;
+        }
+    }
+    EXPECT_EQ(testPass, THREAD_COUNT);
+}
+
+TEST(TestAsyncFileIO, AsyncLoadLargeFile)
+{
+    prepareAsyncLoadFile(true);
+
+    // Run the test
+    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        threadFinish[i] = 0;
+        threadVec[i].reset(new std::thread(runAsyncLoadFile, i, true));
+    }
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+    int readyCount = 0;
+    while (readyCount < THREAD_COUNT)
+    {
+        // Don't flush right away. Wait sometimes for simulate
+        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
+        if (waitingTimeInMs > 10000)
+        {
+            startTime = std::chrono::high_resolution_clock::now();
+            flushAsyncFileIOBuffer();
+        }
+
+        readyCount = 0;
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            char readyFlag = 0;
+            readyFlag = threadFinish[i];
+            if (readyFlag)
+            {
+                readyCount++;
+            }
+        }
+    }
+
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (threadVec[i]->joinable())
+        {
+            threadVec[i]->join();
+        }
+    }
+
+    // Verify result
+    int testPass = 0;
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (verifyResult(i, true))
+        {
+            testPass++;
+        }
+    }
+    EXPECT_EQ(testPass, THREAD_COUNT);
+}

--- a/test/file_io.cpp
+++ b/test/file_io.cpp
@@ -10,7 +10,7 @@
 
 #include "../src/platform/file_io.h"
 
-static constexpr unsigned long long THREAD_COUNT = 8;
+static constexpr unsigned long long THREAD_COUNT = 4;
 static constexpr unsigned long long MEM_BUFFER_SIZE = 52ULL * 1024ULL * 1024ULL;
 std::mutex gMessageLock;
 
@@ -49,7 +49,8 @@ class FileSystemWrapper
 public:
     FileSystemWrapper()
     {
-        bool sts = initFilesystem(NULL);
+        initFilesystem();
+        registerAsynFileIO(NULL);
     }
     ~FileSystemWrapper()
     {
@@ -141,7 +142,7 @@ bool runAsyncSaveFile(int id, bool blocking = true, bool largeFile = false)
         if (sts <= 0)
         {
             std::lock_guard<std::mutex> lock(gMessageLock);
-            std::cout << "saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+            std::cout << "runAsyncSaveFile::saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
             sts = false;
         }
     }
@@ -162,7 +163,7 @@ bool runAsyncSaveFile(int id, bool blocking = true, bool largeFile = false)
             if (sts <= 0)
             {
                 std::lock_guard<std::mutex> lock(gMessageLock);
-                std::cout << "saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                std::cout << "runAsyncSaveFile::saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
                 sts = false;
                 break;
             }
@@ -190,7 +191,7 @@ bool prepareAsyncLoadFile(bool largeFile = false)
             if (sts <= 0)
             {
                 std::lock_guard<std::mutex> lock(gMessageLock);
-                std::cout << "saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                std::cout << "prepareAsyncLoadFile::saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
                 sts = false;
             }
         }
@@ -211,7 +212,7 @@ bool prepareAsyncLoadFile(bool largeFile = false)
                 if (sts <= 0)
                 {
                     std::lock_guard<std::mutex> lock(gMessageLock);
-                    std::cout << "saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                    std::cout << "prepareAsyncLoadFile::saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
                     sts = false;
                     break;
                 }
@@ -234,13 +235,13 @@ bool runAsyncLoadFile(int id, bool largeFile = false)
         if (sts <= 0)
         {
             std::lock_guard<std::mutex> lock(gMessageLock);
-            std::cout << "saveFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+            std::cout << "runAsyncLoadFile::loadFile failed with size " << MEM_BUFFER_SIZE * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
             sts = false;
         }
     }
     else
     {
-        // Try to save the files
+        // Try to load the files
         for (int i = 0; i < sizeof(threadData[id].dataPos) / sizeof(threadData[id].dataPos[0]); i++)
         {
             unsigned long long dataStart = threadData[id].dataPos[i][0];
@@ -255,7 +256,7 @@ bool runAsyncLoadFile(int id, bool largeFile = false)
             if (sts <= 0)
             {
                 std::lock_guard<std::mutex> lock(gMessageLock);
-                std::cout << "saveFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
+                std::cout << "runAsyncLoadFile::loadFile failed with size " << dataCount * sizeof(unsigned int) / 1024 << " KB. Error " << sts << std::endl;
                 sts = false;
                 break;
             }

--- a/test/file_io.cpp
+++ b/test/file_io.cpp
@@ -320,7 +320,9 @@ bool verifyResult(int id, bool largeFile = false)
     return testPass;
 }
 
-TEST(TestAsyncFileIO, AsyncSaveFile)
+#if 0
+
+TEST(TestAsyncFileIO, AsyncNonBlockingSaveFile)
 {
     fileSystem.initTestData();
 
@@ -354,7 +356,7 @@ TEST(TestAsyncFileIO, AsyncSaveFile)
     EXPECT_EQ(testPass, THREAD_COUNT);
 }
 
-TEST(TestAsyncFileIO, AsyncSaveLargeFile)
+TEST(TestAsyncFileIO, AsyncNonBlockingSaveLargeFile)
 {
     fileSystem.initTestData();
 
@@ -388,7 +390,9 @@ TEST(TestAsyncFileIO, AsyncSaveLargeFile)
     EXPECT_EQ(testPass, THREAD_COUNT);
 }
 
-TEST(TestAsyncFileIO, AsyncBlockingSaveFile)
+#endif
+
+TEST(TestAsyncFileIO, AsyncSaveFile)
 {
     fileSystem.initTestData();
 
@@ -444,7 +448,7 @@ TEST(TestAsyncFileIO, AsyncBlockingSaveFile)
     EXPECT_EQ(testPass, THREAD_COUNT);
 }
 
-TEST(TestAsyncFileIO, AsyncBlockingSaveLargeFile)
+TEST(TestAsyncFileIO, AsyncSaveLargeFile)
 {
     fileSystem.initTestData();
 

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="contract_qearn.cpp" />
     <ClCompile Include="contract_qx.cpp" />
     <ClCompile Include="contract_qvault.cpp" />
+    <ClCompile Include="file_io.cpp" />
     <ClCompile Include="qpi_collection.cpp" />
     <ClCompile Include="qpi_hash_map.cpp" />
     <ClCompile Include="kangaroo_twelve.cpp" />

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -22,6 +22,7 @@
     <ClCompile Include="contract_qvault.cpp" />
     <ClCompile Include="common_def.cpp" />
     <ClCompile Include="assets.cpp" />
+    <ClCompile Include="file_io.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="score_reference.h" />


### PR DESCRIPTION
# Purpose
The save/load file functionality does not work on the Application Processor (AP - non-main thread), even with resource locking. It can only operate on the Boot Strap Processor (BS - main thread).
This PR introduces the capability to save/load files on non-main threads by offloading the actual operations to the main thread.

Detail: https://github.com/orgs/qubic/projects/1?pane=issue&itemId=85821090

# Design Features
- `AsyncLoadFile (AsyncLoadLargeFile)`: Can be called from any thread to load a file. This is a blocking call until the load is complete.
- `AsyncSaveFile (AsyncSaveLargeFile)`: Can be called from any thread to save a file. This can be either a blocking or non-blocking call.
- `flushAsyncFileIOBuffer`: this function performs the save/load operations and also releases the blocking calls of the above two functions.

# How to use
- Initialize the file system with the additional EFI_MP_SERVICES_PROTOCOL* using `initFilesystem(pServiceProtocol)`.
- Call `AsyncLoadFile`, `AsyncLoadLargeFile`, `AsyncSaveFile`, or `AsyncSaveLargeFile` with or without blocking flags, depending on the purpose.
- On main thread must frequently call `flushAsyncFileIOBuffer`.
- After done, need to call `deInitFileSystem`

# Test. [UPDATED]
- Unit-test implementation
- An standalone UEFI testing for all functions is implemented in https://github.com/cyber-pc/qubic-core/tree/cyber-pc/uefi-file
- testnet run successfully with this PR
- testnet run successfully with this PR + enable async save file (keep the same logic with current master, and use async file io to repicate the behavior) and all files matched

# Next Step
- For file IO on multiple-process, encourage to use the new asyncFileIO.
- For file IO on main process, can use the normal version.