### PR TITLE
Fix error in test/spectrum.cpp due to wrong logging init

### DIFF
--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -666,22 +666,26 @@ public:
     static void processRequestTickTxLogInfo(Peer* peer, RequestResponseHeader* header);
 };
 
-static qLogger logger;
+GLOBAL_VAR_DECL qLogger logger;
 
 // For smartcontract logging
-template <typename T> void __logContractDebugMessage(unsigned int size, T& msg)
+template <typename T>
+static void __logContractDebugMessage(unsigned int size, T& msg)
 {
     logger.__logContractDebugMessage(size, msg);
 }
-template <typename T> void __logContractErrorMessage(unsigned int size, T& msg)
+template <typename T>
+static void __logContractErrorMessage(unsigned int size, T& msg)
 {
     logger.__logContractErrorMessage(size, msg);
 }
-template <typename T> void __logContractInfoMessage(unsigned int size, T& msg)
+template <typename T>
+static void __logContractInfoMessage(unsigned int size, T& msg)
 {
     logger.__logContractInfoMessage(size, msg);
 }
-template <typename T> void __logContractWarningMessage(unsigned int size, T& msg)
+template <typename T>
+static void __logContractWarningMessage(unsigned int size, T& msg)
 {
     logger.__logContractWarningMessage(size, msg);
 }

--- a/src/spectrum.h
+++ b/src/spectrum.h
@@ -415,6 +415,7 @@ static bool initSpectrum()
     {
         return false;
     }
+    spectrumLock = 0;
 
     return true;
 }

--- a/test/assets.cpp
+++ b/test/assets.cpp
@@ -2,35 +2,28 @@
 
 #include "gtest/gtest.h"
 
-// workaround for name clash with stdlib
-#define system qubicSystemStruct
-
-// reduced size of logging buffer (512 MB instead of 8 GB)
-#define LOG_BUFFER_SIZE (2*268435456ULL)
+#include "logging_test.h"
 
 #include "assets/assets.h"
 #include "contract_core/contract_exec.h"
 #include "contract_core/qpi_asset_impl.h"
-#include "logging/logging.h"
 
 #include "test_util.h"
 
 
-class AssetsTest : public AssetStorage
+class AssetsTest : public AssetStorage, LoggingTest
 {
 public:
     AssetsTest()
     {
         initAssets();
         initCommonBuffers();
-        qLogger::initLogging();
     }
 
     ~AssetsTest()
     {
         deinitCommonBuffers();
         deinitAssets();
-        qLogger::deinitLogging();
     }
 
     static void clearUniverse()

--- a/test/common_def.cpp
+++ b/test/common_def.cpp
@@ -2,3 +2,4 @@
 #define DEFINE_VARIABLES_SHARED_BETWEEN_COMPILE_UNITS
 
 #include "contract_testing.h"
+#include "logging_test.h"

--- a/test/contract_qearn.cpp
+++ b/test/contract_qearn.cpp
@@ -170,7 +170,6 @@ public:
     {
         INIT_CONTRACT(QEARN);
         initEmptySpectrum();
-        qLogger::initLogging();
         rand64.seed(42);
 
         for (unsigned int epChanges = 0; epChanges <= 52; ++epChanges)
@@ -202,11 +201,6 @@ public:
             else
                 epochChangesToUnlockParams.push_back(UnlockTableEntry{ 100, 0 });
         }
-    }
-
-    ~ContractTestingQearn()
-    {
-        qLogger::deinitLogging();
     }
 
     QearnChecker* getState()

--- a/test/contract_qvault.cpp
+++ b/test/contract_qvault.cpp
@@ -262,12 +262,6 @@ public:
         callSystemProcedure(QVAULT_CONTRACT_INDEX, INITIALIZE);
         INIT_CONTRACT(QX);
         callSystemProcedure(QX_CONTRACT_INDEX, INITIALIZE);
-        qLogger::initLogging();
-    }
-
-    ~ContractTestingQvault()
-    {
-        qLogger::deinitLogging();
     }
 
     QVAULTChecker* getState()

--- a/test/contract_qx.cpp
+++ b/test/contract_qx.cpp
@@ -94,12 +94,6 @@ public:
         initEmptyUniverse();
         INIT_CONTRACT(QX);
         callSystemProcedure(QX_CONTRACT_INDEX, INITIALIZE);
-        qLogger::initLogging();
-    }
-
-    ~ContractTestingQx()
-    {
-        qLogger::deinitLogging();
     }
 
     QxChecker* getState()

--- a/test/contract_testing.h
+++ b/test/contract_testing.h
@@ -15,12 +15,12 @@
 #include "contract_core/qpi_asset_impl.h"
 #include "contract_core/qpi_system_impl.h"
 
-#include "logging/logging.h"
+#include "logging_test.h"
 
 #include "test_util.h"
 
 
-class ContractTesting
+class ContractTesting : public LoggingTest
 {
 public:
     ContractTesting()

--- a/test/spectrum.cpp
+++ b/test/spectrum.cpp
@@ -4,26 +4,8 @@
 
 #include "gtest/gtest.h"
 
-// workaround for name clash with stdlib
-#define system qubicSystemStruct
-
-// enable some logging for testing
-#include "private_settings.h"
-#undef LOG_DUST_BURNINGS
-#undef LOG_SPECTRUM_STATS
-#define LOG_DUST_BURNINGS 1
-#define LOG_SPECTRUM_STATS 1
-
-// reduced size of logging buffer (512 MB instead of 8 GB)
-#define LOG_BUFFER_SIZE (2*268435456ULL)
-
-// also reduce size of logging tx index by reducing maximum number of ticks per epoch
-#include "public_settings.h"
-#undef MAX_NUMBER_OF_TICKS_PER_EPOCH
-#define MAX_NUMBER_OF_TICKS_PER_EPOCH 3000
-
+#include "logging_test.h"
 #include "spectrum.h"
-#include "logging/logging.h"
 
 #include <chrono>
 #include <random>
@@ -137,7 +119,7 @@ static void updateAndPrintEntityCategoryPopulations()
 }
 
 // Spectrum test class for proper init, cleanup, and other repeated tasks
-struct SpectrumTest
+struct SpectrumTest : public LoggingTest
 {
     SpectrumInfo beforeAntiDustSpectrumInfo;
     std::chrono::steady_clock::time_point beforeAntiDustTimestamp;
@@ -154,12 +136,10 @@ struct SpectrumTest
         system.tick = 15700000;
         clearSpectrum();
         antiDustCornerCase = false;
-        EXPECT_TRUE(logger.initLogging());
     }
 
     ~SpectrumTest()
     {
-        logger.deinitLogging();
         deinitSpectrum();
         deinitCommonBuffers();
     }

--- a/test/spectrum.cpp
+++ b/test/spectrum.cpp
@@ -175,7 +175,7 @@ struct SpectrumTest : public LoggingTest
             << beforeAntiDustSpectrumInfo.numberOfEntities << " -> " << spectrumInfo.numberOfEntities
             << " (to " << spectrumInfo.numberOfEntities * 100llu / SPECTRUM_CAPACITY
             << "% of capacity);  total amount " << beforeAntiDustSpectrumInfo.totalAmount << " -> " << spectrumInfo.totalAmount
-            << " (" << ((long long)spectrumInfo.totalAmount - (long long)beforeAntiDustSpectrumInfo.totalAmount) * 100ll / beforeAntiDustSpectrumInfo.totalAmount << "% reduction)" << std::endl;
+            << " (" << float(((long long)spectrumInfo.totalAmount - (long long)beforeAntiDustSpectrumInfo.totalAmount) * 10000ll / (long long)beforeAntiDustSpectrumInfo.totalAmount) / 100.0f << "% reduction)" << std::endl;
 
         // Print distribution of entity balances
 #if PRINT_TEST_INFO

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -104,6 +104,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="contract_testing.h" />
+    <ClInclude Include="logging_test.h" />
     <ClInclude Include="score_params.h" />
     <ClInclude Include="score_reference.h" />
     <ClInclude Include="test_util.h" />

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -28,6 +28,7 @@
     <ClInclude Include="score_params.h" />
     <ClInclude Include="contract_testing.h" />
     <ClInclude Include="test_util.h" />
+    <ClInclude Include="logging_test.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Fixes issue #281 (The first testcase of spectrum.cpp was failing with in debug build with "error: SEH exception with code 0xc0000005 thrown in the test body.")