### PR TITLE
Solve contract deadlocks delaying progress of QVAULT

### DIFF
--- a/src/contract_core/contract_def.h
+++ b/src/contract_core/contract_def.h
@@ -280,7 +280,7 @@ enum SystemProcedureID
 
 enum OtherEntryPointIDs
 {
-    // Used together with SystemProcedureID values, so there must be not overlap!
+    // Used together with SystemProcedureID values, so there must be no overlap!
     USER_PROCEDURE_CALL = contractSystemProcedureCount + 1,
     USER_FUNCTION_CALL = contractSystemProcedureCount + 2,
     REGISTER_USER_FUNCTIONS_AND_PROCEDURES_CALL = contractSystemProcedureCount + 3

--- a/src/contract_core/contract_def.h
+++ b/src/contract_core/contract_def.h
@@ -278,10 +278,12 @@ enum SystemProcedureID
     contractSystemProcedureCount,
 };
 
-enum MoreProcedureIDs
+enum OtherEntryPointIDs
 {
     // Used together with SystemProcedureID values, so there must be not overlap!
     USER_PROCEDURE_CALL = contractSystemProcedureCount + 1,
+    USER_FUNCTION_CALL = contractSystemProcedureCount + 2,
+    REGISTER_USER_FUNCTIONS_AND_PROCEDURES_CALL = contractSystemProcedureCount + 3
 };
 
 GLOBAL_VAR_DECL SYSTEM_PROCEDURE contractSystemProcedures[contractCount][contractSystemProcedureCount];

--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -78,7 +78,7 @@ struct ContractRollbackInfo
     unsigned int type : 2;
     unsigned int contractIndex : 30;
     static constexpr int i = (1 << 30) - 1;
-    static_assert(contractCount < (1 << 30) - 1, "Implementation assumes less contracts and must be changed!");
+    static_assert(contractCount < (1 << 30) - 1, "Implementation assumes fewer contracts and must be changed!");
 };
 
 static inline ContractRollbackInfo* contractStackUnwindRollbackInfo(int stackIndex)
@@ -368,24 +368,25 @@ void* QPI::QpiContextFunctionCall::__qpiAcquireStateForReading(unsigned int cont
             //      1. Contract C2 invokes a C1 procedure (C2 and C1 states locked for writing)
             //      2. Contract C1 runs qpi.releaseShares(), which needs to call the PRE_ACQUIRE_SHARES
             //         callback of C1.
-            //    If it is locked for reading (by a function)
+            //      3. C1 then calls a function of C2. For this, it tries to acquire a read lock of
+            //         C2's state, ending up here.
             // -> Because we know that this runs within a procedure entry point, we only have one
-            //    processor running procedures, and a function can never all a procedure, we know that:
+            //    processor running procedures, and a function can never call a procedure, we know that:
             //      1. all write locks are owned by contract processor (running this) and
             //      2. all read locks are owned by request processors (other processors).
             if (contractStateLock[contractIndex].isLockedForWriting())
             {
                 // already locked by this processor
                 // -> signal situation for corresponding __qpiReleaseStateForReading()
-                // -> give write access to state without further ado
+                // -> give read access to state without further ado
                 rollbackInfo->type = ContractRollbackInfo::ContractStateReuseLock;
             }
             else
             {
                 // not locked or already locked by a request processor for reading (contract function)
-                // -> acquire lock as usual (which may need to wait if locked for reading)
-                // -> if there is a deadlock with a request processor, the following acquireWrite()
-                //    needs to wait until it gets resolved in __qpiAcquireStateForReading()
+                // -> acquire lock as usual
+                // -> if there is a deadlock with a request processor, the following acquireRead()
+                //    needs to wait until it gets resolved by stopping the request processor
                 contractStateLock[contractIndex].acquireRead();
                 rollbackInfo->type = ContractRollbackInfo::ContractStateReadLock;
             }
@@ -462,7 +463,7 @@ void* QPI::QpiContextProcedureCall::__qpiAcquireStateForWriting(unsigned int con
         //         callback of C2 -> __qpiCallSystemProcOfOtherContract() tries to acquire write
         //         lock of C2 through __qpiAcquireStateForWriting()
         // -> Because we know that this runs within a procedure entry point, we only have one
-        //    processor running procedures, and a function can never all a procedure, we know that:
+        //    processor running procedures, and a function can never call a procedure, we know that:
         //      1. all write locks are owned by contract processor (running this) and
         //      2. all read locks are owned by request processors (other processors).
         if (contractStateLock[contractIndex].isLockedForWriting())

--- a/src/contract_core/stack_buffer.h
+++ b/src/contract_core/stack_buffer.h
@@ -4,6 +4,8 @@
 
 // Last-In-First-Out storage for data of different size.
 // Size type used for StackBuffer needs to be unsigned.
+// Supports unwinding for analyzing stack in error handling and tagging blocks as "special" (for example those
+// with infos about locks that need to be released).
 // #define TRACK_MAX_STACK_BUFFER_SIZE to collect info on how much stack is used.
 template <typename StackBufferSizeType, StackBufferSizeType bufferSize>
 struct StackBuffer
@@ -53,7 +55,7 @@ struct StackBuffer
 #endif
 
     // Allocate storage in buffer.
-    char* allocate(SizeType size)
+    char* allocate(SizeType size, bool specialBlock = false)
     {
         ASSERT(_allocatedSize <= bufferSize);
 
@@ -64,7 +66,7 @@ struct StackBuffer
 #ifdef TRACK_MAX_STACK_BUFFER_SIZE
             ++_failedAllocAttempts;
 #endif
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(NO_UEFI)
             CHAR16 dbgMsg[200];
             setText(dbgMsg, L"StackBuffer.allocate() failed! old size ");
             appendNumber(dbgMsg, _allocatedSize, TRUE);
@@ -89,6 +91,8 @@ struct StackBuffer
         // store size from before allocating buffer
         SizeType* sizeBeforeAlloc = reinterpret_cast<SizeType*>(allocatedBuffer + size);
         *sizeBeforeAlloc = _allocatedSize;
+        if (specialBlock)
+            *sizeBeforeAlloc |= specialBlockFlag;
          
         // update size
         _allocatedSize = newSize;
@@ -104,21 +108,27 @@ struct StackBuffer
     // Free storage allocated by last call to allocate().
     bool free()
     {
-        bool okay = (_allocatedSize <= bufferSize) && (_allocatedSize >= sizeof(SizeType));
         // get size before last alloc
+        bool okay = (_allocatedSize <= bufferSize) && (_allocatedSize >= sizeof(SizeType));
+#if !defined(NO_UEFI)
         ASSERT(_allocatedSize <= bufferSize);
         ASSERT(_allocatedSize >= sizeof(SizeType));
-        SizeType sizeBeforeLastAlloc = *reinterpret_cast<SizeType*>(_buffer + _allocatedSize - sizeof(SizeType));
-
-        // reduce current size down to size before last alloc
+#endif
+        SizeType sizeBeforeLastAlloc = *reinterpret_cast<SizeType*>(_buffer + _allocatedSize - sizeof(SizeType)) & sizeMask;
+#if !defined(NO_UEFI)
         ASSERT(sizeBeforeLastAlloc < _allocatedSize);
+#endif
         okay = okay && (sizeBeforeLastAlloc < _allocatedSize);
+
+        // some additional checks and ouput for debugging
 #ifdef TRACK_MAX_STACK_BUFFER_SIZE
+#if !defined(NO_UEFI)
         ASSERT(_maxAllocatedSize <= bufferSize);
         ASSERT(sizeBeforeLastAlloc < _maxAllocatedSize);
+#endif
         okay = okay && (_maxAllocatedSize <= bufferSize) && (sizeBeforeLastAlloc < _maxAllocatedSize);
 #endif
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(NO_UEFI)
         CHAR16 dbgMsg[200];
         if (!okay)
         {
@@ -137,8 +147,19 @@ struct StackBuffer
             addDebugMessage(dbgMsg);
         }
 #endif
-        _allocatedSize = sizeBeforeLastAlloc;
-        return okay;
+        if (okay)
+        {
+            // reduce current size down to size before last alloc
+            // (normal behavior if count of alloc matches count of free and memory is not corrupted)
+            _allocatedSize = sizeBeforeLastAlloc;
+            return true;
+        }
+        else
+        {
+            // problem -> reset to prevent wild undefined behavior in following use
+            _allocatedSize = 0;
+            return false;
+        }
     }
 
     // Free all storage allocated before.
@@ -147,12 +168,35 @@ struct StackBuffer
         _allocatedSize = 0;
     }
 
+    // Free last allocated block and return pointer, size, and whether it is a special block.
+    bool unwind(char*& buffer, SizeType& size, bool& specialBlock)
+    {
+        if (_allocatedSize < sizeof(SizeType))
+            return false;
+        SizeType sizePtrOffset = _allocatedSize - sizeof(SizeType);
+        SizeType prevSizeAndFlag = *reinterpret_cast<SizeType*>(_buffer + sizePtrOffset);
+        size = sizePtrOffset - (prevSizeAndFlag & sizeMask);
+        bool okay = free();
+        specialBlock = (prevSizeAndFlag & specialBlockFlag) != 0;
+        buffer = _buffer + _allocatedSize;
+        return okay;
+    }
+
 protected:
     // structure of buffer content: [ allocated buffer 1 | size before allocating buffer 1 | allocated buffer 2 | size before buffer 2 | ... | alloc. buf. n | size bef. buf. n ]
+    // "size before allocating buffer" may have specialBlockFlag set.
     char _buffer[bufferSize];
 
     // number of bytes used in buffer
     SizeType _allocatedSize;
+
+    // Flag used internally to indicate a special block (bit set in size on _buffer)
+    static constexpr SizeType specialBlockFlag = (1 << (sizeof(StackBufferSizeType) * 8 - 1));
+
+    // Mask to extract size from _buffer
+    static constexpr SizeType sizeMask = ~specialBlockFlag;
+
+    static_assert(bufferSize <= sizeMask, "Buffer size too large for the used size type!");
 
 #ifdef TRACK_MAX_STACK_BUFFER_SIZE
     SizeType _maxAllocatedSize;

--- a/src/contract_core/stack_buffer.h
+++ b/src/contract_core/stack_buffer.h
@@ -105,6 +105,12 @@ struct StackBuffer
         return allocatedBuffer;
     }
 
+    // Allocate "special block" storage in buffer, which is relevant for unwinding.
+    inline char* allocateSpecial(SizeType size)
+    {
+        return allocate(size, true);
+    }
+
     // Free storage allocated by last call to allocate().
     bool free()
     {

--- a/src/contracts/TestExampleB.h
+++ b/src/contracts/TestExampleB.h
@@ -58,6 +58,16 @@ struct TESTEXB : public ContractBase
 		sint64 transferredNumberOfShares;
 	};
 
+	struct GetTestExampleAShareManagementRights_input
+	{
+		Asset asset;
+		sint64 numberOfShares;
+	};
+	struct GetTestExampleAShareManagementRights_output
+	{
+		sint64 transferredNumberOfShares;
+	};
+
 protected:
 	
 	PreManagementRightsTransfer_output preReleaseSharesOutput;
@@ -110,8 +120,21 @@ _
 			// success
 			output.transferredNumberOfShares = input.numberOfShares;
 		}
-
     _
+
+	struct GetTestExampleAShareManagementRights_locals
+	{
+		TESTEXA::TransferShareManagementRights_input input;
+		TESTEXA::TransferShareManagementRights_output output;
+	};
+
+	PUBLIC_PROCEDURE_WITH_LOCALS(GetTestExampleAShareManagementRights)
+		locals.input.asset = input.asset;
+		locals.input.numberOfShares = input.numberOfShares;
+		locals.input.newManagingContractIndex = SELF_INDEX;
+		INVOKE_OTHER_CONTRACT_PROCEDURE(TESTEXA, TransferShareManagementRights, locals.input, locals.output, qpi.invocationReward());
+		output.transferredNumberOfShares = locals.output.transferredNumberOfShares;
+	_
 
 	REGISTER_USER_FUNCTIONS_AND_PROCEDURES
 		REGISTER_USER_PROCEDURE(IssueAsset, 1);
@@ -120,6 +143,7 @@ _
 		REGISTER_USER_PROCEDURE(SetPreReleaseSharesOutput, 4);
 		REGISTER_USER_PROCEDURE(SetPreAcquireSharesOutput, 5);
 		REGISTER_USER_PROCEDURE(AcquireShareManagementRights, 6);
+		REGISTER_USER_PROCEDURE(GetTestExampleAShareManagementRights, 7);
 	_
 
 	PRE_RELEASE_SHARES

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -1212,9 +1212,10 @@ namespace QPI
 			unsigned int contractIndex,
 			const m256i& originator,
 			const m256i& invocator,
-			long long invocationReward
+			long long invocationReward,
+			unsigned char entryPoint
 		) {
-			init(contractIndex, originator, invocator, invocationReward);
+			init(contractIndex, originator, invocator, invocationReward, entryPoint, -1);
 		}
 
 		void init(
@@ -1222,7 +1223,8 @@ namespace QPI
 			const m256i& originator,
 			const m256i& invocator,
 			long long invocationReward,
-			int stackIndex = -1
+			unsigned char entryPoint,
+			int stackIndex
 		) {
 			ASSERT(invocationReward >= 0);
 			_currentContractIndex = contractIndex;
@@ -1230,13 +1232,15 @@ namespace QPI
 			_originator = originator;
 			_invocator = invocator;
 			_invocationReward = invocationReward;
+			_entryPoint = entryPoint;
 			_stackIndex = stackIndex;
 		}
 
 		unsigned int _currentContractIndex;
+		int _stackIndex;
 		m256i _currentContractId, _originator, _invocator;
 		long long _invocationReward;
-		int _stackIndex;
+		unsigned char _entryPoint;
 
 	private:
 		// Disabling copy and move
@@ -1354,7 +1358,7 @@ namespace QPI
 
 	protected:
 		// Construction is done in core, not allowed in contracts
-		QpiContextFunctionCall(unsigned int contractIndex, const m256i& originator, long long invocationReward) : QpiContext(contractIndex, originator, originator, invocationReward) {}
+		QpiContextFunctionCall(unsigned int contractIndex, const m256i& originator, long long invocationReward, unsigned char entryPoint) : QpiContext(contractIndex, originator, originator, invocationReward, entryPoint) {}
 	};
 
 	// QPI procedures available to contract procedures (not to contract functions)
@@ -1432,7 +1436,7 @@ namespace QPI
 
 	protected:
 		// Construction is done in core, not allowed in contracts
-		QpiContextProcedureCall(unsigned int contractIndex, const m256i& originator, long long invocationReward) : QpiContextFunctionCall(contractIndex, originator, invocationReward) {}
+		QpiContextProcedureCall(unsigned int contractIndex, const m256i& originator, long long invocationReward, unsigned char entryPoint) : QpiContextFunctionCall(contractIndex, originator, invocationReward, entryPoint) {}
 	};
 
 	// QPI available in REGISTER_USER_FUNCTIONS_AND_PROCEDURES
@@ -1442,7 +1446,7 @@ namespace QPI
 		inline void __registerUserProcedure(USER_PROCEDURE, unsigned short, unsigned short, unsigned short, unsigned int) const;
 
 		// Construction is done in core, not allowed in contracts
-		QpiContextForInit(unsigned int contractIndex) : QpiContext(contractIndex, NULL_ID, NULL_ID, 0) {}
+		inline QpiContextForInit(unsigned int contractIndex);
 	};
 
 	// Used if no locals, input, or output is needed in a procedure or function
@@ -1650,15 +1654,18 @@ namespace QPI
 		qpi.__registerUserProcedure((USER_PROCEDURE)userProcedure, inputType, sizeof(userProcedure##_input), sizeof(userProcedure##_output), sizeof(userProcedure##_locals));
 
 	// Call function or procedure of current contract (without changing invocation reward)
+	// WARNING: input may be changed by called function
 	#define CALL(functionOrProcedure, input, output) \
 		static_assert(sizeof(CONTRACT_STATE_TYPE::functionOrProcedure##_locals) <= MAX_SIZE_OF_CONTRACT_LOCALS, #functionOrProcedure "_locals size too large"); \
 		functionOrProcedure(qpi, state, input, output, *(functionOrProcedure##_locals*)qpi.__qpiAllocLocals(sizeof(CONTRACT_STATE_TYPE::functionOrProcedure##_locals))); \
 		qpi.__qpiFreeLocals()
 
 	// Invoke procedure of current contract with changed invocation reward
+	// WARNING: input may be changed by called function
 	// TODO: INVOKE
 
 	// Call function of other contract
+	// WARNING: input may be changed by called function
 	#define CALL_OTHER_CONTRACT_FUNCTION(contractStateType, function, input, output) \
 		static_assert(sizeof(contractStateType::function##_locals) <= MAX_SIZE_OF_CONTRACT_LOCALS, #function "_locals size too large"); \
 		static_assert(contractStateType::__is_function_##function, "CALL_OTHER_CONTRACT_FUNCTION() cannot be used to invoke procedures."); \
@@ -1669,24 +1676,24 @@ namespace QPI
 			*(contractStateType*)qpi.__qpiAcquireStateForReading(contractStateType::__contract_index), \
 			input, output, \
 			*(contractStateType::function##_locals*)qpi.__qpiAllocLocals(sizeof(contractStateType::function##_locals))); \
-		qpi.__qpiReleaseStateForReading(contractStateType::__contract_index); \
 		qpi.__qpiFreeContextOtherContract(); \
+		qpi.__qpiReleaseStateForReading(contractStateType::__contract_index); \
 		qpi.__qpiFreeLocals()
 
 	// Transfer invocation reward and invoke of other contract (procedure only)
+	// WARNING: input may be changed by called function
 	#define INVOKE_OTHER_CONTRACT_PROCEDURE(contractStateType, procedure, input, output, invocationReward) \
 		static_assert(sizeof(contractStateType::procedure##_locals) <= MAX_SIZE_OF_CONTRACT_LOCALS, #procedure "_locals size too large"); \
 		static_assert(!contractStateType::__is_function_##procedure, "INVOKE_OTHER_CONTRACT_PROCEDURE() cannot be used to call functions."); \
 		static_assert(!(contractStateType::__contract_index == CONTRACT_STATE_TYPE::__contract_index), "Use CALL() to call a function/procedure of this contract."); \
 		static_assert(contractStateType::__contract_index < CONTRACT_STATE_TYPE::__contract_index, "You can only call contracts with lower index."); \
-		static_assert(invocationReward >= 0, "The invocationReward cannot be negative!"); \
 		contractStateType::procedure( \
 			qpi.__qpiConstructContextOtherContractProcedureCall(contractStateType::__contract_index, invocationReward), \
 			*(contractStateType*)qpi.__qpiAcquireStateForWriting(contractStateType::__contract_index), \
 			input, output, \
 			*(contractStateType::procedure##_locals*)qpi.__qpiAllocLocals(sizeof(contractStateType::procedure##_locals))); \
-		qpi.__qpiReleaseStateForWriting(contractStateType::__contract_index); \
 		qpi.__qpiFreeContextOtherContract(); \
+		qpi.__qpiReleaseStateForWriting(contractStateType::__contract_index); \
 		qpi.__qpiFreeLocals()
 
 	#define QUERY_ORACLE(oracle, query) // TODO

--- a/src/platform/read_write_lock.h
+++ b/src/platform/read_write_lock.h
@@ -126,6 +126,22 @@ public:
         readers = 0;
     }
 
+    // Return if currently locked for writing. Note that the status may change any time.
+    bool isLockedForWriting() const
+    {
+        ASSERT(readers >= -1);
+        ASSERT(writersWaiting >= 0);
+        return readers == -1;
+    }
+
+    // Return number of reader who have currently locked the resource or -1 if locked for writing. Note that the status may change any time.
+    long getCurrentReaderLockCount() const
+    {
+        ASSERT(readers >= -1);
+        ASSERT(writersWaiting >= 0);
+        return readers;
+    }
+
 private:
     // Positive values means number of readers using having acquired a read lock; -1 means writer has acquired lock; 0 mean no lock is active
     volatile long readers;

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5216,9 +5216,11 @@ static bool initialize()
         }
         system.tick = system.initialTick;
 
+        beginEpoch();
+
+        // needs to be called after ts.beginEpoch() because it looks up tickIndex, which requires to setup begin of epoch in ts
         updateNumberOfTickTransactions();
 
-        beginEpoch();
 #if TICK_STORAGE_AUTOSAVE_MODE
         bool canLoadFromFile = loadAllNodeStates();
 #else

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1624,8 +1624,8 @@ static void contractProcessor(void*)
             if (system.epoch == contractDescriptions[executedContractIndex].constructionEpoch
                 && system.epoch < contractDescriptions[executedContractIndex].destructionEpoch)
             {
-                QpiContextSystemProcedureCall qpiContext(executedContractIndex);
-                qpiContext.call(INITIALIZE);
+                QpiContextSystemProcedureCall qpiContext(executedContractIndex, INITIALIZE);
+                qpiContext.call();
             }
         }
     }
@@ -1638,8 +1638,8 @@ static void contractProcessor(void*)
             if (system.epoch >= contractDescriptions[executedContractIndex].constructionEpoch
                 && system.epoch < contractDescriptions[executedContractIndex].destructionEpoch)
             {
-                QpiContextSystemProcedureCall qpiContext(executedContractIndex);
-                qpiContext.call(BEGIN_EPOCH);
+                QpiContextSystemProcedureCall qpiContext(executedContractIndex, BEGIN_EPOCH);
+                qpiContext.call();
             }
         }
     }
@@ -1652,8 +1652,8 @@ static void contractProcessor(void*)
             if (system.epoch >= contractDescriptions[executedContractIndex].constructionEpoch
                 && system.epoch < contractDescriptions[executedContractIndex].destructionEpoch)
             {
-                QpiContextSystemProcedureCall qpiContext(executedContractIndex);
-                qpiContext.call(BEGIN_TICK);
+                QpiContextSystemProcedureCall qpiContext(executedContractIndex, BEGIN_TICK);
+                qpiContext.call();
             }
         }
     }
@@ -1666,8 +1666,8 @@ static void contractProcessor(void*)
             if (system.epoch >= contractDescriptions[executedContractIndex].constructionEpoch
                 && system.epoch < contractDescriptions[executedContractIndex].destructionEpoch)
             {
-                QpiContextSystemProcedureCall qpiContext(executedContractIndex);
-                qpiContext.call(END_TICK);
+                QpiContextSystemProcedureCall qpiContext(executedContractIndex, END_TICK);
+                qpiContext.call();
             }
         }
     }
@@ -1680,8 +1680,8 @@ static void contractProcessor(void*)
             if (system.epoch >= contractDescriptions[executedContractIndex].constructionEpoch
                 && system.epoch < contractDescriptions[executedContractIndex].destructionEpoch)
             {
-                QpiContextSystemProcedureCall qpiContext(executedContractIndex);
-                qpiContext.call(END_EPOCH);
+                QpiContextSystemProcedureCall qpiContext(executedContractIndex, END_EPOCH);
+                qpiContext.call();
             }
         }
     }

--- a/test/contract_core.cpp
+++ b/test/contract_core.cpp
@@ -14,13 +14,14 @@ TEST(TestCoreContractCore, StackBuffer)
     EXPECT_EQ(s1.size(), 0);
     EXPECT_EQ(s1.maxSizeObserved(), 0);
     EXPECT_EQ(s1.failedAllocAttempts(), 0);
+    EXPECT_FALSE(s1.free());
 
     EXPECT_NE(s1.allocate(70), nullptr);    // success
     EXPECT_EQ(s1.allocate(50), nullptr);    // fail
     EXPECT_EQ(s1.allocate(100), nullptr);   // fail
     EXPECT_EQ(s1.allocate(255), nullptr);   // fail
     EXPECT_EQ(s1.size(), 71);
-    s1.free();
+    EXPECT_TRUE(s1.free());
     EXPECT_EQ(s1.size(), 0);
     EXPECT_EQ(s1.maxSizeObserved(), 71);
     EXPECT_EQ(s1.failedAllocAttempts(), 3);
@@ -30,28 +31,88 @@ TEST(TestCoreContractCore, StackBuffer)
             EXPECT_NE(s1.allocate(30), nullptr);    // success
                 EXPECT_NE(s1.allocate(40), nullptr);    // success
                     EXPECT_EQ(s1.size(), 104);
-                s1.free();
+                EXPECT_TRUE(s1.free());
                 EXPECT_EQ(s1.size(), 63);
                 EXPECT_NE(s1.allocate(20), nullptr);    // success
                     EXPECT_EQ(s1.size(), 84);
                     EXPECT_EQ(s1.allocate(50), nullptr);    // fail
                     EXPECT_EQ(s1.allocate(100), nullptr);   // fail
                     EXPECT_EQ(s1.allocate(255), nullptr);   // fail
-                s1.free();
+                EXPECT_TRUE(s1.free());
                 EXPECT_EQ(s1.size(), 63);
-            s1.free();
+            EXPECT_TRUE(s1.free());
             EXPECT_EQ(s1.size(), 32);
-        s1.free();
+        EXPECT_TRUE(s1.free());
         EXPECT_EQ(s1.size(), 11);
-    s1.free();
+    EXPECT_TRUE(s1.free());
     EXPECT_EQ(s1.size(), 0);
     EXPECT_EQ(s1.maxSizeObserved(), 104);
     EXPECT_EQ(s1.failedAllocAttempts(), 6);
+    EXPECT_FALSE(s1.free());
 
-    char* p = s1.allocate(70);
+    char* p;
+    EXPECT_NE(p = s1.allocate(70), nullptr);    // success
     *p = 100;
     EXPECT_EQ(*p, 100);
-    s1.free();
+    EXPECT_NE(p = s1.allocate(40), nullptr);    // success
+    *p = 20;
+    EXPECT_EQ(*p, 20);
+    EXPECT_EQ(s1.size(), 112);
+    s1.freeAll();
+    EXPECT_EQ(s1.size(), 0);
+    EXPECT_EQ(s1.maxSizeObserved(), 112);
+    EXPECT_EQ(s1.failedAllocAttempts(), 6);
+
+    char* ptr;
+    unsigned char sz;
+    bool special;
+    EXPECT_FALSE(s1.unwind(ptr, sz, special));
+
+    EXPECT_NE(p = s1.allocate(112, false), nullptr);    // success
+    EXPECT_EQ(s1.size(), 113);
+    EXPECT_EQ(s1.maxSizeObserved(), 113);
+    EXPECT_TRUE(s1.unwind(ptr, sz, special));
+    EXPECT_EQ(sz, 112);
+    EXPECT_EQ(ptr, p);
+    EXPECT_EQ(special, false);
+
+    EXPECT_EQ(s1.size(), 0);
+    EXPECT_EQ(s1.maxSizeObserved(), 113);
+    EXPECT_FALSE(s1.unwind(ptr, sz, special));
+
+    EXPECT_EQ(p = s1.allocate(120, true), nullptr);    // fail
+    EXPECT_EQ(s1.failedAllocAttempts(), 7);
+
+    EXPECT_NE(p = s1.allocate(119, true), nullptr);    // success
+    EXPECT_EQ(s1.size(), 120);
+    EXPECT_EQ(s1.maxSizeObserved(), 120);
+    EXPECT_TRUE(s1.unwind(ptr, sz, special));
+    EXPECT_EQ(sz, 119);
+    EXPECT_EQ(ptr, p);
+    EXPECT_EQ(special, true);
+
+    StackBuffer<unsigned int, 128000> s2;
+    s2.init();
+    EXPECT_EQ(s2.capacity(), 128000);
+    EXPECT_EQ(s2.size(), 0);
+    EXPECT_EQ(s2.maxSizeObserved(), 0);
+    EXPECT_EQ(s2.failedAllocAttempts(), 0);
+    EXPECT_FALSE(s2.free());
+
+    constexpr int depth = 10;
+    unsigned int sz2;
+    char* ptrArray[depth];
+    for (int i = 0; i < depth; ++i)
+    {
+        EXPECT_NE(ptrArray[i] = s2.allocate(i * 1000, i % 3 == 0), nullptr);    // success
+    }
+    for (int i = depth - 1; i >= 0; --i)
+    {
+        EXPECT_TRUE(s2.unwind(ptr, sz2, special));
+        EXPECT_EQ(sz2, i * 1000);
+        EXPECT_EQ(ptr, ptrArray[i]);
+        EXPECT_EQ(special, i % 3 == 0);
+    }
 }
 
 TEST(TestCoreContractCore, ContractActionTracker)

--- a/test/contract_testing.h
+++ b/test/contract_testing.h
@@ -122,8 +122,8 @@ public:
     {
         EXPECT_LT(contractIndex, contractCount);
         EXPECT_NE(contractStates[contractIndex], nullptr);
-        QpiContextSystemProcedureCall qpiContext(contractIndex);
-        qpiContext.call(sysProcId);
+        QpiContextSystemProcedureCall qpiContext(contractIndex, sysProcId);
+        qpiContext.call();
         if (expectSuccess)
         {
             EXPECT_EQ(contractError[contractIndex], 0);


### PR DESCRIPTION
This solves the deadlock happening when QX::TransferShareManagementRights() is invoked from another contract C2, see issue #296 

C2 invokes a procedure of C1 (e.g., QX) that calls qpi.releaseShares() for transferring management rights to C2.  The state of contract C2 is already locked for writing when C1 is calling qpi.releaseShares(), which tries to acquire the write lock again (all in the same processor).

This PR should solve all similar deadlocks with callbacks if no other processor is involved (no parallel contract function calls locking states next to contract procedure).