### PR TITLE
Fix that test.exe doesn't start anymore

### DIFF
--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -164,7 +164,20 @@ static bool initContractExec()
 
     contractCallbacksRunning = NoContractCallback;
 
+    if (!contractActionTracker.allocBuffer())
+        return false;
+
     return true;
+}
+
+static void deinitContractExec()
+{
+    if (contractStateChangeFlags)
+    {
+        freePool(contractStateChangeFlags);
+    }
+
+    contractActionTracker.freeBuffer();
 }
 
 // Acquire lock of an currently unused stack (may block if all in use)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5428,10 +5428,7 @@ static void deinitialize()
     deinitTxStatusRequestAddOn();
 #endif
 
-    if (contractStateChangeFlags)
-    {
-        bs->FreePool(contractStateChangeFlags);
-    }
+    deinitContractExec();
     for (unsigned int contractIndex = 0; contractIndex < contractCount; contractIndex++)
     {
         if (contractStates[contractIndex])

--- a/test/contract_core.cpp
+++ b/test/contract_core.cpp
@@ -122,6 +122,7 @@ TEST(TestCoreContractCore, ContractActionTracker)
     m256i id2(3, 4, 5, 6);
 
     ContractActionTracker<6> at;
+    EXPECT_TRUE(at.allocBuffer());
     at.init();
     EXPECT_EQ(at.getOverallQuTransferBalance(id0), 0);
 
@@ -161,4 +162,6 @@ TEST(TestCoreContractCore, ContractActionTracker)
     EXPECT_EQ(at.getOverallQuTransferBalance(id0), -500);
     EXPECT_EQ(at.getOverallQuTransferBalance(id1), 200);
     EXPECT_EQ(at.getOverallQuTransferBalance(id2), 300);
+
+    at.freeBuffer();
 }

--- a/test/contract_testing.h
+++ b/test/contract_testing.h
@@ -43,6 +43,7 @@ public:
         deinitAssets();
         deinitSpectrum();
         deinitCommonBuffers();
+        deinitContractExec();
         for (unsigned int i = 0; i < contractCount; ++i)
         {
             if (contractStates[i])


### PR DESCRIPTION
Related to the increased size of the contract action tracker array. Alloc on heap instead of instead of global memory helps.