### PR TITLE
Support requesting asset data

### DIFF
--- a/src/assets/net_msg_impl.h
+++ b/src/assets/net_msg_impl.h
@@ -117,3 +117,152 @@ iteration:
 
     RELEASE(universeLock);
 }
+
+static void processRequestAssetsSendRecord(Peer* peer, RequestResponseHeader* responseHeader, unsigned int universeIndex)
+{
+    if (universeIndex >= ASSETS_CAPACITY)
+        return;
+    RespondAssetsWithSiblings* payload = responseHeader->getPayload<RespondAssetsWithSiblings>();
+    copyMemory(payload->asset, assets[universeIndex]);
+    payload->tick = system.tick;
+    payload->universeIndex = universeIndex;
+    if (!responseHeader->checkPayloadSize(sizeof(RequestAssets)))
+    {
+        getSiblings<ASSETS_DEPTH>(universeIndex, assetDigests, payload->siblings);
+    }
+    enqueueResponse(peer, responseHeader);
+}
+
+static void processRequestAssets(Peer* peer, RequestResponseHeader* header)
+{
+    if (!header->checkPayloadSize(sizeof(RequestAssets)))
+        return;
+
+    // initalize output message (with siblings because the variant without siblings is just a subset)
+    struct
+    {
+        RequestResponseHeader header;
+        RespondAssetsWithSiblings payload;
+    } response;
+    setMemory(response, 0);
+    response.header.setType(RespondAssets::type);
+    response.header.setDejavu(header->dejavu());
+
+    // size of output message depends on whether sibilings are requested
+    RequestAssets* request = header->getPayload<RequestAssets>();
+    if (request->byFilter.flags & RequestAssets::getSiblings)
+        response.header.setSize<sizeof(RequestResponseHeader) + sizeof(RespondAssetsWithSiblings)>();
+    else
+        response.header.setSize<sizeof(RequestResponseHeader) + sizeof(RespondAssets)>();
+
+    // find asset records and enqueue response messages (depending on request type)
+    switch (request->assetReqType)
+    {
+    case RequestAssets::requestIssuanceRecords:
+    {
+        // setup issuance filter
+        AssetIssuanceSelect issuanceFilter;
+        if (request->byFilter.flags & RequestAssets::anyIssuer)
+        {
+            if (request->byFilter.flags & RequestAssets::anyAssetName)
+                issuanceFilter = AssetIssuanceSelect::any();
+            else
+                issuanceFilter = AssetIssuanceSelect::byName(request->byFilter.assetName);
+        }
+        else
+        {
+            if (request->byFilter.flags & RequestAssets::anyAssetName)
+                issuanceFilter = AssetIssuanceSelect::byIssuer(request->byFilter.issuer);
+            else
+                issuanceFilter = { request->byFilter.issuer, request->byFilter.assetName };
+        }
+
+        // iterate through assets records with filter
+        ACQUIRE(universeLock);
+        AssetIssuanceIterator iter(issuanceFilter);
+        while (!iter.reachedEnd())
+        {
+            processRequestAssetsSendRecord(peer, &response.header, iter.issuanceIndex());
+            iter.next();
+        }
+        RELEASE(universeLock);
+    }
+    break;
+
+    case RequestAssets::requestOwnershipRecords:
+    case RequestAssets::requestPossessionRecords:
+    {
+        Asset asset{request->byFilter.issuer, request->byFilter.assetName};
+
+        // setup ownership filter
+        AssetOwnershipSelect ownershipFilter;
+        if (request->byFilter.flags & RequestAssets::anyOwner)
+        {
+            if (request->byFilter.flags & RequestAssets::anyOwnershipManagingContract)
+                ownershipFilter = AssetOwnershipSelect::any();
+            else
+                ownershipFilter = AssetOwnershipSelect::byManagingContract(request->byFilter.ownershipManagingContract);
+        }
+        else
+        {
+            if (request->byFilter.flags & RequestAssets::anyOwnershipManagingContract)
+                ownershipFilter = AssetOwnershipSelect::byOwner(request->byFilter.owner);
+            else
+                ownershipFilter = { request->byFilter.owner, request->byFilter.ownershipManagingContract };
+        }
+
+        if (request->assetReqType == RequestAssets::requestOwnershipRecords)
+        {
+            // iterate through asset ownership records with filter
+            ACQUIRE(universeLock);
+            AssetOwnershipIterator iter(asset, ownershipFilter);
+            while (!iter.reachedEnd())
+            {
+                processRequestAssetsSendRecord(peer, &response.header, iter.ownershipIndex());
+                iter.next();
+            }
+            RELEASE(universeLock);
+        }
+        else
+        {
+            // possession records are requested -> setup filter
+            AssetPossessionSelect possessionFilter;
+            if (request->byFilter.flags & RequestAssets::anyPossessor)
+            {
+                if (request->byFilter.flags & RequestAssets::anyPossessionManagingContract)
+                    possessionFilter = AssetPossessionSelect::any();
+                else
+                    possessionFilter = AssetPossessionSelect::byManagingContract(request->byFilter.possessionManagingContract);
+            }
+            else
+            {
+                if (request->byFilter.flags & RequestAssets::anyPossessionManagingContract)
+                    possessionFilter = AssetPossessionSelect::byPossessor(request->byFilter.possessor);
+                else
+                    possessionFilter = { request->byFilter.possessor, request->byFilter.possessionManagingContract };
+            }
+
+            // iterate through asset possession records with filter
+            ACQUIRE(universeLock);
+            AssetPossessionIterator iter(asset, ownershipFilter, possessionFilter);
+            while (!iter.reachedEnd())
+            {
+                processRequestAssetsSendRecord(peer, &response.header, iter.possessionIndex());
+                iter.next();
+            }
+            RELEASE(universeLock);
+        }
+    }
+    break;
+
+    case RequestAssets::requestByUniverseIdx:
+    {
+        ACQUIRE(universeLock);
+        processRequestAssetsSendRecord(peer, &response.header, request->byUniverseIdx.universeIdx);
+        RELEASE(universeLock);
+    }
+    break;
+    }
+
+    enqueueResponse(peer, 0, EndResponse::type, header->dejavu(), nullptr);
+}

--- a/src/contract_core/qpi_asset_impl.h
+++ b/src/contract_core/qpi_asset_impl.h
@@ -6,6 +6,106 @@
 #include "spectrum/spectrum.h"
 
 
+
+// Start iteration with issuance filter (selects first record).
+void QPI::AssetIssuanceIterator::begin(const QPI::AssetIssuanceSelect& issuance)
+{
+    _issuance = issuance;
+    _issuanceIdx = NO_ASSET_INDEX;
+
+    next();
+}
+
+// Return if iteration with next() has reached end.
+bool QPI::AssetIssuanceIterator::reachedEnd() const
+{
+    return _issuanceIdx == NO_ASSET_INDEX;
+}
+
+// Step to next issuance record matching filtering criteria.
+bool QPI::AssetIssuanceIterator::next()
+{
+    ASSERT(_issuanceIdx < ASSETS_CAPACITY || _issuanceIdx == NO_ASSET_INDEX);
+
+    if (!_issuance.anyIssuer)
+    {
+        // searching for specific issuer -> use hash map
+        if (_issuanceIdx == NO_ASSET_INDEX)
+        {
+            // get first candidate for issuance in first call of next()
+            _issuanceIdx = _issuance.issuer.m256i_u32[0] & (ASSETS_CAPACITY - 1);
+        }
+        else
+        {
+            // get next candidate in following calls of next()
+            _issuanceIdx = (_issuanceIdx + 1) & (ASSETS_CAPACITY - 1);
+        }
+
+        // search entry in consecutive non-empty fields of hash map
+        while (assets[_issuanceIdx].varStruct.issuance.type != EMPTY)
+        {
+            if (assets[_issuanceIdx].varStruct.issuance.type == ISSUANCE
+                && assets[_issuanceIdx].varStruct.issuance.publicKey == _issuance.issuer
+                && (_issuance.anyName || ((*((unsigned long long*)assets[_issuanceIdx].varStruct.issuance.name)) & 0xFFFFFFFFFFFFFF) == _issuance.assetName))
+            {
+                // found matching entry
+                return true;
+            }
+
+            _issuanceIdx = (_issuanceIdx + 1) & (ASSETS_CAPACITY - 1);
+        }
+
+        // no matching entry found
+        _issuanceIdx = NO_ASSET_INDEX;
+        return false;
+    }
+    else
+    {
+        // issuer is unknow -> use index lists instead of hash map to iterate through issuances
+        if (_issuanceIdx == NO_ASSET_INDEX)
+        {
+            // get first issuance
+            _issuanceIdx = as.indexLists.issuancesFirstIdx;
+        }
+        else
+        {
+            // get next issuance
+            _issuanceIdx = as.indexLists.nextIdx[_issuanceIdx];
+        }
+        ASSERT(_issuanceIdx == NO_ASSET_INDEX
+            || (_issuanceIdx < ASSETS_CAPACITY
+                && assets[_issuanceIdx].varStruct.issuance.type == ISSUANCE));
+
+        // if specific asset name is requested, make sure the issuance matches
+        if (!_issuance.anyName)
+        {
+            while (_issuanceIdx != NO_ASSET_INDEX
+                && ((*((unsigned long long*)assets[_issuanceIdx].varStruct.issuance.name)) & 0xFFFFFFFFFFFFFF) != _issuance.assetName)
+            {
+                _issuanceIdx = as.indexLists.nextIdx[_issuanceIdx];
+                ASSERT(_issuanceIdx == NO_ASSET_INDEX
+                    || (_issuanceIdx < ASSETS_CAPACITY
+                        && assets[_issuanceIdx].varStruct.issuance.type == ISSUANCE));
+            }
+        }
+
+        return _issuanceIdx != NO_ASSET_INDEX;
+    }
+}
+
+id QPI::AssetIssuanceIterator::issuer() const
+{
+    ASSERT(_issuanceIdx == NO_ASSET_INDEX || (_issuanceIdx < ASSETS_CAPACITY && assets[_issuanceIdx].varStruct.issuance.type == ISSUANCE));
+    return (_issuanceIdx < ASSETS_CAPACITY) ? assets[_issuanceIdx].varStruct.issuance.publicKey : id::zero();
+}
+
+uint64 QPI::AssetIssuanceIterator::assetName() const
+{
+    ASSERT(_issuanceIdx == NO_ASSET_INDEX || (_issuanceIdx < ASSETS_CAPACITY && assets[_issuanceIdx].varStruct.issuance.type == ISSUANCE));
+    return (_issuanceIdx < ASSETS_CAPACITY) ? ((*((unsigned long long*)assets[_issuanceIdx].varStruct.issuance.name)) & 0xFFFFFFFFFFFFFF) : 0;
+}
+
+
 // Start iteration with given issuance and given ownership filter (selects first record).
 void QPI::AssetOwnershipIterator::begin(const QPI::Asset& issuance, const QPI::AssetOwnershipSelect& ownership)
 {
@@ -109,6 +209,12 @@ id QPI::AssetOwnershipIterator::issuer() const
 {
     ASSERT(_issuanceIdx == NO_ASSET_INDEX || (_issuanceIdx < ASSETS_CAPACITY && assets[_issuanceIdx].varStruct.issuance.type == ISSUANCE));
     return (_issuanceIdx < ASSETS_CAPACITY) ? assets[_issuanceIdx].varStruct.issuance.publicKey : id::zero();
+}
+
+uint64 QPI::AssetOwnershipIterator::assetName() const
+{
+    ASSERT(_issuanceIdx == NO_ASSET_INDEX || (_issuanceIdx < ASSETS_CAPACITY && assets[_issuanceIdx].varStruct.issuance.type == ISSUANCE));
+    return (_issuanceIdx < ASSETS_CAPACITY) ? ((*((unsigned long long*)assets[_issuanceIdx].varStruct.issuance.name)) & 0xFFFFFFFFFFFFFF) : 0;
 }
 
 id QPI::AssetOwnershipIterator::owner() const

--- a/src/network_messages/assets.h
+++ b/src/network_messages/assets.h
@@ -134,3 +134,83 @@ struct RespondPossessedAssets
         type = 41,
     };
 };
+
+// Options to request assets:
+// - all issued asset records, optionally with filtering by issuer and/or name
+// - all ownership records of a specific asset type, optionally with filtering by owner and managing contract
+// - all possession records of a specific asset type, optionally with filtering by possessor and managing contract
+// - by universeIdx (set issuer and asset name to 0)
+union RequestAssets
+{
+    enum {
+        type = 52,
+    };
+
+    // type of asset request
+    static constexpr unsigned short requestIssuanceRecords = 0;
+    static constexpr unsigned short requestOwnershipRecords = 1;
+    static constexpr unsigned short requestPossessionRecords = 2;
+    static constexpr unsigned short requestByUniverseIdx = 3;
+    unsigned short assetReqType;
+
+    // common flags
+    static constexpr unsigned short getSiblings = 0b1;
+
+    // flags of requestIssuanceRecords
+    static constexpr unsigned short anyIssuer = 0b10;
+    static constexpr unsigned short anyAssetName = 0b100;
+
+    // flags of requestOwnershipRecords
+    static constexpr unsigned short anyOwner = 0b1000;
+    static constexpr unsigned short anyOwnershipManagingContract = 0b10000;
+
+    // flags of requestOwnershipRecords and requestPossessionRecords
+    static constexpr unsigned short anyPossessor = 0b100000;
+    static constexpr unsigned short anyPossessionManagingContract = 0b1000000;
+
+    // data of type requestIssuanceRecords, requestOwnershipRecords, and requestPossessionRecords
+    struct
+    {
+        unsigned short assetReqType;
+        unsigned short flags;
+        unsigned short ownershipManagingContract;
+        unsigned short possessionManagingContract;
+        m256i issuer;
+        unsigned long long assetName;
+        m256i owner;
+        m256i possessor;
+    } byFilter;
+
+    // data of type requestByUniverseIdx
+    struct
+    {
+        unsigned short assetReqType;
+        unsigned short flags;
+        unsigned int universeIdx;
+    } byUniverseIdx;
+};
+
+static_assert(sizeof(RequestAssets) == 112, "Something is wrong with the struct size.");
+
+
+// Response message after RequestAssets without flag getSiblings
+struct RespondAssets
+{
+    AssetRecord asset;
+    unsigned int tick;
+    unsigned int universeIndex;
+
+    enum {
+        type = 53,
+    };
+};
+
+static_assert(sizeof(RespondAssets) == 56, "Something is wrong with the struct size.");
+
+// Response message after RequestAssets with flag getSiblings
+struct RespondAssetsWithSiblings : public RespondAssets
+{
+    m256i siblings[ASSETS_DEPTH];
+};
+
+static_assert(sizeof(RespondAssetsWithSiblings) == 824, "Something is wrong with the struct size.");

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1581,6 +1581,12 @@ static void requestProcessor(void* ProcedureArgument)
                 }
                 break;
 
+                case RequestAssets::type:
+                {
+                    processRequestAssets(peer, header);
+                }
+                break;
+
                 case SpecialCommand::type:
                 {
                     processSpecialCommand(peer, header);

--- a/test/assets.cpp
+++ b/test/assets.cpp
@@ -166,6 +166,19 @@ struct AssetSharesKey
     }
 };
 
+struct AssetKey : public Asset
+{
+    bool operator < (const Asset& rhs) const
+    {
+        if (issuer < rhs.issuer)
+            return true;
+        else if (rhs.issuer < issuer)
+            return false;
+        else
+            return assetName < rhs.assetName;
+    }
+};
+
 struct IssuanceTestData
 {
     Asset id;
@@ -178,6 +191,19 @@ struct IssuanceTestData
     std::map<AssetSharesKey, long long> shares;
     std::map<AssetSharesKey, long long> ownershipIdx;
     std::map<AssetSharesKey, long long> possessionIdx;
+
+    void checkIssuance(const AssetIssuanceIterator& iter) const
+    {
+        unsigned int idxI = iter.issuanceIndex();
+        EXPECT_LT(idxI, ASSETS_CAPACITY);
+        EXPECT_EQ(idxI, universeIdx);
+        EXPECT_EQ(assets[idxI].varStruct.issuance.type, ISSUANCE);
+        EXPECT_EQ((*((unsigned long long*)assets[idxI].varStruct.issuance.name)) & 0xFFFFFFFFFFFFFF, id.assetName);
+        EXPECT_EQ(assets[idxI].varStruct.issuance.publicKey, id.issuer);
+
+        EXPECT_EQ(iter.issuer(), id.issuer);
+        EXPECT_EQ(iter.assetName(), id.assetName);
+    }
 
     void checkOwnershipAndIssuance(const AssetOwnershipIterator& iter) const
     {
@@ -206,6 +232,7 @@ struct IssuanceTestData
 
         EXPECT_EQ(iter.numberOfOwnedShares(), numOfShares);
         EXPECT_EQ(iter.issuer(), id.issuer);
+        EXPECT_EQ(iter.assetName(), id.assetName);
         EXPECT_EQ(iter.owner(), owner);
         EXPECT_EQ((uint32)iter.ownershipManagingContract(), managingContract);
     }
@@ -236,7 +263,7 @@ struct IssuanceTestData
     }
 };
 
-TEST(TestCoreAssets, AssetIteratorOwnershipAndPossession)
+TEST(TestCoreAssets, AssetIterators)
 {
     AssetsTest test;
     test.clearUniverse();
@@ -253,18 +280,20 @@ TEST(TestCoreAssets, AssetIteratorOwnershipAndPossession)
     m256i unusedPublicKey(9876, 4321, 0, 13579);
 
     // With empty universe, all iterators should stop right after init
+    AssetIssuanceIterator iterI;
+    EXPECT_TRUE(iterI.reachedEnd());
+    EXPECT_EQ(iterI.issuanceIndex(), NO_ASSET_INDEX);
     for (int i = 0; i < issuancesCount; ++i)
     {
         AssetOwnershipIterator iterO(issuances[i].id);
         EXPECT_TRUE(iterO.reachedEnd());
         EXPECT_EQ(iterO.issuanceIndex(), NO_ASSET_INDEX);
         EXPECT_EQ(iterO.ownershipIndex(), NO_ASSET_INDEX);
-        EXPECT_EQ(iterO.issuanceIndex(), NO_ASSET_INDEX);
-        AssetOwnershipIterator iterP(issuances[i].id);
+        AssetPossessionIterator iterP(issuances[i].id);
         EXPECT_TRUE(iterP.reachedEnd());
         EXPECT_EQ(iterP.issuanceIndex(), NO_ASSET_INDEX);
         EXPECT_EQ(iterP.ownershipIndex(), NO_ASSET_INDEX);
-        EXPECT_EQ(iterP.issuanceIndex(), NO_ASSET_INDEX);
+        EXPECT_EQ(iterP.possessionIndex(), NO_ASSET_INDEX);
     }
 
     // Build universe with multiple owners / possessor per issuance
@@ -297,6 +326,94 @@ TEST(TestCoreAssets, AssetIteratorOwnershipAndPossession)
         issuances[i].possessionIdx[key] = firstPossessionIdx;
 
         test.checkAssetsConsistency(i == issuancesCount - 1);
+    }
+
+    {
+        // Test iterating all issuances with AssetIssuanceIterator
+        std::map<AssetKey, IssuanceTestData*> testIssuancesSet;
+        for (int i = 0; i < issuancesCount; ++i)
+        {
+            AssetKey key{ issuances[i].id.issuer, issuances[i].id.assetName };
+            //std::cout << issuances[i].id.issuer << ", name " << issuances[i].id.assetName << ", idx " << issuances[i].universeIdx << std::endl;
+            testIssuancesSet[key] = &issuances[i];
+        }
+        AssetIssuanceIterator iter;
+        while (!iter.reachedEnd())
+        {
+            AssetKey key{ iter.issuer(), iter.assetName() };
+            //std::cout << iter.issuer() << ", name " << iter.assetName() << ", idx " << iter.issuanceIndex() << std::endl;
+            auto testIssuancesSetIt = testIssuancesSet.find(key);
+            EXPECT_NE(testIssuancesSetIt, testIssuancesSet.end());
+            testIssuancesSetIt->second->checkIssuance(iter);
+            testIssuancesSet.erase(key);
+            bool hasNext = iter.next();
+            EXPECT_EQ(hasNext, !iter.reachedEnd());
+        }
+        EXPECT_EQ(testIssuancesSet.size(), 0);
+
+        // Iterate by issuer (also test reusing the iterator)
+        auto assetSelect = AssetIssuanceSelect::byIssuer(issuances[0].id.issuer);
+        for (int i = 0; i < issuancesCount; ++i)
+        {
+            if (issuances[i].id.issuer != assetSelect.issuer)
+                continue;
+            AssetKey key{ issuances[i].id.issuer, issuances[i].id.assetName };
+            //std::cout << issuances[i].id.issuer << ", name " << issuances[i].id.assetName << ", idx " << issuances[i].universeIdx << std::endl;
+            testIssuancesSet[key] = &issuances[i];
+        }
+        iter.begin(assetSelect);
+        while (!iter.reachedEnd())
+        {
+            AssetKey key{ iter.issuer(), iter.assetName() };
+            //std::cout << iter.issuer() << ", name " << iter.assetName() << ", idx " << iter.issuanceIndex() << std::endl;
+            auto testIssuancesSetIt = testIssuancesSet.find(key);
+            EXPECT_NE(testIssuancesSetIt, testIssuancesSet.end());
+            testIssuancesSetIt->second->checkIssuance(iter);
+            testIssuancesSet.erase(key);
+            bool hasNext = iter.next();
+            EXPECT_EQ(hasNext, !iter.reachedEnd());
+        }
+        EXPECT_EQ(testIssuancesSet.size(), 0);
+
+        // Iterate by name
+        assetSelect = AssetIssuanceSelect::byName(assetNameFromString("BLA"));
+        for (int i = 0; i < issuancesCount; ++i)
+        {
+            if (issuances[i].id.assetName != assetSelect.assetName)
+                continue;
+            AssetKey key{ issuances[i].id.issuer, issuances[i].id.assetName };
+            //std::cout << issuances[i].id.issuer << ", name " << issuances[i].id.assetName << ", idx " << issuances[i].universeIdx << std::endl;
+            testIssuancesSet[key] = &issuances[i];
+        }
+        iter.begin(assetSelect);
+        while (!iter.reachedEnd())
+        {
+            AssetKey key{ iter.issuer(), iter.assetName() };
+            //std::cout << iter.issuer() << ", name " << iter.assetName() << ", idx " << iter.issuanceIndex() << std::endl;
+            auto testIssuancesSetIt = testIssuancesSet.find(key);
+            EXPECT_NE(testIssuancesSetIt, testIssuancesSet.end());
+            testIssuancesSetIt->second->checkIssuance(iter);
+            testIssuancesSet.erase(key);
+            bool hasNext = iter.next();
+            EXPECT_EQ(hasNext, !iter.reachedEnd());
+        }
+        EXPECT_EQ(testIssuancesSet.size(), 0);
+
+        // Test iterator to return single issuance
+        for (int i = 0; i < issuancesCount; ++i)
+        {
+            iter.begin({ issuances[i].id.issuer, issuances[i].id.assetName });
+            issuances[i].checkIssuance(iter);
+            EXPECT_FALSE(iter.next());
+        }
+
+        // Test issuance iterator with unused key
+        iter.begin({ unusedPublicKey, assetNameFromString("UNUSED") });
+        EXPECT_TRUE(iter.reachedEnd());
+        iter.begin(AssetIssuanceSelect::byIssuer(unusedPublicKey));
+        EXPECT_TRUE(iter.reachedEnd());
+        iter.begin(AssetIssuanceSelect::byName(assetNameFromString("UNUSED")));
+        EXPECT_TRUE(iter.reachedEnd());
     }
 
     {


### PR DESCRIPTION
Options to request assets:
- all issued asset records, optionally with filtering by issuer and/or name
- all ownership records of a specific asset type, optionally with filtering by owner and managing contract
- all possession records of a specific asset type, optionally with filtering by possessor and managing contract
- by universeIdx (set issuer and asset name to 0)
- each with or without siblings