### PR TITLE
Correct flagging of unknown tx in prepareNextTickTransactions

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4330,10 +4330,14 @@ static void prepareNextTickTransactions()
                     unknownTransactions[i >> 6] |= (1ULL << (i & 63));
                 }
             }
+            else
+            {
+                unknownTransactions[i >> 6] |= (1ULL << (i & 63));
+            }
             ts.tickTransactions.releaseLock();
         }
     }
-        
+
     if (numberOfKnownNextTickTransactions != numberOfNextTickTransactions)
     {
         for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS * MAX_NUMBER_OF_PENDING_TRANSACTIONS_PER_COMPUTOR; i++)
@@ -4418,9 +4422,12 @@ static void prepareNextTickTransactions()
         // Update requestedTickTransactions the list of txs that not exist in memory so the MAIN loop can try to fetch them from peers
         for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
         {
-            if (!(unknownTransactions[i >> 6] & (1ULL << (i & 63))))
+            if (!isZero(nextTickData.transactionDigests[i]))
             {
-                requestedTickTransactions.requestedTickTransactions.transactionFlags[i >> 3] |= (1 << (i & 7));
+                if (!(unknownTransactions[i >> 6] & (1ULL << (i & 63))))
+                {
+                    requestedTickTransactions.requestedTickTransactions.transactionFlags[i >> 3] |= (1 << (i & 7));
+                }
             }
         }
     }


### PR DESCRIPTION
The basic workflow consists of 4 loops.


1. Check if tx is in tickstorage if not found mark as unknown
2. Check if tx is in pendingTransactions of computor
3. Check if tx is in pendingTransactions of entities
4. Mark all missing tx in requestedTickTransactions

In the first loop we have two potential path to handle. 

1. There is already an entry in the tickstorage -> comparison of the digests of tickstorage and tickdata digests -> if mismatch mark as missing
2. There is no entry in the tickstorage -> so far nothing happens, this PR marks such transactions as unknown as well

