### PR TITLE
Renaming some classes

### DIFF
--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -28,7 +28,7 @@
 
 // TODO: move this into AssetStorage class
 GLOBAL_VAR_DECL volatile char universeLock GLOBAL_VAR_INIT(0);
-GLOBAL_VAR_DECL Asset* assets GLOBAL_VAR_INIT(nullptr);
+GLOBAL_VAR_DECL AssetRecord* assets GLOBAL_VAR_INIT(nullptr);
 GLOBAL_VAR_DECL m256i* assetDigests GLOBAL_VAR_INIT(nullptr);
 static constexpr unsigned long long assetDigestsSizeInBytes = (ASSETS_CAPACITY * 2 - 1) * 32ULL;
 GLOBAL_VAR_DECL unsigned long long* assetChangeFlags GLOBAL_VAR_INIT(nullptr);
@@ -159,7 +159,7 @@ static unsigned int issuanceIndex(const m256i& issuer, unsigned long long assetN
 
 static bool initAssets()
 {
-    if (!allocatePool(ASSETS_CAPACITY * sizeof(Asset), (void**)&assets)
+    if (!allocatePool(ASSETS_CAPACITY * sizeof(AssetRecord), (void**)&assets)
         || !allocatePool(assetDigestsSizeInBytes, (void**)&assetDigests)
         || !allocatePool(ASSETS_CAPACITY / 8, (void**)&assetChangeFlags))
     {
@@ -505,7 +505,7 @@ static void getUniverseDigest(m256i& digest)
     {
         if (assetChangeFlags[digestIndex >> 6] & (1ULL << (digestIndex & 63)))
         {
-            KangarooTwelve(&assets[digestIndex], sizeof(Asset), &assetDigests[digestIndex], 32);
+            KangarooTwelve(&assets[digestIndex], sizeof(AssetRecord), &assetDigests[digestIndex], 32);
         }
     }
     unsigned int previousLevelBeginning = 0;
@@ -538,10 +538,10 @@ static bool saveUniverse(const CHAR16* fileName = UNIVERSE_FILE_NAME, const CHAR
     const unsigned long long beginningTick = __rdtsc();
 
     ACQUIRE(universeLock);
-    long long savedSize = save(fileName, ASSETS_CAPACITY * sizeof(Asset), (unsigned char*)assets, directory);
+    long long savedSize = save(fileName, ASSETS_CAPACITY * sizeof(AssetRecord), (unsigned char*)assets, directory);
     RELEASE(universeLock);
 
-    if (savedSize == ASSETS_CAPACITY * sizeof(Asset))
+    if (savedSize == ASSETS_CAPACITY * sizeof(AssetRecord))
     {
         setNumber(message, savedSize, TRUE);
         appendText(message, L" bytes of the universe data are saved (");
@@ -555,8 +555,8 @@ static bool saveUniverse(const CHAR16* fileName = UNIVERSE_FILE_NAME, const CHAR
 
 static bool loadUniverse(const CHAR16* fileName = UNIVERSE_FILE_NAME, CHAR16* directory = NULL)
 {
-    long long loadedSize = load(fileName, ASSETS_CAPACITY * sizeof(Asset), (unsigned char*)assets, directory);
-    if (loadedSize != ASSETS_CAPACITY * sizeof(Asset))
+    long long loadedSize = load(fileName, ASSETS_CAPACITY * sizeof(AssetRecord), (unsigned char*)assets, directory);
+    if (loadedSize != ASSETS_CAPACITY * sizeof(AssetRecord))
     {
         logStatusToConsole(L"EFI_FILE_PROTOCOL.Read() reads invalid number of bytes", loadedSize, __LINE__);
 
@@ -571,8 +571,8 @@ static void assetsEndEpoch()
     ACQUIRE(universeLock);
 
     // rebuild asset hash map, getting rid of all elements with zero shares
-    Asset* reorgAssets = (Asset*)reorgBuffer;
-    setMem(reorgAssets, ASSETS_CAPACITY * sizeof(Asset), 0);
+    AssetRecord* reorgAssets = (AssetRecord*)reorgBuffer;
+    setMem(reorgAssets, ASSETS_CAPACITY * sizeof(AssetRecord), 0);
     for (unsigned int i = 0; i < ASSETS_CAPACITY; i++)
     {
         if (assets[i].varStruct.possession.type == POSSESSION
@@ -591,7 +591,7 @@ static void assetsEndEpoch()
             {
                 if (reorgAssets[issuanceIndex].varStruct.issuance.type == EMPTY)
                 {
-                    copyMem(&reorgAssets[issuanceIndex], &assets[oldIssuanceIndex], sizeof(Asset));
+                    copyMem(&reorgAssets[issuanceIndex], &assets[oldIssuanceIndex], sizeof(AssetRecord));
                 }
 
                 const m256i& ownerPublicKey = assets[oldOwnershipIndex].varStruct.ownership.publicKey;
@@ -651,7 +651,7 @@ static void assetsEndEpoch()
             }
         }
     }
-    copyMem(assets, reorgAssets, ASSETS_CAPACITY * sizeof(Asset));
+    copyMem(assets, reorgAssets, ASSETS_CAPACITY * sizeof(AssetRecord));
 
     setMem(assetChangeFlags, ASSETS_CAPACITY / 8, 0xFF);
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -276,7 +276,7 @@ iteration:
 }
 
 static sint64 numberOfShares(
-    const AssetIssuanceId& issuanceId,
+    const Asset& issuanceId,
     const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any(),
     const AssetPossessionSelect& possession = AssetPossessionSelect::any())
 {

--- a/src/assets/net_msg_impl.h
+++ b/src/assets/net_msg_impl.h
@@ -25,7 +25,7 @@ iteration:
         if (assets[universeIndex].varStruct.issuance.type == ISSUANCE
             && assets[universeIndex].varStruct.issuance.publicKey == request->publicKey)
         {
-            bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(Asset));
+            bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(AssetRecord));
             response.tick = system.tick;
             response.universeIndex = universeIndex;
             getSiblings<ASSETS_DEPTH>(response.universeIndex, assetDigests, response.siblings);
@@ -62,8 +62,8 @@ iteration:
         if (assets[universeIndex].varStruct.issuance.type == OWNERSHIP
             && assets[universeIndex].varStruct.issuance.publicKey == request->publicKey)
         {
-            bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(Asset));
-            bs->CopyMem(&response.issuanceAsset, &assets[assets[universeIndex].varStruct.ownership.issuanceIndex], sizeof(Asset));
+            bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(AssetRecord));
+            bs->CopyMem(&response.issuanceAsset, &assets[assets[universeIndex].varStruct.ownership.issuanceIndex], sizeof(AssetRecord));
             response.tick = system.tick;
             response.universeIndex = universeIndex;
             getSiblings<ASSETS_DEPTH>(response.universeIndex, assetDigests, response.siblings);
@@ -100,9 +100,9 @@ iteration:
         if (assets[universeIndex].varStruct.issuance.type == POSSESSION
             && assets[universeIndex].varStruct.issuance.publicKey == request->publicKey)
         {
-            bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(Asset));
-            bs->CopyMem(&response.ownershipAsset, &assets[assets[universeIndex].varStruct.possession.ownershipIndex], sizeof(Asset));
-            bs->CopyMem(&response.issuanceAsset, &assets[assets[assets[universeIndex].varStruct.possession.ownershipIndex].varStruct.ownership.issuanceIndex], sizeof(Asset));
+            bs->CopyMem(&response.asset, &assets[universeIndex], sizeof(AssetRecord));
+            bs->CopyMem(&response.ownershipAsset, &assets[assets[universeIndex].varStruct.possession.ownershipIndex], sizeof(AssetRecord));
+            bs->CopyMem(&response.issuanceAsset, &assets[assets[assets[universeIndex].varStruct.possession.ownershipIndex].varStruct.ownership.issuanceIndex], sizeof(AssetRecord));
             response.tick = system.tick;
             response.universeIndex = universeIndex;
             getSiblings<ASSETS_DEPTH>(response.universeIndex, assetDigests, response.siblings);

--- a/src/common_buffers.h
+++ b/src/common_buffers.h
@@ -8,7 +8,7 @@
 
 
 constexpr unsigned long long spectrumSizeInBytes = SPECTRUM_CAPACITY * sizeof(::Entity);
-constexpr unsigned long long universeSizeInBytes = ASSETS_CAPACITY * sizeof(Asset);
+constexpr unsigned long long universeSizeInBytes = ASSETS_CAPACITY * sizeof(AssetRecord);
 
 // Buffer used for reorganizing spectrum and universe hash maps, currently also used as scratchpad buffer for contracts
 // Must be large enough to fit any contract, full spectrum, and full universe!

--- a/src/contract_core/qpi_asset_impl.h
+++ b/src/contract_core/qpi_asset_impl.h
@@ -7,7 +7,7 @@
 
 
 // Start iteration with given issuance and given ownership filter (selects first record).
-void QPI::AssetOwnershipIterator::begin(const QPI::AssetIssuanceId& issuance, const QPI::AssetOwnershipSelect& ownership)
+void QPI::AssetOwnershipIterator::begin(const QPI::Asset& issuance, const QPI::AssetOwnershipSelect& ownership)
 {
     _issuance = issuance;
     _issuanceIdx = ::issuanceIndex(issuance.issuer, issuance.assetName);
@@ -125,7 +125,7 @@ sint64 QPI::AssetOwnershipIterator::numberOfOwnedShares() const
 
 
 // Start iteration with given issuance and given ownership + possession filters (selects first record).
-void QPI::AssetPossessionIterator::begin(const AssetIssuanceId& issuance, const AssetOwnershipSelect& ownership, const AssetPossessionSelect& possession)
+void QPI::AssetPossessionIterator::begin(const Asset& issuance, const AssetOwnershipSelect& ownership, const AssetPossessionSelect& possession)
 {
     AssetOwnershipIterator::begin(issuance, ownership);
 
@@ -433,7 +433,7 @@ long long QPI::QpiContextFunctionCall::numberOfPossessedShares(unsigned long lon
     return ::numberOfPossessedShares(assetName, issuer, owner, possessor, ownershipManagingContractIndex, possessionManagingContractIndex);
 }
 
-sint64 QPI::QpiContextFunctionCall::numberOfShares(const QPI::AssetIssuanceId& issuanceId, const QPI::AssetOwnershipSelect& ownership, const QPI::AssetPossessionSelect& possession) const
+sint64 QPI::QpiContextFunctionCall::numberOfShares(const QPI::Asset& issuanceId, const QPI::AssetOwnershipSelect& ownership, const QPI::AssetPossessionSelect& possession) const
 {
     return ::numberOfShares(issuanceId, ownership, possession);
 }

--- a/src/contract_core/qpi_collection_impl.h
+++ b/src/contract_core/qpi_collection_impl.h
@@ -1,4 +1,4 @@
-// Implements functions of QPI::collection in order to:
+// Implements functions of QPI::Collection in order to:
 // 1. keep setMem() and copyMem() unavailable to contracts
 // 2. keep QPI file smaller and easier to read for contract devs
 // CAUTION: Include this AFTER the contract implementations!
@@ -11,7 +11,7 @@
 namespace QPI
 {
 	template <typename T, uint64 L>
-	void collection<T, L>::_softReset()
+	void Collection<T, L>::_softReset()
 	{
 		setMem(_povs, sizeof(_povs), 0);
 		setMem(_povOccupationFlags, sizeof(_povOccupationFlags), 0);
@@ -20,7 +20,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_povIndex(const id& pov) const
+	sint64 Collection<T, L>::_povIndex(const id& pov) const
 	{
 		sint64 povIndex = pov.u64._0 & (L - 1);
 		for (sint64 counter = 0; counter < L; counter += 32)
@@ -46,7 +46,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_headIndex(const sint64 povIndex, const sint64 maxPriority) const
+	sint64 Collection<T, L>::_headIndex(const sint64 povIndex, const sint64 maxPriority) const
 	{
 		// with current code path, pov is not empty here
 		const auto& pov = _povs[povIndex];
@@ -95,7 +95,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_tailIndex(const sint64 povIndex, const sint64 minPriority) const
+	sint64 Collection<T, L>::_tailIndex(const sint64 povIndex, const sint64 minPriority) const
 	{
 		// with current code path, pov is not empty here
 		const auto& pov = _povs[povIndex];
@@ -145,7 +145,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_searchElement(const sint64 bstRootIndex,
+	sint64 Collection<T, L>::_searchElement(const sint64 bstRootIndex,
 		const sint64 priority, int* pIterationsCount) const
 	{
 		sint64 idx = bstRootIndex;
@@ -183,7 +183,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_addPovElement(const sint64 povIndex, const T value, const sint64 priority)
+	sint64 Collection<T, L>::_addPovElement(const sint64 povIndex, const T value, const sint64 priority)
 	{
 		const sint64 newElementIdx = _population++;
 		auto& newElement = _elements[newElementIdx].init(value, priority, povIndex);
@@ -230,7 +230,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	uint64 collection<T, L>::_getSortedElements(const sint64 rootIdx, sint64* sortedElementIndices) const
+	uint64 Collection<T, L>::_getSortedElements(const sint64 rootIdx, sint64* sortedElementIndices) const
 	{
 		uint64 count = 0;
 		sint64 elementIdx = rootIdx;
@@ -269,7 +269,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	inline void collection<T, L>::_set(sint64_4& vec, sint64 v0, sint64 v1, sint64 v2, sint64 v3) const
+	inline void Collection<T, L>::_set(sint64_4& vec, sint64 v0, sint64 v1, sint64 v2, sint64 v3) const
 	{
 		vec.set(0, v0);
 		vec.set(1, v1);
@@ -278,7 +278,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_rebuild(sint64 rootIdx)
+	sint64 Collection<T, L>::_rebuild(sint64 rootIdx)
 	{
 		auto* sortedElementIndices = reinterpret_cast<sint64*>(::__scratchpad());
 		if (sortedElementIndices == NULL)
@@ -364,7 +364,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_getMostLeft(sint64 elementIdx) const
+	sint64 Collection<T, L>::_getMostLeft(sint64 elementIdx) const
 	{
 		while (_elements[elementIdx].bstLeftIndex != NULL_INDEX)
 		{
@@ -374,7 +374,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_getMostRight(sint64 elementIdx) const
+	sint64 Collection<T, L>::_getMostRight(sint64 elementIdx) const
 	{
 		while (_elements[elementIdx].bstRightIndex != NULL_INDEX)
 		{
@@ -384,7 +384,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_previousElementIndex(sint64 elementIdx) const
+	sint64 Collection<T, L>::_previousElementIndex(sint64 elementIdx) const
 	{
 		elementIdx &= (L - 1);
 		if (uint64(elementIdx) < _population)
@@ -415,7 +415,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::_nextElementIndex(sint64 elementIdx) const
+	sint64 Collection<T, L>::_nextElementIndex(sint64 elementIdx) const
 	{
 		elementIdx &= (L - 1);
 		if (uint64(elementIdx) < _population)
@@ -446,7 +446,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	bool collection<T, L>::_updateParent(const sint64 elementIdx, const sint64 newElementIdx)
+	bool Collection<T, L>::_updateParent(const sint64 elementIdx, const sint64 newElementIdx)
 	{
 		if (elementIdx != NULL_INDEX)
 		{
@@ -473,7 +473,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	void collection<T, L>::_moveElement(const sint64 srcIdx, const sint64 dstIdx)
+	void Collection<T, L>::_moveElement(const sint64 srcIdx, const sint64 dstIdx)
 	{
 		copyMem(&_elements[dstIdx], &_elements[srcIdx], sizeof(_elements[0]));
 
@@ -516,7 +516,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	uint64 collection<T, L>::_getEncodedPovOccupationFlags(const uint64* povOccupationFlags, const sint64 povIndex) const
+	uint64 Collection<T, L>::_getEncodedPovOccupationFlags(const uint64* povOccupationFlags, const sint64 povIndex) const
 	{
 		const sint64 offset = (povIndex & 31) << 1;
 		uint64 flags = povOccupationFlags[povIndex >> 5] >> offset;
@@ -528,7 +528,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::add(const id& pov, T element, sint64 priority)
+	sint64 Collection<T, L>::add(const id& pov, T element, sint64 priority)
 	{
 		if (_population < capacity() && _markRemovalCounter < capacity())
 		{
@@ -562,12 +562,12 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	void collection<T, L>::cleanup()
+	void Collection<T, L>::cleanup()
 	{
 		// _povs gets occupied over time with entries of type 3 which means they are marked for cleanup.
-		// Once cleanup is called it's necessary to remove all these type 3 entries by reconstructing a fresh collection residing in scratchpad buffer.
+		// Once cleanup is called it's necessary to remove all these type 3 entries by reconstructing a fresh Collection residing in scratchpad buffer.
 		// The _elements array is not reorganized by the cleanup (only references to _povs are updated).
-		// Cleanup() called for a collection having only type 3 entries in _povs must give the result equal to reset() memory content wise.
+		// Cleanup() called for a Collection having only type 3 entries in _povs must give the result equal to reset() memory content wise.
 
 		// Quick check to cleanup
 		if (!_markRemovalCounter)
@@ -575,7 +575,7 @@ namespace QPI
 			return;
 		}
 
-		// Speedup case of empty collection but existed marked for removal povs
+		// Speedup case of empty Collection but existed marked for removal povs
 		if (!population())
 		{
 			_softReset();
@@ -590,7 +590,7 @@ namespace QPI
 		setMem(::__scratchpad(), sizeof(_povs) + sizeof(_povOccupationFlags), 0);
 		uint64 newPopulation = 0;
 
-		// Go through pov hash map. For each pov that is occupied but not marked for removal, insert pov in new collection's pov buffers and
+		// Go through pov hash map. For each pov that is occupied but not marked for removal, insert pov in new Collection's pov buffers and
 		// update povIndex in elements belonging to pov.
 		constexpr uint64 oldPovIndexGroupCount = (L >> 5) ? (L >> 5) : 1;
 		for (sint64 oldPovIndexGroup = 0; oldPovIndexGroup < oldPovIndexGroupCount; oldPovIndexGroup++)
@@ -603,7 +603,7 @@ namespace QPI
 			for (maskBits >>= oldPovIndexOffset;
 				oldPovIndexOffset < oldPovIndexOffsetEnd; oldPovIndexOffset += 2, maskBits >>= 2)
 			{
-				// Only add pov to new collection that are occupied and not marked for removal
+				// Only add pov to new Collection that are occupied and not marked for removal
 				if (maskBits & 3ULL)
 				{
 					// find empty position in new pov hash map
@@ -674,13 +674,13 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	inline T collection<T, L>::element(sint64 elementIndex) const
+	inline T Collection<T, L>::element(sint64 elementIndex) const
 	{
 		return _elements[elementIndex & (L - 1)].value;
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::headIndex(const id& pov) const
+	sint64 Collection<T, L>::headIndex(const id& pov) const
 	{
 		const sint64 povIndex = _povIndex(pov);
 
@@ -688,7 +688,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::headIndex(const id& pov, sint64 maxPriority) const
+	sint64 Collection<T, L>::headIndex(const id& pov, sint64 maxPriority) const
 	{
 		const sint64 povIndex = _povIndex(pov);
 		if (povIndex < 0)
@@ -700,19 +700,19 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::nextElementIndex(sint64 elementIndex) const
+	sint64 Collection<T, L>::nextElementIndex(sint64 elementIndex) const
 	{
 		return _nextElementIndex(elementIndex);
 	}
 
 	template <typename T, uint64 L>
-	inline uint64 collection<T, L>::population() const
+	inline uint64 Collection<T, L>::population() const
 	{
 		return _population;
 	}
 
 	template <typename T, uint64 L>
-	uint64 collection<T, L>::population(const id& pov) const
+	uint64 Collection<T, L>::population(const id& pov) const
 	{
 		const sint64 povIndex = _povIndex(pov);
 
@@ -720,25 +720,25 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	id collection<T, L>::pov(sint64 elementIndex) const
+	id Collection<T, L>::pov(sint64 elementIndex) const
 	{
 		return _povs[_elements[elementIndex & (L - 1)].povIndex].value;
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::prevElementIndex(sint64 elementIndex) const
+	sint64 Collection<T, L>::prevElementIndex(sint64 elementIndex) const
 	{
 		return _previousElementIndex(elementIndex);
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::priority(sint64 elementIndex) const
+	sint64 Collection<T, L>::priority(sint64 elementIndex) const
 	{
 		return _elements[elementIndex & (L - 1)].priority;
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::remove(sint64 elementIdx)
+	sint64 Collection<T, L>::remove(sint64 elementIdx)
 	{
 		sint64 nextElementIdxOfRemoved = NULL_INDEX;
 		elementIdx &= (L - 1);
@@ -853,7 +853,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	void collection<T, L>::replace(sint64 oldElementIndex, const T& newElement)
+	void Collection<T, L>::replace(sint64 oldElementIndex, const T& newElement)
 	{
 		if (uint64(oldElementIndex) < _population)
 		{
@@ -862,13 +862,13 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	void collection<T, L>::reset()
+	void Collection<T, L>::reset()
 	{
 		setMem(this, sizeof(*this), 0);
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::tailIndex(const id& pov) const
+	sint64 Collection<T, L>::tailIndex(const id& pov) const
 	{
 		const sint64 povIndex = _povIndex(pov);
 
@@ -876,7 +876,7 @@ namespace QPI
 	}
 
 	template <typename T, uint64 L>
-	sint64 collection<T, L>::tailIndex(const id& pov, sint64 minPriority) const
+	sint64 Collection<T, L>::tailIndex(const id& pov, sint64 minPriority) const
 	{
 		const sint64 povIndex = _povIndex(pov);
 		if (povIndex < 0)

--- a/src/contract_core/qpi_trivial_impl.h
+++ b/src/contract_core/qpi_trivial_impl.h
@@ -23,14 +23,14 @@ namespace QPI
 
 	// Check if array is sorted in given range (duplicates allowed). Returns false if range is invalid.
 	template <typename T, uint64 L>
-	bool isArraySorted(const array<T, L>& array, uint64 beginIdx, uint64 endIdx)
+	bool isArraySorted(const Array<T, L>& Array, uint64 beginIdx, uint64 endIdx)
 	{
 		if (endIdx > L || beginIdx > endIdx)
 			return false;
 
 		for (uint64 i = beginIdx + 1; i < endIdx; ++i)
 		{
-			if (array.get(i - 1) > array.get(i))
+			if (Array.get(i - 1) > Array.get(i))
 				return false;
 		}
 
@@ -39,14 +39,14 @@ namespace QPI
 
 	// Check if array is sorted without duplicates in given range. Returns false if range is invalid.
 	template <typename T, uint64 L>
-	bool isArraySortedWithoutDuplicates(const array<T, L>& array, uint64 beginIdx, uint64 endIdx)
+	bool isArraySortedWithoutDuplicates(const Array<T, L>& Array, uint64 beginIdx, uint64 endIdx)
 	{
 		if (endIdx > L || beginIdx > endIdx)
 			return false;
 
 		for (uint64 i = beginIdx + 1; i < endIdx; ++i)
 		{
-			if (array.get(i - 1) >= array.get(i))
+			if (Array.get(i - 1) >= Array.get(i))
 				return false;
 		}
 

--- a/src/contracts/ComputorControlledFund.h
+++ b/src/contracts/ComputorControlledFund.h
@@ -27,13 +27,13 @@ struct CCF : public ContractBase
 	struct LatestTransfersEntry
 	{
 		id destination;
-		array<uint8, 256> url;
+		Array<uint8, 256> url;
 		sint64 amount;
 		uint32 tick;
 		bool success;
 	};
 
-	typedef array<LatestTransfersEntry, 128> LatestTransfersT;
+	typedef Array<LatestTransfersEntry, 128> LatestTransfersT;
 
 private:
 	//----------------------------------------------------------------------------
@@ -102,7 +102,7 @@ public:
 	struct GetProposalIndices_output
 	{
 		uint16 numOfIndices;		// Number of valid entries in indices. Call again if it is 64.
-		array<uint16, 64> indices;	// Requested proposal indices. Valid entries are in range 0 ... (numOfIndices - 1).
+		Array<uint16, 64> indices;	// Requested proposal indices. Valid entries are in range 0 ... (numOfIndices - 1).
 	};
 
 	PUBLIC_FUNCTION(GetProposalIndices)

--- a/src/contracts/GeneralQuorumProposal.h
+++ b/src/contracts/GeneralQuorumProposal.h
@@ -31,7 +31,7 @@ struct GQMPROP : public ContractBase
 		uint16 firstEpoch;
 	};
 
-	typedef array<RevenueDonationEntry, 128> RevenueDonationT;
+	typedef Array<RevenueDonationEntry, 128> RevenueDonationT;
 
 private:
 	//----------------------------------------------------------------------------
@@ -125,7 +125,7 @@ public:
 	struct GetProposalIndices_output
 	{
 		uint16 numOfIndices;		// Number of valid entries in indices. Call again if it is 64.
-		array<uint16, 64> indices;	// Requested proposal indices. Valid entries are in range 0 ... (numOfIndices - 1).
+		Array<uint16, 64> indices;	// Requested proposal indices. Valid entries are in range 0 ... (numOfIndices - 1).
 	};
 
 	PUBLIC_FUNCTION(GetProposalIndices)

--- a/src/contracts/QVAULT.h
+++ b/src/contracts/QVAULT.h
@@ -216,7 +216,7 @@ protected:
     id adminAddress, newAdminAddress1, newAdminAddress2, newAdminAddress3;
     id bannedAddress1, bannedAddress2, bannedAddress3;
     id unbannedAddress1, unbannedAddress2, unbannedAddress3;
-    array<id, QVAULT_MAX_NUMBER_OF_BANNED_ADDRESSES> bannedAddress;
+    Array<id, QVAULT_MAX_NUMBER_OF_BANNED_ADDRESSES> bannedAddress;
     uint32 numberOfBannedAddress;
     uint32 shareholderDividend, QCAPHolderPermille, reinvestingPermille, devPermille, burnPermille;
     uint32 newQCAPHolderPermille1, newReinvestingPermille1, newDevPermille1;

--- a/src/contracts/QVAULT.h
+++ b/src/contracts/QVAULT.h
@@ -606,7 +606,7 @@ protected:
     {
         ::Entity entity;
         AssetPossessionIterator iter;
-        AssetIssuanceId QCAPId;
+        Asset QCAPId;
         uint64 revenue;
         uint64 paymentForShareholders;
         uint64 paymentForQCAPHolders;

--- a/src/contracts/Qearn.h
+++ b/src/contracts/Qearn.h
@@ -180,8 +180,8 @@ protected:
 
     };
 
-    array<RoundInfo, QEARN_MAX_EPOCHS> _initialRoundInfo;
-    array<RoundInfo, QEARN_MAX_EPOCHS> _currentRoundInfo;
+    Array<RoundInfo, QEARN_MAX_EPOCHS> _initialRoundInfo;
+    Array<RoundInfo, QEARN_MAX_EPOCHS> _currentRoundInfo;
 
     struct EpochIndexInfo {
 
@@ -189,7 +189,7 @@ protected:
         uint32 endIndex;
     };
 
-    array<EpochIndexInfo, QEARN_MAX_EPOCHS> _epochIndex;
+    Array<EpochIndexInfo, QEARN_MAX_EPOCHS> _epochIndex;
 
     struct LockInfo {
 
@@ -199,7 +199,7 @@ protected:
         
     };
 
-    array<LockInfo, QEARN_MAX_LOCKS> locker;
+    Array<LockInfo, QEARN_MAX_LOCKS> locker;
 
     struct HistoryInfo {
 
@@ -209,8 +209,8 @@ protected:
 
     };
 
-    array<HistoryInfo, QEARN_MAX_USERS> earlyUnlocker;
-    array<HistoryInfo, QEARN_MAX_USERS> fullyUnlocker;
+    Array<HistoryInfo, QEARN_MAX_USERS> earlyUnlocker;
+    Array<HistoryInfo, QEARN_MAX_USERS> fullyUnlocker;
     
     uint32 _earlyUnlockedCnt;
     uint32 _fullyUnlockedCnt;

--- a/src/contracts/Quottery.h
+++ b/src/contracts/Quottery.h
@@ -135,7 +135,7 @@ public:
     };
     struct getBetOptionDetail_output
     {
-        array<id, 1024> bettor;
+        Array<id, 1024> bettor;
     };
     struct getActiveBet_input
     {
@@ -143,7 +143,7 @@ public:
     struct getActiveBet_output
     {
         uint32 count;
-        array<uint32, 1024> activeBetId;
+        Array<uint32, 1024> activeBetId;
     };
     struct getBetByCreator_input
     {
@@ -152,7 +152,7 @@ public:
     struct getBetByCreator_output
     {
         uint32 count;
-        array<uint32, 1024> betId;
+        Array<uint32, 1024> betId;
     };
     struct cancelBet_input
     {
@@ -201,27 +201,27 @@ public:
     /**************************************/
     /************CONTRACT STATES***********/
     /**************************************/
-    array<uint32, QUOTTERY_MAX_BET> mBetID;
-    array<id, QUOTTERY_MAX_BET> mCreator;
-    array<id, QUOTTERY_MAX_BET> mBetDesc;
-    array<id, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mOptionDesc;
-    array<uint64, QUOTTERY_MAX_BET> mBetAmountPerSlot;
-    array<uint32, QUOTTERY_MAX_BET> mMaxNumberOfBetSlotPerOption;
-    array<id, QUOTTERY_MAX_BET* QUOTTERY_MAX_ORACLE_PROVIDER> mOracleProvider;
-    array<uint32, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mOracleFees;
-    array<uint32, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mCurrentBetState;
-    array<uint8, QUOTTERY_MAX_BET> mNumberOption;
-    array<uint32, QUOTTERY_MAX_BET> mOpenDate;
-    array<uint32, QUOTTERY_MAX_BET> mCloseDate;
-    array<uint32, QUOTTERY_MAX_BET> mEndDate;
-    array<bit, QUOTTERY_MAX_BET> mIsOccupied;
-    array<uint32, QUOTTERY_MAX_BET> mBetEndTick;
+    Array<uint32, QUOTTERY_MAX_BET> mBetID;
+    Array<id, QUOTTERY_MAX_BET> mCreator;
+    Array<id, QUOTTERY_MAX_BET> mBetDesc;
+    Array<id, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mOptionDesc;
+    Array<uint64, QUOTTERY_MAX_BET> mBetAmountPerSlot;
+    Array<uint32, QUOTTERY_MAX_BET> mMaxNumberOfBetSlotPerOption;
+    Array<id, QUOTTERY_MAX_BET* QUOTTERY_MAX_ORACLE_PROVIDER> mOracleProvider;
+    Array<uint32, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mOracleFees;
+    Array<uint32, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mCurrentBetState;
+    Array<uint8, QUOTTERY_MAX_BET> mNumberOption;
+    Array<uint32, QUOTTERY_MAX_BET> mOpenDate;
+    Array<uint32, QUOTTERY_MAX_BET> mCloseDate;
+    Array<uint32, QUOTTERY_MAX_BET> mEndDate;
+    Array<bit, QUOTTERY_MAX_BET> mIsOccupied;
+    Array<uint32, QUOTTERY_MAX_BET> mBetEndTick;
     //bettor info:
-    array<id, QUOTTERY_MAX_BET* QUOTTERY_MAX_SLOT_PER_OPTION_PER_BET* QUOTTERY_MAX_OPTION> mBettorID;
-    array<uint8, QUOTTERY_MAX_BET* QUOTTERY_MAX_SLOT_PER_OPTION_PER_BET* QUOTTERY_MAX_OPTION> mBettorBetOption;
+    Array<id, QUOTTERY_MAX_BET* QUOTTERY_MAX_SLOT_PER_OPTION_PER_BET* QUOTTERY_MAX_OPTION> mBettorID;
+    Array<uint8, QUOTTERY_MAX_BET* QUOTTERY_MAX_SLOT_PER_OPTION_PER_BET* QUOTTERY_MAX_OPTION> mBettorBetOption;
     // bet result:
-    array<sint8, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mBetResultWonOption;
-    array<sint8, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mBetResultOPId;
+    Array<sint8, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mBetResultWonOption;
+    Array<sint8, QUOTTERY_MAX_BET* QUOTTERY_MAX_OPTION> mBetResultOPId;
 
     //static assert for developing:
     static_assert(sizeof(mBetID) == (sizeof(uint32) * QUOTTERY_MAX_BET), "bet id array");

--- a/src/contracts/Qx.h
+++ b/src/contracts/Qx.h
@@ -32,7 +32,7 @@ public:
 			sint64 numberOfShares;
 		};
 
-		array<Order, 256> orders;
+		Array<Order, 256> orders;
 	};
 
 	struct AssetBidOrders_input
@@ -50,7 +50,7 @@ public:
 			sint64 numberOfShares;
 		};
 
-		array<Order, 256> orders;
+		Array<Order, 256> orders;
 	};
 
 	struct EntityAskOrders_input
@@ -68,7 +68,7 @@ public:
 			sint64 numberOfShares;
 		};
 
-		array<Order, 256> orders;
+		Array<Order, 256> orders;
 	};
 
 	struct EntityBidOrders_input
@@ -86,7 +86,7 @@ public:
 			sint64 numberOfShares;
 		};
 
-		array<Order, 256> orders;
+		Array<Order, 256> orders;
 	};
 
 	struct IssueAsset_input
@@ -175,7 +175,7 @@ protected:
 		id entity;
 		sint64 numberOfShares;
 	};
-	collection<_AssetOrder, 2097152 * X_MULTIPLIER> _assetOrders;
+	Collection<_AssetOrder, 2097152 * X_MULTIPLIER> _assetOrders;
 
 	struct _EntityOrder
 	{
@@ -183,7 +183,7 @@ protected:
 		uint64 assetName;
 		sint64 numberOfShares;
 	};
-	collection<_EntityOrder, 2097152 * X_MULTIPLIER> _entityOrders;
+	Collection<_EntityOrder, 2097152 * X_MULTIPLIER> _entityOrders;
 
 	// TODO: change to "locals" variables and remove from state? -> every func/proc can define struct of "locals" that is passed as an argument (stored on stack structure per processor)
 	sint64 _elementIndex, _elementIndex2;

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -593,7 +593,7 @@ namespace QPI
 	//////////
 
 
-	struct AssetIssuanceId
+	struct Asset
 	{
 		id issuer;
 		uint64 assetName;
@@ -650,7 +650,7 @@ namespace QPI
 	class AssetOwnershipIterator
 	{
 	protected:
-		AssetIssuanceId _issuance;
+		Asset _issuance;
 		unsigned int _issuanceIdx;
 		AssetOwnershipSelect _ownership;
 		unsigned int _ownershipIdx;
@@ -661,13 +661,13 @@ namespace QPI
 		}
 
 	public:
-		AssetOwnershipIterator(const AssetIssuanceId& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any())
+		AssetOwnershipIterator(const Asset& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any())
 		{
 			begin(issuance, ownership);
 		}
 
 		// Start iteration with given issuance and given ownership filter (selects first record).
-		inline void begin(const AssetIssuanceId& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any());
+		inline void begin(const Asset& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any());
 
 		// Return if iteration with next() has reached end.
 		inline bool reachedEnd() const;
@@ -709,13 +709,13 @@ namespace QPI
 		unsigned int _possessionIdx;
 
 	public:
-		AssetPossessionIterator(const AssetIssuanceId& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any(), const AssetPossessionSelect& possession = AssetPossessionSelect::any())
+		AssetPossessionIterator(const Asset& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any(), const AssetPossessionSelect& possession = AssetPossessionSelect::any())
 		{
 			begin(issuance, ownership, possession);
 		}
 
 		// Start iteration with given issuance and given ownership + possession filters (selects first record).
-		inline void begin(const AssetIssuanceId& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any(), const AssetPossessionSelect& possession = AssetPossessionSelect::any());
+		inline void begin(const Asset& issuance, const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any(), const AssetPossessionSelect& possession = AssetPossessionSelect::any());
 
 		// Return if iteration with next() has reached end.
 		inline bool reachedEnd() const;
@@ -1298,7 +1298,7 @@ namespace QPI
 		) const;
 
 		inline sint64 numberOfShares(
-			const AssetIssuanceId& issuanceId,
+			const Asset& issuanceId,
 			const AssetOwnershipSelect& ownership = AssetOwnershipSelect::any(),
 			const AssetPossessionSelect& possession = AssetPossessionSelect::any()
 		) const;

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -116,11 +116,11 @@ namespace QPI
 
 	// Array of L bits encoded in array of uint64 (overall size is at least 8 bytes, L must be 2^N)
 	template <uint64 L>
-	struct bit_array
+	struct BitArray
 	{
 	private:
 		static_assert(L && !(L & (L - 1)),
-			"The capacity of the bit_array must be 2^N."
+			"The capacity of the BitArray must be 2^N."
 			);
 
 		static constexpr uint64 _bits = L;
@@ -175,23 +175,23 @@ namespace QPI
 	};
 
 	// Bit array convenience definitions
-	typedef bit_array<2> bit_2;
-	typedef bit_array<4> bit_4;
-	typedef bit_array<8> bit_8;
-	typedef bit_array<16> bit_16;
-	typedef bit_array<32> bit_32;
-	typedef bit_array<64> bit_64;
-	typedef bit_array<128> bit_128;
-	typedef bit_array<256> bit_256;
-	typedef bit_array<512> bit_512;
-	typedef bit_array<1024> bit_1024;
-	typedef bit_array<2048> bit_2048;
-	typedef bit_array<4096> bit_4096;
+	typedef BitArray<2> bit_2;
+	typedef BitArray<4> bit_4;
+	typedef BitArray<8> bit_8;
+	typedef BitArray<16> bit_16;
+	typedef BitArray<32> bit_32;
+	typedef BitArray<64> bit_64;
+	typedef BitArray<128> bit_128;
+	typedef BitArray<256> bit_256;
+	typedef BitArray<512> bit_512;
+	typedef BitArray<1024> bit_1024;
+	typedef BitArray<2048> bit_2048;
+	typedef BitArray<4096> bit_4096;
 
 
 	// Array of L elements of type T (L must be 2^N)
 	template <typename T, uint64 L>
-	struct array
+	struct Array
 	{
 	private:
 		static_assert(L && !(L & (L - 1)),
@@ -266,49 +266,49 @@ namespace QPI
 	};
 	
 	// Array convenience definitions
-	typedef array<sint8, 2> sint8_2;
-	typedef array<sint8, 4> sint8_4;
-	typedef array<sint8, 8> sint8_8;
+	typedef Array<sint8, 2> sint8_2;
+	typedef Array<sint8, 4> sint8_4;
+	typedef Array<sint8, 8> sint8_8;
 
-	typedef array<uint8, 2> uint8_2;
-	typedef array<uint8, 4> uint8_4;
-	typedef array<uint8, 8> uint8_8;
+	typedef Array<uint8, 2> uint8_2;
+	typedef Array<uint8, 4> uint8_4;
+	typedef Array<uint8, 8> uint8_8;
 
-	typedef array<sint16, 2> sint16_2;
-	typedef array<sint16, 4> sint16_4;
-	typedef array<sint16, 8> sint16_8;
+	typedef Array<sint16, 2> sint16_2;
+	typedef Array<sint16, 4> sint16_4;
+	typedef Array<sint16, 8> sint16_8;
 
-	typedef array<uint16, 2> uint16_2;
-	typedef array<uint16, 4> uint16_4;
-	typedef array<uint16, 8> uint16_8;
+	typedef Array<uint16, 2> uint16_2;
+	typedef Array<uint16, 4> uint16_4;
+	typedef Array<uint16, 8> uint16_8;
 
-	typedef array<sint32, 2> sint32_2;
-	typedef array<sint32, 4> sint32_4;
-	typedef array<sint32, 8> sint32_8;
+	typedef Array<sint32, 2> sint32_2;
+	typedef Array<sint32, 4> sint32_4;
+	typedef Array<sint32, 8> sint32_8;
 
-	typedef array<uint32, 2> uint32_2;
-	typedef array<uint32, 4> uint32_4;
-	typedef array<uint32, 8> uint32_8;
+	typedef Array<uint32, 2> uint32_2;
+	typedef Array<uint32, 4> uint32_4;
+	typedef Array<uint32, 8> uint32_8;
 
-	typedef array<sint64, 2> sint64_2;
-	typedef array<sint64, 4> sint64_4;
-	typedef array<sint64, 8> sint64_8;
+	typedef Array<sint64, 2> sint64_2;
+	typedef Array<sint64, 4> sint64_4;
+	typedef Array<sint64, 8> sint64_8;
 
-	typedef array<uint64, 2> uint64_2;
-	typedef array<uint64, 4> uint64_4;
-	typedef array<uint64, 8> uint64_8;
+	typedef Array<uint64, 2> uint64_2;
+	typedef Array<uint64, 4> uint64_4;
+	typedef Array<uint64, 8> uint64_8;
 
-	typedef array<id, 2> id_2;
-	typedef array<id, 8> id_4;
-	typedef array<id, 8> id_8;
+	typedef Array<id, 2> id_2;
+	typedef Array<id, 8> id_4;
+	typedef Array<id, 8> id_8;
 
 	// Check if array is sorted in given range (duplicates allowed). Returns false if range is invalid.
 	template <typename T, uint64 L>
-	bool isArraySorted(const array<T, L>& array, uint64 beginIdx = 0, uint64 endIdx = L);
+	bool isArraySorted(const Array<T, L>& Array, uint64 beginIdx = 0, uint64 endIdx = L);
 
 	// Check if array is sorted without duplicates in given range. Returns false if range is invalid.
 	template <typename T, uint64 L>
-	bool isArraySortedWithoutDuplicates(const array<T, L>& array, uint64 beginIdx = 0, uint64 endIdx = L);
+	bool isArraySortedWithoutDuplicates(const Array<T, L>& Array, uint64 beginIdx = 0, uint64 endIdx = L);
 
 
 	// Hash function class to be used with the hash map.
@@ -402,11 +402,11 @@ namespace QPI
 	// Collection of priority queues of elements with type T and total element capacity L.
 	// Each ID pov (point of view) has an own queue.
 	template <typename T, uint64 L>
-	struct collection
+	struct Collection
 	{
 	private:
 		static_assert(L && !(L & (L - 1)),
-			"The capacity of the collection must be 2^N."
+			"The capacity of the Collection must be 2^N."
 			);
 		static constexpr sint64 _nEncodedFlags = L > 32 ? 32 : L;
 
@@ -782,7 +782,7 @@ namespace QPI
 		union
 		{
 			// Number of votes for different options (0 = no change, 1 to N = yes to specific proposed value)
-			array<uint32, 8> optionVoteCount;
+			Array<uint32, 8> optionVoteCount;
 
 			// Scalar voting result (currently only for proposalType VariableScalarMean, mean value of all valid votes)
 			sint64 scalarVotingResult;
@@ -876,7 +876,7 @@ namespace QPI
 	struct ProposalDataV1
 	{
 		// URL explaining proposal, zero-terminated string.
-		array<uint8, 256> url;	
+		Array<uint8, 256> url;	
 		
 		// Epoch, when proposal is active. For setProposal(), 0 means to clear proposal and non-zero means the current epoch.
 		uint16 epoch;
@@ -894,14 +894,14 @@ namespace QPI
 			struct Transfer
 			{
 				id destination;
-				array<sint64, 4> amounts;   // N first amounts are the proposed options (non-negative, sorted without duplicates), rest zero
+				Array<sint64, 4> amounts;   // N first amounts are the proposed options (non-negative, sorted without duplicates), rest zero
 			} transfer;
 
 			// Used if type class is Variable and type is not VariableScalarMean
 			struct VariableOptions
 			{
 				uint64 variable;            // For identifying variable (interpreted by contract only)
-				array<sint64, 4> values;    // N first amounts are proposed options sorted without duplicates, rest zero
+				Array<sint64, 4> values;    // N first amounts are proposed options sorted without duplicates, rest zero
 			} variableOptions;
 
 			// Used if type is VariableScalarMean
@@ -980,7 +980,7 @@ namespace QPI
 	struct ProposalDataYesNo
 	{
 		// URL explaining proposal, zero-terminated string.
-		array<uint8, 256> url;
+		Array<uint8, 256> url;
 
 		// Epoch, when proposal is active. For setProposal(), 0 means to clear proposal and non-zero means the current epoch.
 		uint16 epoch;
@@ -1315,7 +1315,7 @@ namespace QPI
 		bit signatureValidity(
 			const id& entity,
 			const id& digest,
-			const array<sint8, 64>& signature
+			const Array<sint8, 64>& signature
 		) const;
 
 		inline uint32 tick(

--- a/src/network_messages/assets.h
+++ b/src/network_messages/assets.h
@@ -15,7 +15,7 @@
 #define MOLE 5
 #define SECOND 6
 
-struct Asset
+struct AssetRecord
 {
     union
     {
@@ -72,7 +72,7 @@ static_assert(sizeof(RequestIssuedAssets) == 32, "Something is wrong with the st
 
 struct RespondIssuedAssets
 {
-    Asset asset;
+    AssetRecord asset;
     unsigned int tick;
     unsigned int universeIndex;
     m256i siblings[ASSETS_DEPTH];
@@ -97,8 +97,8 @@ static_assert(sizeof(RequestOwnedAssets) == 32, "Something is wrong with the str
 
 struct RespondOwnedAssets
 {
-    Asset asset;
-    Asset issuanceAsset;
+    AssetRecord asset;
+    AssetRecord issuanceAsset;
     unsigned int tick;
     unsigned int universeIndex;
     m256i siblings[ASSETS_DEPTH];
@@ -123,9 +123,9 @@ static_assert(sizeof(RequestPossessedAssets) == 32, "Something is wrong with the
 
 struct RespondPossessedAssets
 {
-    Asset asset;
-    Asset ownershipAsset;
-    Asset issuanceAsset;
+    AssetRecord asset;
+    AssetRecord ownershipAsset;
+    AssetRecord issuanceAsset;
     unsigned int tick;
     unsigned int universeIndex;
     m256i siblings[ASSETS_DEPTH];

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1634,7 +1634,7 @@ unsigned char QPI::QpiContextFunctionCall::second() const
     return etalonTick.second;
 }
 
-bool QPI::QpiContextFunctionCall::signatureValidity(const m256i& entity, const m256i& digest, const array<signed char, 64>& signature) const
+bool QPI::QpiContextFunctionCall::signatureValidity(const m256i& entity, const m256i& digest, const Array<signed char, 64>& signature) const
 {
     return verify(entity.m256i_u8, digest.m256i_u8, reinterpret_cast<const unsigned char*>(&signature));
 }

--- a/test/assets.cpp
+++ b/test/assets.cpp
@@ -126,7 +126,7 @@ public:
         issuanceIdx = indexLists.issuancesFirstIdx;
         while (issuanceIdx != NO_ASSET_INDEX)
         {
-            AssetIssuanceId issuanceId(assets[issuanceIdx].varStruct.issuance.publicKey, assetNameFromString(assets[issuanceIdx].varStruct.issuance.name));
+            Asset issuanceId(assets[issuanceIdx].varStruct.issuance.publicKey, assetNameFromString(assets[issuanceIdx].varStruct.issuance.name));
             long long numOfSharesOwned = 0, numOfSharesPossessed = 0;
             for (AssetOwnershipIterator iter(issuanceId); !iter.reachedEnd(); iter.next())
             {
@@ -159,7 +159,7 @@ TEST(TestCoreAssets, CheckLoadFile)
 
 struct IssuanceTestData
 {
-    AssetIssuanceId id;
+    Asset id;
     unsigned short managingContract;
     unsigned int universeIdx;
     long long numOfShares;

--- a/test/qpi.cpp
+++ b/test/qpi.cpp
@@ -28,7 +28,7 @@ TEST(TestCoreQPI, Array)
 {
     //QPI::array<int, 0> mustFail; // should raise compile error
 
-    QPI::array<QPI::uint8, 4> uint8_4;
+    QPI::Array<QPI::uint8, 4> uint8_4;
     EXPECT_EQ(uint8_4.capacity(), 4);
     //uint8_4.setMem(QPI::id(1, 2, 3, 4)); // should raise compile error
     uint8_4.setAll(2);
@@ -58,13 +58,13 @@ TEST(TestCoreQPI, Array)
     EXPECT_TRUE(isArraySorted(uint8_4));
     EXPECT_TRUE(isArraySortedWithoutDuplicates(uint8_4));
 
-    QPI::array<QPI::uint64, 4> uint64_4;
+    QPI::Array<QPI::uint64, 4> uint64_4;
     uint64_4.setMem(QPI::id(101, 102, 103, 104));
     for (int i = 0; i < uint64_4.capacity(); ++i)
         EXPECT_EQ(uint64_4.get(i), i + 101);
     //uint64_4.setMem(uint8_4); // should raise compile error
 
-    QPI::array<QPI::uint16, 2> uint16_2;
+    QPI::Array<QPI::uint16, 2> uint16_2;
     EXPECT_EQ(uint8_4.capacity(), 4);
     //uint16_2.setMem(QPI::id(1, 2, 3, 4)); // should raise compile error
     uint16_2.setAll(12345);
@@ -81,9 +81,9 @@ TEST(TestCoreQPI, Array)
 
 TEST(TestCoreQPI, BitArray)
 {
-    //QPI::bit_array<0> mustFail;
+    //QPI::BitArray<0> mustFail;
 
-    QPI::bit_array<1> b1;
+    QPI::BitArray<1> b1;
     EXPECT_EQ(b1.capacity(), 1);
     b1.setAll(0);
     EXPECT_EQ(b1.get(0), 0);
@@ -98,7 +98,7 @@ TEST(TestCoreQPI, BitArray)
     b1.set(0, true);
     EXPECT_EQ(b1.get(0), 1);
 
-    QPI::bit_array<64> b64;
+    QPI::BitArray<64> b64;
     EXPECT_EQ(b64.capacity(), 64);
     b64.setMem(0x11llu);
     EXPECT_EQ(b64.get(0), 1);
@@ -109,7 +109,7 @@ TEST(TestCoreQPI, BitArray)
     EXPECT_EQ(b64.get(5), 0);
     EXPECT_EQ(b64.get(6), 0);
     EXPECT_EQ(b64.get(7), 0);
-    QPI::array<QPI::uint64, 1> llu1;
+    QPI::Array<QPI::uint64, 1> llu1;
     llu1.setMem(b64);
     EXPECT_EQ(llu1.get(0), 0x11llu);
     b64.setAll(0);
@@ -119,11 +119,11 @@ TEST(TestCoreQPI, BitArray)
     llu1.setMem(b64);
     EXPECT_EQ(llu1.get(0), 0xffffffffffffffffllu);
 
-    //QPI::bit_array<96> b96; // must trigger compile error
+    //QPI::BitArray<96> b96; // must trigger compile error
 
-    QPI::bit_array<128> b128;
+    QPI::BitArray<128> b128;
     EXPECT_EQ(b128.capacity(), 128);
-    QPI::array<QPI::uint64, 2> llu2;
+    QPI::Array<QPI::uint64, 2> llu2;
     llu2.setAll(0x4llu);
     EXPECT_EQ(llu2.get(0), 0x4llu);
     EXPECT_EQ(llu2.get(1), 0x4llu);

--- a/test/qpi_collection.cpp
+++ b/test/qpi_collection.cpp
@@ -26,7 +26,7 @@ typedef void (*USER_PROCEDURE)(const QPI::QpiContextProcedureCall&, void* state,
 #include <chrono>
 
 template <typename T, unsigned long long capacity>
-void checkPriorityQueue(const QPI::collection<T, capacity>& coll, const QPI::id& pov, bool print = false)
+void checkPriorityQueue(const QPI::Collection<T, capacity>& coll, const QPI::id& pov, bool print = false)
 {
     if (print)
     {
@@ -79,7 +79,7 @@ void printPovElementCounts(const std::map<QPI::id, unsigned long long>& povEleme
 
 // return sorted set of PoVs
 template <typename T, unsigned long long capacity>
-std::map<QPI::id, unsigned long long> getPovElementCounts(const QPI::collection<T, capacity>& coll)
+std::map<QPI::id, unsigned long long> getPovElementCounts(const QPI::Collection<T, capacity>& coll)
 {
     // use that in current implementation elements are always in range 0 to N-1
     std::map<QPI::id, unsigned long long> povs;
@@ -100,13 +100,13 @@ std::map<QPI::id, unsigned long long> getPovElementCounts(const QPI::collection<
 }
 
 template <typename T, unsigned long long capacity>
-bool isCompletelySame(const QPI::collection<T, capacity>& coll1, const QPI::collection<T, capacity>& coll2)
+bool isCompletelySame(const QPI::Collection<T, capacity>& coll1, const QPI::Collection<T, capacity>& coll2)
 {
     return memcmp(&coll1, &coll2, sizeof(coll1)) == 0;
 }
 
 template <typename T, unsigned long long capacity>
-bool haveSameContent(const QPI::collection<T, capacity>& coll1, const QPI::collection<T, capacity>& coll2, bool verbose = true)
+bool haveSameContent(const QPI::Collection<T, capacity>& coll1, const QPI::Collection<T, capacity>& coll2, bool verbose = true)
 {
     // check that both contain the same PoVs, each with the same number of elements
     auto coll1PovCounts = getPovElementCounts(coll1);
@@ -153,7 +153,7 @@ bool haveSameContent(const QPI::collection<T, capacity>& coll1, const QPI::colle
 }
 
 template <typename T, unsigned long long capacity>
-void cleanupCollectionReferenceImplementation(const QPI::collection<T, capacity>& coll, QPI::collection<T, capacity>& newColl)
+void cleanupCollectionReferenceImplementation(const QPI::Collection<T, capacity>& coll, QPI::Collection<T, capacity>& newColl)
 {
     newColl.reset();
 
@@ -172,10 +172,10 @@ void cleanupCollectionReferenceImplementation(const QPI::collection<T, capacity>
 }
 
 template <typename T, unsigned long long capacity>
-void cleanupCollection(QPI::collection<T, capacity>& coll)
+void cleanupCollection(QPI::Collection<T, capacity>& coll)
 {
     // save original data for checking
-    QPI::collection<T, capacity> origColl;
+    QPI::Collection<T, capacity> origColl;
     copyMem(&origColl, &coll, sizeof(coll));
 
     // run reference cleanup and test that cleanup did not change any relevant content
@@ -197,7 +197,7 @@ TEST(TestCoreQPI, CollectionMultiPovMultiElements)
     constexpr unsigned long long capacity = 8;
 
     // for valid init you either need to call reset or load the data from a file (in SC, state is zeroed before INITIALIZE is called)
-    QPI::collection<int, capacity> coll;
+    QPI::Collection<int, capacity> coll;
     coll.reset();
 
     // test behavior of empty collection
@@ -584,7 +584,7 @@ TEST(TestCoreQPI, CollectionMultiPovMultiElements)
     EXPECT_EQ(coll.population(), 8);
 
     // test comparison function of full collection
-    QPI::collection<int, capacity> empty_coll;
+    QPI::Collection<int, capacity> empty_coll;
     empty_coll.reset();
     EXPECT_TRUE(isCompletelySame(coll, coll));
     EXPECT_TRUE(haveSameContent(coll, coll));
@@ -614,7 +614,7 @@ template <unsigned long long capacity>
 void testCollectionOnePovMultiElements(int prioAmpFactor, int prioFreqDiv)
 {
     // for valid init you either need to call reset or load the data from a file (in SC, state is zeroed before INITIALIZE is called)
-    QPI::collection<int, capacity> coll;
+    QPI::Collection<int, capacity> coll;
     coll.reset();
 
     // these tests support changing the implementation of the element array filling to non-sequential
@@ -814,7 +814,7 @@ void testCollectionOnePovMultiElements(int prioAmpFactor, int prioFreqDiv)
     }
 
     // check that cleanup after removing all elements leads to same as reset() in terms of memory
-    QPI::collection<int, capacity> resetColl;
+    QPI::Collection<int, capacity> resetColl;
     resetColl.reset();
     EXPECT_FALSE(isCompletelySame(resetColl, coll));
     coll.cleanup();
@@ -835,7 +835,7 @@ TEST(TestCoreQPI, CollectionOnePovMultiElementsSamePrioOrder)
     constexpr unsigned long long capacity = 16;
 
     // for valid init you either need to call reset or load the data from a file (in SC, state is zeroed before INITIALIZE is called)
-    QPI::collection<int, capacity> coll;
+    QPI::Collection<int, capacity> coll;
     coll.reset();
 
     // these tests support changing the implementation of the element array filling to non-sequential
@@ -881,7 +881,7 @@ template <unsigned long long capacity>
 void testCollectionMultiPovOneElement(bool cleanupAfterEachRemove)
 {
     // for valid init you either need to call reset or load the data from a file (in SC, state is zeroed before INITIALIZE is called)
-    QPI::collection<int, capacity> coll;
+    QPI::Collection<int, capacity> coll;
     coll.reset();
 
     for (int i = 0; i < capacity; ++i)
@@ -944,7 +944,7 @@ void testCollectionMultiPovOneElement(bool cleanupAfterEachRemove)
     }
 
     // check that cleanup after removing all elements leads to same as reset() in terms of memory
-    QPI::collection<int, capacity> resetColl;
+    QPI::Collection<int, capacity> resetColl;
     resetColl.reset();
     if (!cleanupAfterEachRemove)
         EXPECT_FALSE(isCompletelySame(resetColl, coll));
@@ -971,7 +971,7 @@ TEST(TestCoreQPI, CollectionOneRemoveLastHeadTail)
     constexpr unsigned long long capacity = 4;
 
     // for valid init you either need to call reset or load the data from a file (in SC, state is zeroed before INITIALIZE is called)
-    QPI::collection<int, capacity> coll;
+    QPI::Collection<int, capacity> coll;
     coll.reset();
 
     bool print = false;
@@ -993,7 +993,7 @@ TEST(TestCoreQPI, CollectionSubCollections)
 {
     QPI::id pov(1, 2, 3, 4);
 
-    QPI::collection<size_t, 512> coll;
+    QPI::Collection<size_t, 512> coll;
     coll.reset();
 
     // test empty
@@ -1073,7 +1073,7 @@ TEST(TestCoreQPI, CollectionSubCollectionsRandom)
 {
     QPI::id pov(1, 2, 3, 4);
 
-    QPI::collection<size_t, 1024> coll;
+    QPI::Collection<size_t, 1024> coll;
     coll.reset();
 
     const int seed = 246357;
@@ -1170,7 +1170,7 @@ TEST(TestCoreQPI, CollectionReplaceElements)
 {
     QPI::id pov(1, 2, 3, 4);
 
-    QPI::collection<size_t, 1024> coll;
+    QPI::Collection<size_t, 1024> coll;
     coll.reset();
 
     const int seed = 246357;
@@ -1251,7 +1251,7 @@ void testCollectionCleanupPseudoRandom(int povs, int seed, bool povCollisions)
     // add and remove entries with pseudo-random sequence
     std::mt19937_64 gen64(seed);
 
-    QPI::collection<unsigned long long, capacity> coll;
+    QPI::Collection<unsigned long long, capacity> coll;
     coll.reset();
 
     // test cleanup of empty collection
@@ -1345,7 +1345,7 @@ T genNumber(
 // TODO: move all performance tests into a separate project!?
 template <unsigned long long capacity>
 QPI::uint64 testCollectionPerformance(
-    QPI::collection<QPI::uint64, capacity>& coll,
+    QPI::Collection<QPI::uint64, capacity>& coll,
     const QPI::uint64 povs,
     const QPI::sint64* genBuffer,
     const QPI::uint64 genSize,
@@ -1423,7 +1423,7 @@ QPI::uint64 testCollectionPerformance(
         gen_buffers[i] = gen64();
     }
 
-    QPI::collection<QPI::uint64, capacity>* coll = new QPI::collection<QPI::uint64, capacity>();
+    QPI::Collection<QPI::uint64, capacity>* coll = new QPI::Collection<QPI::uint64, capacity>();
     coll->reset();
 
     auto t0 = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
- rename `Asset` (class of elements in universe storage) to `AssetRecord`
- rename `AssetIssuanceId` (QPI struct) to `Asset`
- Rename some QPI classes to follow the naming rule (starting with a capital letter and having a capital letter for each new word, with no underscores)