### PR TITLE
Implement equality operators for QPI::BitArray

### DIFF
--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -174,6 +174,25 @@ namespace QPI
 			for (uint64 i = 0; i < _elements; ++i)
 				_values[i] = setValue;
 		}
+
+
+        bool operator==(const BitArray<L>& other) const
+        {
+            for (uint64 i = 0; i < _elements; ++i)
+            {
+                if (_values[i] != other._values[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool operator!=(const BitArray<L>& other) const
+        {
+            return !(*this == other);
+        }
+
 	};
 
 	// Bit array convenience definitions

--- a/test/qpi.cpp
+++ b/test/qpi.cpp
@@ -98,6 +98,15 @@ TEST(TestCoreQPI, BitArray)
     b1.set(0, true);
     EXPECT_EQ(b1.get(0), 1);
 
+    b1.setAll(0);
+    QPI::BitArray<1> b1_2;
+    b1_2.setAll(0);
+    QPI::BitArray<1> b1_3;
+    b1_3.setAll(1);
+    EXPECT_TRUE(b1 == b1_2);
+    EXPECT_TRUE(b1 != b1_3);
+    EXPECT_FALSE(b1 == b1_3);
+
     QPI::BitArray<64> b64;
     EXPECT_EQ(b64.capacity(), 64);
     b64.setMem(0x11llu);
@@ -118,6 +127,18 @@ TEST(TestCoreQPI, BitArray)
     b64.setAll(1);
     llu1.setMem(b64);
     EXPECT_EQ(llu1.get(0), 0xffffffffffffffffllu);
+
+
+    b64.setMem(0x11llu);
+    QPI::BitArray<64> b64_2;
+    EXPECT_EQ(b64.capacity(), 64);
+    b64_2.setMem(0x11llu);
+    QPI::BitArray<64> b64_3;
+    EXPECT_EQ(b64.capacity(), 64);
+    b64_3.setMem(0x55llu);
+    EXPECT_TRUE(b64 == b64_2);
+    EXPECT_TRUE(b64 != b64_3);
+    EXPECT_FALSE(b64 == b64_3);
 
     //QPI::BitArray<96> b96; // must trigger compile error
 
@@ -152,6 +173,15 @@ TEST(TestCoreQPI, BitArray)
     {
         EXPECT_EQ(b128.get(i), i % 2 == 0);
     }
+
+    b128.setAll(1);
+    QPI::BitArray<128> b128_2;
+    QPI::BitArray<128> b128_3;
+    b128_2.setAll(1);
+    b128_3.setAll(0);
+    EXPECT_TRUE(b128 == b128_2);
+    EXPECT_TRUE(b128 != b128_3);
+    EXPECT_FALSE(b128 == b128_3);
 }
 
 TEST(TestCoreQPI, Div) {

--- a/test/qpi_hash_map.cpp
+++ b/test/qpi_hash_map.cpp
@@ -82,6 +82,67 @@ inline char HashMapTestData<QPI::sint64, char>::GetValueNotInTestPairs()
 }
 
 
+// testdata for KeyT = QPI::BitArray<1024>, ValueT = uint64
+template<>
+std::array<std::pair<QPI::bit_1024, QPI::uint64>, 4>  HashMapTestData<QPI::bit_1024, QPI::uint64>::CreateKeyValueTestPairs()
+{
+    // Create a properly sized array to work with BitArray's setMem
+    alignas(32) unsigned char buffer[128] = {0}; // 1024 bits = 128 bytes
+
+    // Helper lambda to set a string pattern in bit_1024
+    auto setStringKey = [](QPI::bit_1024& bits, const std::string& str) {
+        bits.setAll(0);  // Clear all bits first
+        // Each character becomes 8 bits
+        for(size_t i = 0; i < str.length() && i < 128; i++)  // 128 is max bytes (1024/8)
+        {
+            unsigned char c = str[i];
+            // Set 8 bits for this character
+            for(int bit = 0; bit < 8; bit++)
+            {
+                bits.set(i * 8 + bit, (c & (1 << bit)) != 0);
+            }
+        }
+    };
+
+    QPI::bit_1024 key1, key2, key3, key4;
+    setStringKey(key1, "TestString1");
+    setStringKey(key2, "AnotherTest2");
+    setStringKey(key3, "ThirdString3");
+    setStringKey(key4, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()_-+={}[]|;:\"\'<>,.?/~`abcdefghijklmnopqrstuvwxyzABCDEFGH");
+
+    std::array<std::pair<QPI::bit_1024, QPI::uint64>, 4> res;
+	res = { {
+		{ key1, 12},
+		{ key2, 99},
+		{ key3, 723},
+		{ key4, 0},
+	} };
+	return res;
+}
+
+template<>
+inline QPI::bit_1024 HashMapTestData<QPI::bit_1024, QPI::uint64>::GetKeyNotInTestPairs()
+{
+    alignas(32) unsigned char buffer[128] = {0};
+    QPI::bit_1024 key;
+    std::string str = "NotInTestPairs";
+    for(size_t i = 0; i < str.length() && i < 128; i++)
+    {
+        unsigned char c = str[i];
+        for(int bit = 0; bit < 8; bit++)
+        {
+            key.set(i * 8 + bit, (c & (1 << bit)) != 0);
+        }
+    }
+    return key;
+}
+
+template<>
+inline QPI::uint64 HashMapTestData<QPI::bit_1024, QPI::uint64>::GetValueNotInTestPairs()
+{
+	return 42;
+}
+
 // Define the test fixture class with a single template parameter T because the type list
 // for test instantiation will contain pair-types std::pair<KeyT, ValueT> to use for T.
 template <typename T>
@@ -391,5 +452,5 @@ REGISTER_TYPED_TEST_CASE_P(QPIHashMapTest,
 	TestReset
 );
 
-typedef Types<std::pair<QPI::id, int>, std::pair<QPI::sint64, char>> KeyValueTypesToTest;
+typedef Types<std::pair<QPI::id, int>, std::pair<QPI::sint64, char>, std::pair<QPI::bit_1024, QPI::uint64>> KeyValueTypesToTest;
 INSTANTIATE_TYPED_TEST_CASE_P(TypedQPIHashMapTests, QPIHashMapTest, KeyValueTypesToTest);


### PR DESCRIPTION
This commit implements `operator==` and `operator!=` for the `QPI::BitArray` class.  These operators compare the underlying `_values` arrays element-by-element.  This change enables the use of `BitArray` as a key in hash map structures.

Tests for the equality operators are included, covering different `BitArray` sizes and bit patterns.  These tests are located in `test/qpi.cpp` and `test/qpi_hash_map.cpp`.  `test/qpi_hash_map.cpp` is updated to include `QPI::bit_1024` as a tested key type, demonstrating its use in a hash map context.