### PR TITLE
Add txBodyDigest as additional proof that a node has all Tx

### DIFF
--- a/src/K12/brg_endian.h
+++ b/src/K12/brg_endian.h
@@ -1,0 +1,143 @@
+/*
+ ---------------------------------------------------------------------------
+ Copyright (c) 1998-2008, Brian Gladman, Worcester, UK. All rights reserved.
+
+ LICENSE TERMS
+
+ The redistribution and use of this software (with or without changes)
+ is allowed without the payment of fees or royalties provided that:
+
+  1. source code distributions include the above copyright notice, this
+     list of conditions and the following disclaimer;
+
+  2. binary distributions include the above copyright notice, this list
+     of conditions and the following disclaimer in their documentation;
+
+  3. the name of the copyright holder is not used to endorse products
+     built using this software without specific written permission.
+
+ DISCLAIMER
+
+ This software is provided 'as is' with no explicit or implied warranties
+ in respect of its properties, including, but not limited to, correctness
+ and/or fitness for purpose.
+ ---------------------------------------------------------------------------
+ Issue Date: 20/12/2007
+ Changes for ARM 9/9/2010
+*/
+
+#ifndef _BRG_ENDIAN_H
+#define _BRG_ENDIAN_H
+
+#define IS_BIG_ENDIAN      4321 /* byte 0 is most significant (mc68k) */
+#define IS_LITTLE_ENDIAN   1234 /* byte 0 is least significant (i386) */
+
+#if 0
+/* Include files where endian defines and byteswap functions may reside */
+#if defined( __sun )
+#  include <sys/isa_defs.h>
+#elif defined( __FreeBSD__ ) || defined( __OpenBSD__ ) || defined( __NetBSD__ )
+#  include <sys/endian.h>
+#elif defined( BSD ) && ( BSD >= 199103 ) || defined( __APPLE__ ) || \
+      defined( __CYGWIN32__ ) || defined( __DJGPP__ ) || defined( __osf__ )
+#  include <machine/endian.h>
+#elif defined( __linux__ ) || defined( __GNUC__ ) || defined( __GNU_LIBRARY__ )
+#  if !defined( __MINGW32__ ) && !defined( _AIX )
+#    include <endian.h>
+#    if !defined( __BEOS__ )
+#      include <byteswap.h>
+#    endif
+#  endif
+#endif
+#endif
+
+/* Now attempt to set the define for platform byte order using any  */
+/* of the four forms SYMBOL, _SYMBOL, __SYMBOL & __SYMBOL__, which  */
+/* seem to encompass most endian symbol definitions                 */
+
+#if defined( BIG_ENDIAN ) && defined( LITTLE_ENDIAN )
+#  if defined( BYTE_ORDER ) && BYTE_ORDER == BIG_ENDIAN
+#    define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#  elif defined( BYTE_ORDER ) && BYTE_ORDER == LITTLE_ENDIAN
+#    define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#  endif
+#elif defined( BIG_ENDIAN )
+#  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined( LITTLE_ENDIAN )
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if defined( _BIG_ENDIAN ) && defined( _LITTLE_ENDIAN )
+#  if defined( _BYTE_ORDER ) && _BYTE_ORDER == _BIG_ENDIAN
+#    define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#  elif defined( _BYTE_ORDER ) && _BYTE_ORDER == _LITTLE_ENDIAN
+#    define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#  endif
+#elif defined( _BIG_ENDIAN )
+#  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined( _LITTLE_ENDIAN )
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if defined( __BIG_ENDIAN ) && defined( __LITTLE_ENDIAN )
+#  if defined( __BYTE_ORDER ) && __BYTE_ORDER == __BIG_ENDIAN
+#    define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#  elif defined( __BYTE_ORDER ) && __BYTE_ORDER == __LITTLE_ENDIAN
+#    define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#  endif
+#elif defined( __BIG_ENDIAN )
+#  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined( __LITTLE_ENDIAN )
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if defined( __BIG_ENDIAN__ ) && defined( __LITTLE_ENDIAN__ )
+#  if defined( __BYTE_ORDER__ ) && __BYTE_ORDER__ == __BIG_ENDIAN__
+#    define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#  elif defined( __BYTE_ORDER__ ) && __BYTE_ORDER__ == __LITTLE_ENDIAN__
+#    define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#  endif
+#elif defined( __BIG_ENDIAN__ )
+#  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined( __LITTLE_ENDIAN__ )
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+/*  if the platform byte order could not be determined, then try to */
+/*  set this define using common machine defines                    */
+#if !defined(PLATFORM_BYTE_ORDER)
+
+#if   defined( __alpha__ ) || defined( __alpha ) || defined( i386 )       || \
+      defined( __i386__ )  || defined( _M_I86 )  || defined( _M_IX86 )    || \
+      defined( __OS2__ )   || defined( sun386 )  || defined( __TURBOC__ ) || \
+      defined( vax )       || defined( vms )     || defined( VMS )        || \
+      defined( __VMS )     || defined( _M_X64 )
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+
+#elif defined( AMIGA )    || defined( applec )    || defined( __AS400__ )  || \
+      defined( _CRAY )    || defined( __hppa )    || defined( __hp9000 )   || \
+      defined( ibm370 )   || defined( mc68000 )   || defined( m68k )       || \
+      defined( __MRC__ )  || defined( __MVS__ )   || defined( __MWERKS__ ) || \
+      defined( sparc )    || defined( __sparc)    || defined( SYMANTEC_C ) || \
+      defined( __VOS__ )  || defined( __TIGCC__ ) || defined( __TANDEM )   || \
+      defined( THINK_C )  || defined( __VMCMS__ ) || defined( _AIX )       || \
+      defined( __s390__ ) || defined( __s390x__ ) || defined( __zarch__ )
+#  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+
+#elif defined(__arm__)
+# ifdef __BIG_ENDIAN
+#  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+# else
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+# endif
+#elif 1     /* **** EDIT HERE IF NECESSARY **** */
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#elif 0     /* **** EDIT HERE IF NECESSARY **** */
+#  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#else
+#  error Please edit lines 132 or 134 in brg_endian.h to set the platform byte order
+#endif
+
+#endif
+
+#endif

--- a/src/K12/kangaroo_twelve_xkcp.h
+++ b/src/K12/kangaroo_twelve_xkcp.h
@@ -1,0 +1,1441 @@
+#pragma once
+
+#include <intrin.h>
+
+#include "platform/memory.h"
+
+typedef unsigned char uint8_t;
+typedef unsigned long long uint64_t;
+
+#ifdef ALIGN
+#undef ALIGN
+#endif
+
+#if defined(__GNUC__)
+#define ALIGN(x) __attribute__ ((aligned(x)))
+#elif defined(_MSC_VER)
+#define ALIGN(x) __declspec(align(x))
+#elif defined(__ARMCC_VERSION)
+#define ALIGN(x) __align(x)
+#else
+#define ALIGN(x)
+#endif
+
+#define KeccakP1600_stateSizeInBytes    200
+#define KeccakP1600_stateAlignment      8
+
+// Forward declarations
+namespace K12xkcp
+{
+    void KeccakP1600_Initialize(void *state);
+    void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset);
+    void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
+    void KeccakP1600_Permute_12rounds(void *state);
+    void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
+    size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
+}
+
+typedef struct TurboSHAKE_InstanceStruct {
+    uint8_t state[KeccakP1600_stateSizeInBytes];
+    unsigned int rate;
+    uint8_t byteIOIndex;
+    uint8_t squeezing;
+} TurboSHAKE_Instance;
+
+
+typedef struct KangarooTwelve_InstanceStruct {
+    ALIGN(KeccakP1600_stateAlignment) TurboSHAKE_Instance queueNode;
+    ALIGN(KeccakP1600_stateAlignment) TurboSHAKE_Instance finalNode;
+    size_t fixedOutputLength;
+    size_t blockNumber;
+    unsigned int queueAbsorbedLen;
+    int phase;
+    int securityLevel;
+} KangarooTwelve_Instance;
+
+static void TurboSHAKE_Initialize(TurboSHAKE_Instance* instance, int securityLevel)
+{
+    K12xkcp::KeccakP1600_Initialize(instance->state);
+    instance->rate = (1600 - (2 * securityLevel));
+    instance->byteIOIndex = 0;
+    instance->squeezing = 0;
+}
+
+static void TurboSHAKE_Absorb(TurboSHAKE_Instance* instance, const unsigned char* data, size_t dataByteLen)
+{
+    size_t i, j;
+    uint8_t partialBlock;
+    const unsigned char* curData;
+
+    const uint8_t rateInBytes = instance->rate / 8;
+
+    //assert(instance->squeezing == 0);
+
+    i = 0;
+    curData = data;
+    while (i < dataByteLen) {
+        if ((instance->byteIOIndex == 0) && (dataByteLen - i >= rateInBytes)) {
+#ifdef KeccakP1600_12rounds_FastLoop_supported
+            /* processing full blocks first */
+            j = KeccakP1600_12rounds_FastLoop_Absorb(instance->state, instance->rate / 64, curData, dataByteLen - i);
+            i += j;
+            curData += j;
+#endif
+            for (j = dataByteLen - i; j >= rateInBytes; j -= rateInBytes) {
+                K12xkcp::KeccakP1600_AddBytes(instance->state, curData, 0, rateInBytes);
+                K12xkcp::KeccakP1600_Permute_12rounds(instance->state);
+                curData += rateInBytes;
+            }
+            i = dataByteLen - j;
+        }
+        else {
+            /* normal lane: using the message queue */
+            if (dataByteLen - i > (size_t)rateInBytes - instance->byteIOIndex) {
+                partialBlock = rateInBytes - instance->byteIOIndex;
+            }
+            else {
+                partialBlock = (uint8_t)(dataByteLen - i);
+            }
+            i += partialBlock;
+
+            K12xkcp::KeccakP1600_AddBytes(instance->state, curData, instance->byteIOIndex, partialBlock);
+            curData += partialBlock;
+            instance->byteIOIndex += partialBlock;
+            if (instance->byteIOIndex == rateInBytes) {
+                K12xkcp::KeccakP1600_Permute_12rounds(instance->state);
+                instance->byteIOIndex = 0;
+            }
+        }
+    }
+}
+
+static void TurboSHAKE_AbsorbDomainSeparationByte(TurboSHAKE_Instance* instance, unsigned char D)
+{
+    const unsigned int rateInBytes = instance->rate / 8;
+
+    //assert(D != 0);
+    //assert(instance->squeezing == 0);
+
+    /* Last few bits, whose delimiter coincides with first bit of padding */
+    K12xkcp::KeccakP1600_AddByte(instance->state, D, instance->byteIOIndex);
+    /* If the first bit of padding is at position rate-1, we need a whole new block for the second bit of padding */
+    if ((D >= 0x80) && (instance->byteIOIndex == (rateInBytes - 1)))
+        K12xkcp::KeccakP1600_Permute_12rounds(instance->state);
+    /* Second bit of padding */
+    K12xkcp::KeccakP1600_AddByte(instance->state, 0x80, rateInBytes - 1);
+    K12xkcp::KeccakP1600_Permute_12rounds(instance->state);
+    instance->byteIOIndex = 0;
+    instance->squeezing = 1;
+}
+
+static void TurboSHAKE_Squeeze(TurboSHAKE_Instance* instance, unsigned char* data, size_t dataByteLen)
+{
+    size_t i, j;
+    unsigned int partialBlock;
+    const unsigned int rateInBytes = instance->rate / 8;
+    unsigned char* curData;
+
+    if (!instance->squeezing)
+        TurboSHAKE_AbsorbDomainSeparationByte(instance, 0x01);
+
+    i = 0;
+    curData = data;
+    while (i < dataByteLen) {
+        if ((instance->byteIOIndex == rateInBytes) && (dataByteLen - i >= rateInBytes)) {
+            for (j = dataByteLen - i; j >= rateInBytes; j -= rateInBytes) {
+                K12xkcp::KeccakP1600_Permute_12rounds(instance->state);
+                K12xkcp::KeccakP1600_ExtractBytes(instance->state, curData, 0, rateInBytes);
+                curData += rateInBytes;
+            }
+            i = dataByteLen - j;
+        }
+        else {
+            /* normal lane: using the message queue */
+            if (instance->byteIOIndex == rateInBytes) {
+                K12xkcp::KeccakP1600_Permute_12rounds(instance->state);
+                instance->byteIOIndex = 0;
+            }
+            if (dataByteLen - i > rateInBytes - instance->byteIOIndex)
+                partialBlock = rateInBytes - instance->byteIOIndex;
+            else
+                partialBlock = (unsigned int)(dataByteLen - i);
+            i += partialBlock;
+
+            K12xkcp::KeccakP1600_ExtractBytes(instance->state, curData, instance->byteIOIndex, partialBlock);
+            curData += partialBlock;
+            instance->byteIOIndex += partialBlock;
+        }
+    }
+}
+
+typedef enum {
+    NOT_INITIALIZED,
+    ABSORBING,
+    FINAL,
+    SQUEEZING
+} KCP_Phases;
+typedef KCP_Phases KangarooTwelve_Phases;
+
+#define K12_chunkSize       8192
+#define K12_suffixLeaf      0x0B /* '110': message hop, simple padding, inner node */
+#define KT128_capacityInBytes   32
+#define KT256_capacityInBytes   64
+
+#define maxCapacityInBytes 64
+
+
+static unsigned int right_encode(unsigned char* encbuf, size_t value)
+{
+    unsigned int n, i;
+    size_t v;
+
+    for (v = value, n = 0; v && (n < sizeof(size_t)); ++n, v >>= 8)
+        ; /* empty */
+    for (i = 1; i <= n; ++i) {
+        encbuf[i - 1] = (unsigned char)(value >> (8 * (n - i)));
+    }
+    encbuf[n] = (unsigned char)n;
+    return n + 1;
+}
+
+
+/**
+  * Function to initialize a KangarooTwelve instance.
+  * @param  ktInstance      Pointer to the instance to be initialized.
+  * @param  securityLevel   The desired security strength level (128 bits or 256 bits).
+  * @param  outputByteLen   The desired number of output bytes,
+  *                         or 0 for an arbitrarily-long output.
+  * @return 0 if successful, 1 otherwise.
+  */
+int KangarooTwelve_Initialize(KangarooTwelve_Instance* ktInstance, int securityLevel, size_t outputByteLen)
+{
+    ktInstance->fixedOutputLength = outputByteLen;
+    ktInstance->queueAbsorbedLen = 0;
+    ktInstance->blockNumber = 0;
+    ktInstance->phase = ABSORBING;
+    ktInstance->securityLevel = securityLevel;
+    TurboSHAKE_Initialize(&ktInstance->finalNode, securityLevel);
+    return 0;
+}
+
+
+/**
+  * Function to give input data to be absorbed.
+  * @param  ktInstance      Pointer to the instance initialized by KangarooTwelve_Initialize().
+  * @param  input           Pointer to the input message data (M).
+  * @param  inputByteLen    The number of bytes provided in the input message data.
+  * @return 0 if successful, 1 otherwise.
+  */
+int KangarooTwelve_Update(KangarooTwelve_Instance* ktInstance, const unsigned char* input, size_t inputByteLen)
+{
+    if (ktInstance->phase != ABSORBING)
+        return 1;
+
+    if (ktInstance->blockNumber == 0) {
+        /* First block, absorb in final node */
+        unsigned int len = (inputByteLen < (K12_chunkSize - ktInstance->queueAbsorbedLen)) ? (unsigned int)inputByteLen : (K12_chunkSize - ktInstance->queueAbsorbedLen);
+        TurboSHAKE_Absorb(&ktInstance->finalNode, input, len);
+        input += len;
+        inputByteLen -= len;
+        ktInstance->queueAbsorbedLen += len;
+        if ((ktInstance->queueAbsorbedLen == K12_chunkSize) && (inputByteLen != 0)) {
+            /* First block complete and more input data available, finalize it */
+            const unsigned char padding = 0x03; /* '110^6': message hop, simple padding */
+            ktInstance->queueAbsorbedLen = 0;
+            ktInstance->blockNumber = 1;
+            TurboSHAKE_Absorb(&ktInstance->finalNode, &padding, 1);
+            ktInstance->finalNode.byteIOIndex = (ktInstance->finalNode.byteIOIndex + 7) & ~7; /* Zero padding up to 64 bits */
+        }
+    }
+    else if (ktInstance->queueAbsorbedLen != 0) {
+        /* There is data in the queue, absorb further in queue until block complete */
+        unsigned int len = (inputByteLen < (K12_chunkSize - ktInstance->queueAbsorbedLen)) ? (unsigned int)inputByteLen : (K12_chunkSize - ktInstance->queueAbsorbedLen);
+        TurboSHAKE_Absorb(&ktInstance->queueNode, input, len);
+        input += len;
+        inputByteLen -= len;
+        ktInstance->queueAbsorbedLen += len;
+        if (ktInstance->queueAbsorbedLen == K12_chunkSize) {
+            int capacityInBytes = 2 * (ktInstance->securityLevel) / 8;
+            unsigned char intermediate[maxCapacityInBytes];
+            //assert(capacityInBytes <= maxCapacityInBytes);
+            ktInstance->queueAbsorbedLen = 0;
+            ++ktInstance->blockNumber;
+            TurboSHAKE_AbsorbDomainSeparationByte(&ktInstance->queueNode, K12_suffixLeaf);
+            TurboSHAKE_Squeeze(&ktInstance->queueNode, intermediate, capacityInBytes);
+            TurboSHAKE_Absorb(&ktInstance->finalNode, intermediate, capacityInBytes);
+        }
+    }
+
+    while (inputByteLen > 0) {
+        unsigned int len = (inputByteLen < K12_chunkSize) ? (unsigned int)inputByteLen : K12_chunkSize;
+        TurboSHAKE_Initialize(&ktInstance->queueNode, ktInstance->securityLevel);
+        TurboSHAKE_Absorb(&ktInstance->queueNode, input, len);
+        input += len;
+        inputByteLen -= len;
+        if (len == K12_chunkSize) {
+            int capacityInBytes = 2 * (ktInstance->securityLevel) / 8;
+            unsigned char intermediate[maxCapacityInBytes];
+            //assert(capacityInBytes <= maxCapacityInBytes);
+            ++ktInstance->blockNumber;
+            TurboSHAKE_AbsorbDomainSeparationByte(&ktInstance->queueNode, K12_suffixLeaf);
+            TurboSHAKE_Squeeze(&ktInstance->queueNode, intermediate, capacityInBytes);
+            TurboSHAKE_Absorb(&ktInstance->finalNode, intermediate, capacityInBytes);
+        }
+        else {
+            ktInstance->queueAbsorbedLen = len;
+        }
+    }
+
+    return 0;
+}
+
+
+/**
+  * Function to call after all the input message has been input, and to get
+  * output bytes if the length was specified when calling KangarooTwelve_Initialize().
+  * @param  ktInstance      Pointer to the hash instance initialized by KangarooTwelve_Initialize().
+  * If @a outputByteLen was not 0 in the call to KangarooTwelve_Initialize(), the number of
+  *     output bytes is equal to @a outputByteLen.
+  * If @a outputByteLen was 0 in the call to KangarooTwelve_Initialize(), the output bytes
+  *     must be extracted using the KangarooTwelve_Squeeze() function.
+  * @param  output          Pointer to the buffer where to store the output data.
+  * @param  customization   Pointer to the customization string (C).
+  * @param  customByteLen   The length of the customization string in bytes.
+  * @return 0 if successful, 1 otherwise.
+  */
+int KangarooTwelve_Final(KangarooTwelve_Instance* ktInstance, unsigned char* output, const unsigned char* customization, size_t customByteLen)
+{
+    unsigned char encbuf[sizeof(size_t) + 1 + 2];
+    unsigned char padding;
+
+    if (ktInstance->phase != ABSORBING)
+        return 1;
+
+    /* Absorb customization | right_encode(customByteLen) */
+    if ((customByteLen != 0) && (KangarooTwelve_Update(ktInstance, customization, customByteLen) != 0))
+        return 1;
+    if (KangarooTwelve_Update(ktInstance, encbuf, right_encode(encbuf, customByteLen)) != 0)
+        return 1;
+
+    if (ktInstance->blockNumber == 0) {
+        /* Non complete first block in final node, pad it */
+        padding = 0x07; /*  '11': message hop, final node */
+    }
+    else {
+        unsigned int n;
+
+        if (ktInstance->queueAbsorbedLen != 0) {
+            /* There is data in the queue node */
+            int capacityInBytes = 2 * (ktInstance->securityLevel) / 8;
+            unsigned char intermediate[maxCapacityInBytes];
+            //assert(capacityInBytes <= maxCapacityInBytes);
+            ++ktInstance->blockNumber;
+            TurboSHAKE_AbsorbDomainSeparationByte(&ktInstance->queueNode, K12_suffixLeaf);
+            TurboSHAKE_Squeeze(&ktInstance->queueNode, intermediate, capacityInBytes);
+            TurboSHAKE_Absorb(&ktInstance->finalNode, intermediate, capacityInBytes);
+        }
+        --ktInstance->blockNumber; /* Absorb right_encode(number of Chaining Values) || 0xFF || 0xFF */
+        n = right_encode(encbuf, ktInstance->blockNumber);
+        encbuf[n++] = 0xFF;
+        encbuf[n++] = 0xFF;
+        TurboSHAKE_Absorb(&ktInstance->finalNode, encbuf, n);
+        padding = 0x06; /* '01': chaining hop, final node */
+    }
+    TurboSHAKE_AbsorbDomainSeparationByte(&ktInstance->finalNode, padding);
+    if (ktInstance->fixedOutputLength != 0) {
+        ktInstance->phase = FINAL;
+        TurboSHAKE_Squeeze(&ktInstance->finalNode, output, ktInstance->fixedOutputLength);
+        return 0;
+    }
+    ktInstance->phase = SQUEEZING;
+    return 0;
+}
+
+/**
+  * Function to squeeze output data.
+  * @param  ktInstance     Pointer to the hash instance initialized by KangarooTwelve_Initialize().
+  * @param  data           Pointer to the buffer where to store the output data.
+  * @param  outputByteLen  The number of output bytes desired.
+  * @pre    KangarooTwelve_Final() must have been already called.
+  * @return 0 if successful, 1 otherwise.
+  */
+int KangarooTwelve_Squeeze(KangarooTwelve_Instance* ktInstance, unsigned char* output, size_t outputByteLen)
+{
+    if (ktInstance->phase != SQUEEZING)
+        return 1;
+    TurboSHAKE_Squeeze(&ktInstance->finalNode, output, outputByteLen);
+    return 0;
+}
+
+/** Extendable ouput function KangarooTwelve.
+* @param  input           Pointer to the input message (M).
+* @param  inputByteLen    The length of the input message in bytes.
+* @param  output          Pointer to the output buffer.
+* @param  outputByteLen   The desired number of output bytes.
+* @param  customization   Pointer to the customization string (C).
+* @param  customByteLen   The length of the customization string in bytes.
+* @param  securityLevel   The desired security strength level (128 bits or 256 bits).
+* @return 0 if successful, 1 otherwise.
+*/
+
+int KangarooTwelveXKPC(int securityLevel, const unsigned char* input, size_t inputByteLen,
+    unsigned char* output, size_t outputByteLen,
+    const unsigned char* customization, size_t customByteLen)
+{
+    KangarooTwelve_Instance ktInstance;
+
+    if (outputByteLen == 0)
+        return 1;
+    KangarooTwelve_Initialize(&ktInstance, securityLevel, outputByteLen);
+    if (KangarooTwelve_Update(&ktInstance, input, inputByteLen) != 0)
+        return 1;
+    return KangarooTwelve_Final(&ktInstance, output, customization, customByteLen);
+}
+
+
+/**
+ * Wrapper around `KangarooTwelve` to use the 128-bit security level and no customization String.
+*/
+static void KangarooTwelve(const unsigned char* input, unsigned int inputByteLen, unsigned char* output, unsigned int outputByteLen)
+{
+    unsigned char a = 'a';
+    int sts = KangarooTwelveXKPC(128, input, (size_t)inputByteLen, output, (size_t) outputByteLen, &a, 0);
+}
+
+
+static void random(const unsigned char* publicKey, const unsigned char* nonce, unsigned char* output, unsigned long long outputSize)
+{
+    unsigned char state[200];
+    *((__m256i*) & state[0]) = *((__m256i*)publicKey);
+    *((__m256i*) & state[32]) = *((__m256i*)nonce);
+    setMem(&state[64], sizeof(state) - 64, 0);
+
+    for (unsigned long long i = 0; i < outputSize / sizeof(state); i++)
+    {
+        K12xkcp::KeccakP1600_Permute_12rounds(state);
+        copyMem(output, state, sizeof(state));
+        output += sizeof(state);
+    }
+    if (outputSize % sizeof(state))
+    {
+        K12xkcp::KeccakP1600_Permute_12rounds(state);
+        copyMem(output, state, outputSize % sizeof(state));
+    }
+}
+
+#ifdef __AVX512F__
+
+/*
+* This part is get from
+https://github.com/XKCP/K12/blob/master/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
+
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+The Keccak-p permutations, designed by Guido Bertoni, Joan Daemen, Micha�l Peeters and Gilles Van Assche.
+
+Implementation by Ronny Van Keer, hereby denoted as "the implementer".
+
+For more information, feedback or questions, please refer to the Keccak Team website:
+https://keccak.team/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+
+---
+
+We would like to thank Vladimir Sedach, we have used parts of his Keccak AVX-512 C++ code.
+ */
+
+
+// #define KeccakP1600_12rounds_FastLoop_supported
+
+//#define K12_security        128
+//#define K12_capacity        (2 * K12_security)
+//#define K12_capacityInBytes (K12_capacity / 8)
+//#define K12_rateInBytes     ((1600 - K12_capacity) / 8)
+//#define K12_chunkSize       8192
+//#define K12_suffixLeaf      0x0B
+
+
+typedef __m512i     V512;
+
+#define XOR(a,b)                    _mm512_xor_si512(a,b)
+#define XOR3(a,b,c)                 _mm512_ternarylogic_epi64(a,b,c,0x96)
+#define XOR5(a,b,c,d,e)             XOR3(XOR3(a,b,c),d,e)
+#define ROL(a,offset)               _mm512_rol_epi64(a,offset)
+#define Chi(a,b,c)                  _mm512_ternarylogic_epi64(a,b,c,0xD2)
+
+#define LOAD_Lanes(m,a)             _mm512_maskz_loadu_epi64(m,a)
+#define LOAD_Lane(a)                LOAD_Lanes(0x01,a)
+#define LOAD_Plane(a)               LOAD_Lanes(0x1F,a)
+#define LOAD_8Lanes(a)              LOAD_Lanes(0xFF,a)
+#define STORE_Lanes(a,m,v)          _mm512_mask_storeu_epi64(a,m,v)
+#define STORE_Lane(a,v)             STORE_Lanes(a,0x01,v)
+#define STORE_Plane(a,v)            STORE_Lanes(a,0x1F,v)
+#define STORE_8Lanes(a,v)           STORE_Lanes(a,0xFF,v)
+
+#define KeccakP_DeclareVars \
+    V512    b0, b1, b2, b3, b4; \
+    V512    Baeiou, Gaeiou, Kaeiou, Maeiou, Saeiou; \
+    V512    moveThetaPrev = _mm512_setr_epi64(4, 0, 1, 2, 3, 5, 6, 7); \
+    V512    moveThetaNext = _mm512_setr_epi64(1, 2, 3, 4, 0, 5, 6, 7); \
+    V512    rhoB = _mm512_setr_epi64( 0,  1, 62, 28, 27, 0, 0, 0); \
+    V512    rhoG = _mm512_setr_epi64(36, 44,  6, 55, 20, 0, 0, 0); \
+    V512    rhoK = _mm512_setr_epi64( 3, 10, 43, 25, 39, 0, 0, 0); \
+    V512    rhoM = _mm512_setr_epi64(41, 45, 15, 21,  8, 0, 0, 0); \
+    V512    rhoS = _mm512_setr_epi64(18,  2, 61, 56, 14, 0, 0, 0); \
+    V512    pi1B = _mm512_setr_epi64(0, 3, 1, 4, 2, 5, 6, 7); \
+    V512    pi1G = _mm512_setr_epi64(1, 4, 2, 0, 3, 5, 6, 7); \
+    V512    pi1K = _mm512_setr_epi64(2, 0, 3, 1, 4, 5, 6, 7); \
+    V512    pi1M = _mm512_setr_epi64(3, 1, 4, 2, 0, 5, 6, 7); \
+    V512    pi1S = _mm512_setr_epi64(4, 2, 0, 3, 1, 5, 6, 7); \
+    V512    pi2S1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 0+8, 2+8); \
+    V512    pi2S2 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 1+8, 3+8); \
+    V512    pi2BG = _mm512_setr_epi64(0, 1, 0+8, 1+8, 6, 5, 6, 7); \
+    V512    pi2KM = _mm512_setr_epi64(2, 3, 2+8, 3+8, 7, 5, 6, 7); \
+    V512    pi2S3 = _mm512_setr_epi64(4, 5, 4+8, 5+8, 4, 5, 6, 7);
+
+#define KeccakP_DeclareVars2 \
+    V512    b0, b1, b2, b3, b4; \
+    V512    moveThetaPrev = _mm512_setr_epi64(4, 0, 1, 2, 3, 5, 6, 7); \
+    V512    moveThetaNext = _mm512_setr_epi64(1, 2, 3, 4, 0, 5, 6, 7); \
+    V512    rhoB = _mm512_setr_epi64( 0,  1, 62, 28, 27, 0, 0, 0); \
+    V512    rhoG = _mm512_setr_epi64(36, 44,  6, 55, 20, 0, 0, 0); \
+    V512    rhoK = _mm512_setr_epi64( 3, 10, 43, 25, 39, 0, 0, 0); \
+    V512    rhoM = _mm512_setr_epi64(41, 45, 15, 21,  8, 0, 0, 0); \
+    V512    rhoS = _mm512_setr_epi64(18,  2, 61, 56, 14, 0, 0, 0); \
+    V512    pi1B = _mm512_setr_epi64(0, 3, 1, 4, 2, 5, 6, 7); \
+    V512    pi1G = _mm512_setr_epi64(1, 4, 2, 0, 3, 5, 6, 7); \
+    V512    pi1K = _mm512_setr_epi64(2, 0, 3, 1, 4, 5, 6, 7); \
+    V512    pi1M = _mm512_setr_epi64(3, 1, 4, 2, 0, 5, 6, 7); \
+    V512    pi1S = _mm512_setr_epi64(4, 2, 0, 3, 1, 5, 6, 7); \
+    V512    pi2S1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 0+8, 2+8); \
+    V512    pi2S2 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 1+8, 3+8); \
+    V512    pi2BG = _mm512_setr_epi64(0, 1, 0+8, 1+8, 6, 5, 6, 7); \
+    V512    pi2KM = _mm512_setr_epi64(2, 3, 2+8, 3+8, 7, 5, 6, 7); \
+    V512    pi2S3 = _mm512_setr_epi64(4, 5, 4+8, 5+8, 4, 5, 6, 7);
+
+#define copyFromState_xkpc_AVX512(pState) \
+    Baeiou = LOAD_Plane(pState+ 0); \
+    Gaeiou = LOAD_Plane(pState+ 5); \
+    Kaeiou = LOAD_Plane(pState+10); \
+    Maeiou = LOAD_Plane(pState+15); \
+    Saeiou = LOAD_Plane(pState+20);
+
+#define copyToState_xkpc_AVX512(pState) \
+    STORE_Plane(pState+ 0, Baeiou); \
+    STORE_Plane(pState+ 5, Gaeiou); \
+    STORE_Plane(pState+10, Kaeiou); \
+    STORE_Plane(pState+15, Maeiou); \
+    STORE_Plane(pState+20, Saeiou);
+
+#define KeccakP_Round(i) \
+    /* Theta */ \
+    b0 = XOR5( Baeiou, Gaeiou, Kaeiou, Maeiou, Saeiou ); \
+    b1 = _mm512_permutexvar_epi64(moveThetaPrev, b0); \
+    b0 = _mm512_permutexvar_epi64(moveThetaNext, b0); \
+    b0 = _mm512_rol_epi64(b0, 1); \
+    Baeiou = XOR3( Baeiou, b0, b1 ); \
+    Gaeiou = XOR3( Gaeiou, b0, b1 ); \
+    Kaeiou = XOR3( Kaeiou, b0, b1 ); \
+    Maeiou = XOR3( Maeiou, b0, b1 ); \
+    Saeiou = XOR3( Saeiou, b0, b1 ); \
+    /* Rho */ \
+    Baeiou = _mm512_rolv_epi64(Baeiou, rhoB); \
+    Gaeiou = _mm512_rolv_epi64(Gaeiou, rhoG); \
+    Kaeiou = _mm512_rolv_epi64(Kaeiou, rhoK); \
+    Maeiou = _mm512_rolv_epi64(Maeiou, rhoM); \
+    Saeiou = _mm512_rolv_epi64(Saeiou, rhoS); \
+    /* Pi 1 */ \
+    b0 = _mm512_permutexvar_epi64(pi1B, Baeiou); \
+    b1 = _mm512_permutexvar_epi64(pi1G, Gaeiou); \
+    b2 = _mm512_permutexvar_epi64(pi1K, Kaeiou); \
+    b3 = _mm512_permutexvar_epi64(pi1M, Maeiou); \
+    b4 = _mm512_permutexvar_epi64(pi1S, Saeiou); \
+    /* Chi */ \
+    Baeiou = Chi(b0, b1, b2); \
+    Gaeiou = Chi(b1, b2, b3); \
+    Kaeiou = Chi(b2, b3, b4); \
+    Maeiou = Chi(b3, b4, b0); \
+    Saeiou = Chi(b4, b0, b1); \
+    /* Iota */ \
+    Baeiou = XOR(Baeiou, LOAD_Lane(K12xkcp::KeccakP1600RoundConstants+i)); \
+    /* Pi 2 */ \
+    b0 = _mm512_unpacklo_epi64(Baeiou, Gaeiou); \
+    b1 = _mm512_unpacklo_epi64(Kaeiou, Maeiou); \
+    b0 = _mm512_permutex2var_epi64(b0, pi2S1, Saeiou); \
+    b2 = _mm512_unpackhi_epi64(Baeiou, Gaeiou); \
+    b3 = _mm512_unpackhi_epi64(Kaeiou, Maeiou); \
+    b2 = _mm512_permutex2var_epi64(b2, pi2S2, Saeiou); \
+    Baeiou = _mm512_permutex2var_epi64(b0, pi2BG, b1); \
+    Gaeiou = _mm512_permutex2var_epi64(b2, pi2BG, b3); \
+    Kaeiou = _mm512_permutex2var_epi64(b0, pi2KM, b1); \
+    Maeiou = _mm512_permutex2var_epi64(b2, pi2KM, b3); \
+    b0 = _mm512_permutex2var_epi64(b0, pi2S3, b1); \
+    Saeiou = _mm512_mask_blend_epi64(0x10, b0, Saeiou)
+
+
+#define rounds12_xkpc_AVX512 \
+    KeccakP_Round( 12 ); \
+    KeccakP_Round( 13 ); \
+    KeccakP_Round( 14 ); \
+    KeccakP_Round( 15 ); \
+    KeccakP_Round( 16 ); \
+    KeccakP_Round( 17 ); \
+    KeccakP_Round( 18 ); \
+    KeccakP_Round( 19 ); \
+    KeccakP_Round( 20 ); \
+    KeccakP_Round( 21 ); \
+    KeccakP_Round( 22 ); \
+    KeccakP_Round( 23 )
+
+namespace K12xkcp
+{
+
+    /* ---------------------------------------------------------------- */
+
+    void KeccakP1600_Initialize(void* state)
+    {
+        setMem(state, 200, 0);
+    }
+
+    /* ---------------------------------------------------------------- */
+
+    void KeccakP1600_AddBytes(void* state, const unsigned char* data, unsigned int offset, unsigned int length)
+    {
+        unsigned char* stateAsBytes;
+        unsigned long long* stateAsLanes;
+
+        for (stateAsBytes = (unsigned char*)state; ((offset % 8) != 0) && (length != 0); ++offset, --length)
+            stateAsBytes[offset] ^= *(data++);
+        for (stateAsLanes = (unsigned long long*)(stateAsBytes + offset); length >= 8 * 8; stateAsLanes += 8, data += 8 * 8, length -= 8 * 8)
+            STORE_8Lanes(stateAsLanes, XOR(LOAD_8Lanes(stateAsLanes), LOAD_8Lanes((const unsigned long long*)data)));
+        for (/* empty */; length >= 8; ++stateAsLanes, data += 8, length -= 8)
+            STORE_Lane(stateAsLanes, XOR(LOAD_Lane(stateAsLanes), LOAD_Lane((const unsigned long long*)data)));
+        for (stateAsBytes = (unsigned char*)stateAsLanes; length != 0; --length)
+            *(stateAsBytes++) ^= *(data++);
+    }
+
+    /* ---------------------------------------------------------------- */
+
+    void KeccakP1600_ExtractBytes(const void* state, unsigned char* data, unsigned int offset, unsigned int length)
+    {
+        copyMem(data, (unsigned char*)state + offset, length);
+    }
+
+    void KeccakP1600_AddByte(void* state, unsigned char data, unsigned int offset)
+    {
+        ((unsigned char*)(state))[offset] ^= data;
+    }
+
+    /* ---------------------------------------------------------------- */
+
+    const unsigned long long KeccakP1600RoundConstants[24] = {
+        0x0000000000000001ULL,
+        0x0000000000008082ULL,
+        0x800000000000808aULL,
+        0x8000000080008000ULL,
+        0x000000000000808bULL,
+        0x0000000080000001ULL,
+        0x8000000080008081ULL,
+        0x8000000000008009ULL,
+        0x000000000000008aULL,
+        0x0000000000000088ULL,
+        0x0000000080008009ULL,
+        0x000000008000000aULL,
+        0x000000008000808bULL,
+        0x800000000000008bULL,
+        0x8000000000008089ULL,
+        0x8000000000008003ULL,
+        0x8000000000008002ULL,
+        0x8000000000000080ULL,
+        0x000000000000800aULL,
+        0x800000008000000aULL,
+        0x8000000080008081ULL,
+        0x8000000000008080ULL,
+        0x0000000080000001ULL,
+        0x8000000080008008ULL };
+
+    /* ---------------------------------------------------------------- */
+
+    void KeccakP1600_Permute_12rounds(void* state)
+    {
+        KeccakP_DeclareVars
+            unsigned long long* stateAsLanes = (unsigned long long*)state;
+
+        copyFromState_xkpc_AVX512(stateAsLanes);
+        rounds12_xkpc_AVX512;
+        copyToState_xkpc_AVX512(stateAsLanes);
+    }
+
+    size_t KeccakP1600_12rounds_FastLoop_Absorb(void* state, unsigned int laneCount, const unsigned char* data, size_t dataByteLen)
+    {
+        size_t originalDataByteLen = dataByteLen;
+
+        KeccakP_DeclareVars
+        unsigned long long* stateAsLanes = (unsigned long long*)state;
+        unsigned long long* inDataAsLanes = (unsigned long long*)data;
+
+        if (laneCount == 21) {
+#define laneCount 21
+            copyToState_xkpc_AVX512(stateAsLanes);
+            while (dataByteLen >= 21 * 8) {
+                Baeiou = XOR(Baeiou, LOAD_Plane(inDataAsLanes + 0));
+                Gaeiou = XOR(Gaeiou, LOAD_Plane(inDataAsLanes + 5));
+                Kaeiou = XOR(Kaeiou, LOAD_Plane(inDataAsLanes + 10));
+                Maeiou = XOR(Maeiou, LOAD_Plane(inDataAsLanes + 15));
+                Saeiou = XOR(Saeiou, LOAD_Lane(inDataAsLanes + 20));
+                rounds12_xkpc_AVX512;
+                inDataAsLanes += 21;
+                dataByteLen -= 21 * 8;
+            }
+#undef laneCount
+            copyToState_xkpc_AVX512(stateAsLanes);
+        }
+        else if (laneCount == 17) {
+            // TODO: further optimization needed for this case, laneCount == 17.
+            while (dataByteLen >= laneCount * 8) {
+                KeccakP1600_AddBytes(state, data, 0, laneCount * 8);
+                KeccakP1600_Permute_12rounds(state);
+                data += laneCount * 8;
+                dataByteLen -= laneCount * 8;
+            }
+        }
+
+        return originalDataByteLen - dataByteLen;
+    }
+
+
+
+
+    /* ---------------------------------------------------------------- */
+
+
+}
+
+
+#elif defined(__AVX2__)
+// XKCP AVX2 Implementation uses ASM Code in GCC syntax hence it is not applicable with MSVC at the moment hence we have to use the opt64 version
+
+
+#include "brg_endian.h"
+
+#define KeccakP1600_opt64_implementation_config "all rounds unrolled"
+#define KeccakP1600_opt64_fullUnrolling
+
+#define ROL64(a, offset) _rotl64(a, offset)
+
+static const unsigned long long KeccakF1600RoundConstants[24] = {
+    0x0000000000000001ULL,
+    0x0000000000008082ULL,
+    0x800000000000808aULL,
+    0x8000000080008000ULL,
+    0x000000000000808bULL,
+    0x0000000080000001ULL,
+    0x8000000080008081ULL,
+    0x8000000000008009ULL,
+    0x000000000000008aULL,
+    0x0000000000000088ULL,
+    0x0000000080008009ULL,
+    0x000000008000000aULL,
+    0x000000008000808bULL,
+    0x800000000000008bULL,
+    0x8000000000008089ULL,
+    0x8000000000008003ULL,
+    0x8000000000008002ULL,
+    0x8000000000000080ULL,
+    0x000000000000800aULL,
+    0x800000008000000aULL,
+    0x8000000080008081ULL,
+    0x8000000000008080ULL,
+    0x0000000080000001ULL,
+    0x8000000080008008ULL };
+
+
+
+
+#define declareABCDE \
+    unsigned long long Aba, Abe, Abi, Abo, Abu; \
+    unsigned long long Aga, Age, Agi, Ago, Agu; \
+    unsigned long long Aka, Ake, Aki, Ako, Aku; \
+    unsigned long long Ama, Ame, Ami, Amo, Amu; \
+    unsigned long long Asa, Ase, Asi, Aso, Asu; \
+    unsigned long long Bba, Bbe, Bbi, Bbo, Bbu; \
+    unsigned long long Bga, Bge, Bgi, Bgo, Bgu; \
+    unsigned long long Bka, Bke, Bki, Bko, Bku; \
+    unsigned long long Bma, Bme, Bmi, Bmo, Bmu; \
+    unsigned long long Bsa, Bse, Bsi, Bso, Bsu; \
+    unsigned long long Ca, Ce, Ci, Co, Cu; \
+    unsigned long long Da, De, Di, Do, Du; \
+    unsigned long long Eba, Ebe, Ebi, Ebo, Ebu; \
+    unsigned long long Ega, Ege, Egi, Ego, Egu; \
+    unsigned long long Eka, Eke, Eki, Eko, Eku; \
+    unsigned long long Ema, Eme, Emi, Emo, Emu; \
+    unsigned long long Esa, Ese, Esi, Eso, Esu; \
+
+#define prepareTheta \
+    Ca = Aba^Aga^Aka^Ama^Asa; \
+    Ce = Abe^Age^Ake^Ame^Ase; \
+    Ci = Abi^Agi^Aki^Ami^Asi; \
+    Co = Abo^Ago^Ako^Amo^Aso; \
+    Cu = Abu^Agu^Aku^Amu^Asu; \
+
+
+#define thetaRhoPiChiIotaPrepareTheta(i, A, E) \
+    Da = Cu^ROL64(Ce, 1); \
+    De = Ca^ROL64(Ci, 1); \
+    Di = Ce^ROL64(Co, 1); \
+    Do = Ci^ROL64(Cu, 1); \
+    Du = Co^ROL64(Ca, 1); \
+\
+    A##ba ^= Da; \
+    Bba = A##ba; \
+    A##ge ^= De; \
+    Bbe = ROL64(A##ge, 44); \
+    A##ki ^= Di; \
+    Bbi = ROL64(A##ki, 43); \
+    A##mo ^= Do; \
+    Bbo = ROL64(A##mo, 21); \
+    A##su ^= Du; \
+    Bbu = ROL64(A##su, 14); \
+    E##ba =   Bba ^((~Bbe)&  Bbi ); \
+    E##ba ^= KeccakF1600RoundConstants[i]; \
+    Ca = E##ba; \
+    E##be =   Bbe ^((~Bbi)&  Bbo ); \
+    Ce = E##be; \
+    E##bi =   Bbi ^((~Bbo)&  Bbu ); \
+    Ci = E##bi; \
+    E##bo =   Bbo ^((~Bbu)&  Bba ); \
+    Co = E##bo; \
+    E##bu =   Bbu ^((~Bba)&  Bbe ); \
+    Cu = E##bu; \
+\
+    A##bo ^= Do; \
+    Bga = ROL64(A##bo, 28); \
+    A##gu ^= Du; \
+    Bge = ROL64(A##gu, 20); \
+    A##ka ^= Da; \
+    Bgi = ROL64(A##ka, 3); \
+    A##me ^= De; \
+    Bgo = ROL64(A##me, 45); \
+    A##si ^= Di; \
+    Bgu = ROL64(A##si, 61); \
+    E##ga =   Bga ^((~Bge)&  Bgi ); \
+    Ca ^= E##ga; \
+    E##ge =   Bge ^((~Bgi)&  Bgo ); \
+    Ce ^= E##ge; \
+    E##gi =   Bgi ^((~Bgo)&  Bgu ); \
+    Ci ^= E##gi; \
+    E##go =   Bgo ^((~Bgu)&  Bga ); \
+    Co ^= E##go; \
+    E##gu =   Bgu ^((~Bga)&  Bge ); \
+    Cu ^= E##gu; \
+\
+    A##be ^= De; \
+    Bka = ROL64(A##be, 1); \
+    A##gi ^= Di; \
+    Bke = ROL64(A##gi, 6); \
+    A##ko ^= Do; \
+    Bki = ROL64(A##ko, 25); \
+    A##mu ^= Du; \
+    Bko = ROL64(A##mu, 8); \
+    A##sa ^= Da; \
+    Bku = ROL64(A##sa, 18); \
+    E##ka =   Bka ^((~Bke)&  Bki ); \
+    Ca ^= E##ka; \
+    E##ke =   Bke ^((~Bki)&  Bko ); \
+    Ce ^= E##ke; \
+    E##ki =   Bki ^((~Bko)&  Bku ); \
+    Ci ^= E##ki; \
+    E##ko =   Bko ^((~Bku)&  Bka ); \
+    Co ^= E##ko; \
+    E##ku =   Bku ^((~Bka)&  Bke ); \
+    Cu ^= E##ku; \
+\
+    A##bu ^= Du; \
+    Bma = ROL64(A##bu, 27); \
+    A##ga ^= Da; \
+    Bme = ROL64(A##ga, 36); \
+    A##ke ^= De; \
+    Bmi = ROL64(A##ke, 10); \
+    A##mi ^= Di; \
+    Bmo = ROL64(A##mi, 15); \
+    A##so ^= Do; \
+    Bmu = ROL64(A##so, 56); \
+    E##ma =   Bma ^((~Bme)&  Bmi ); \
+    Ca ^= E##ma; \
+    E##me =   Bme ^((~Bmi)&  Bmo ); \
+    Ce ^= E##me; \
+    E##mi =   Bmi ^((~Bmo)&  Bmu ); \
+    Ci ^= E##mi; \
+    E##mo =   Bmo ^((~Bmu)&  Bma ); \
+    Co ^= E##mo; \
+    E##mu =   Bmu ^((~Bma)&  Bme ); \
+    Cu ^= E##mu; \
+\
+    A##bi ^= Di; \
+    Bsa = ROL64(A##bi, 62); \
+    A##go ^= Do; \
+    Bse = ROL64(A##go, 55); \
+    A##ku ^= Du; \
+    Bsi = ROL64(A##ku, 39); \
+    A##ma ^= Da; \
+    Bso = ROL64(A##ma, 41); \
+    A##se ^= De; \
+    Bsu = ROL64(A##se, 2); \
+    E##sa =   Bsa ^((~Bse)&  Bsi ); \
+    Ca ^= E##sa; \
+    E##se =   Bse ^((~Bsi)&  Bso ); \
+    Ce ^= E##se; \
+    E##si =   Bsi ^((~Bso)&  Bsu ); \
+    Ci ^= E##si; \
+    E##so =   Bso ^((~Bsu)&  Bsa ); \
+    Co ^= E##so; \
+    E##su =   Bsu ^((~Bsa)&  Bse ); \
+    Cu ^= E##su; \
+\
+
+/* --- Code for round */
+/* --- 64-bit lanes mapped to 64-bit words */
+#define thetaRhoPiChiIota(i, A, E) \
+    Da = Cu^ROL64(Ce, 1); \
+    De = Ca^ROL64(Ci, 1); \
+    Di = Ce^ROL64(Co, 1); \
+    Do = Ci^ROL64(Cu, 1); \
+    Du = Co^ROL64(Ca, 1); \
+\
+    A##ba ^= Da; \
+    Bba = A##ba; \
+    A##ge ^= De; \
+    Bbe = ROL64(A##ge, 44); \
+    A##ki ^= Di; \
+    Bbi = ROL64(A##ki, 43); \
+    A##mo ^= Do; \
+    Bbo = ROL64(A##mo, 21); \
+    A##su ^= Du; \
+    Bbu = ROL64(A##su, 14); \
+    E##ba =   Bba ^((~Bbe)&  Bbi ); \
+    E##ba ^= KeccakF1600RoundConstants[i]; \
+    E##be =   Bbe ^((~Bbi)&  Bbo ); \
+    E##bi =   Bbi ^((~Bbo)&  Bbu ); \
+    E##bo =   Bbo ^((~Bbu)&  Bba ); \
+    E##bu =   Bbu ^((~Bba)&  Bbe ); \
+\
+    A##bo ^= Do; \
+    Bga = ROL64(A##bo, 28); \
+    A##gu ^= Du; \
+    Bge = ROL64(A##gu, 20); \
+    A##ka ^= Da; \
+    Bgi = ROL64(A##ka, 3); \
+    A##me ^= De; \
+    Bgo = ROL64(A##me, 45); \
+    A##si ^= Di; \
+    Bgu = ROL64(A##si, 61); \
+    E##ga =   Bga ^((~Bge)&  Bgi ); \
+    E##ge =   Bge ^((~Bgi)&  Bgo ); \
+    E##gi =   Bgi ^((~Bgo)&  Bgu ); \
+    E##go =   Bgo ^((~Bgu)&  Bga ); \
+    E##gu =   Bgu ^((~Bga)&  Bge ); \
+\
+    A##be ^= De; \
+    Bka = ROL64(A##be, 1); \
+    A##gi ^= Di; \
+    Bke = ROL64(A##gi, 6); \
+    A##ko ^= Do; \
+    Bki = ROL64(A##ko, 25); \
+    A##mu ^= Du; \
+    Bko = ROL64(A##mu, 8); \
+    A##sa ^= Da; \
+    Bku = ROL64(A##sa, 18); \
+    E##ka =   Bka ^((~Bke)&  Bki ); \
+    E##ke =   Bke ^((~Bki)&  Bko ); \
+    E##ki =   Bki ^((~Bko)&  Bku ); \
+    E##ko =   Bko ^((~Bku)&  Bka ); \
+    E##ku =   Bku ^((~Bka)&  Bke ); \
+\
+    A##bu ^= Du; \
+    Bma = ROL64(A##bu, 27); \
+    A##ga ^= Da; \
+    Bme = ROL64(A##ga, 36); \
+    A##ke ^= De; \
+    Bmi = ROL64(A##ke, 10); \
+    A##mi ^= Di; \
+    Bmo = ROL64(A##mi, 15); \
+    A##so ^= Do; \
+    Bmu = ROL64(A##so, 56); \
+    E##ma =   Bma ^((~Bme)&  Bmi ); \
+    E##me =   Bme ^((~Bmi)&  Bmo ); \
+    E##mi =   Bmi ^((~Bmo)&  Bmu ); \
+    E##mo =   Bmo ^((~Bmu)&  Bma ); \
+    E##mu =   Bmu ^((~Bma)&  Bme ); \
+\
+    A##bi ^= Di; \
+    Bsa = ROL64(A##bi, 62); \
+    A##go ^= Do; \
+    Bse = ROL64(A##go, 55); \
+    A##ku ^= Du; \
+    Bsi = ROL64(A##ku, 39); \
+    A##ma ^= Da; \
+    Bso = ROL64(A##ma, 41); \
+    A##se ^= De; \
+    Bsu = ROL64(A##se, 2); \
+    E##sa =   Bsa ^((~Bse)&  Bsi ); \
+    E##se =   Bse ^((~Bsi)&  Bso ); \
+    E##si =   Bsi ^((~Bso)&  Bsu ); \
+    E##so =   Bso ^((~Bsu)&  Bsa ); \
+    E##su =   Bsu ^((~Bsa)&  Bse ); \
+\
+
+
+#define copyFromState(X, state) \
+    X##ba = state[ 0]; \
+    X##be = state[ 1]; \
+    X##bi = state[ 2]; \
+    X##bo = state[ 3]; \
+    X##bu = state[ 4]; \
+    X##ga = state[ 5]; \
+    X##ge = state[ 6]; \
+    X##gi = state[ 7]; \
+    X##go = state[ 8]; \
+    X##gu = state[ 9]; \
+    X##ka = state[10]; \
+    X##ke = state[11]; \
+    X##ki = state[12]; \
+    X##ko = state[13]; \
+    X##ku = state[14]; \
+    X##ma = state[15]; \
+    X##me = state[16]; \
+    X##mi = state[17]; \
+    X##mo = state[18]; \
+    X##mu = state[19]; \
+    X##sa = state[20]; \
+    X##se = state[21]; \
+    X##si = state[22]; \
+    X##so = state[23]; \
+    X##su = state[24]; \
+
+#define copyToState(state, X) \
+    state[ 0] = X##ba; \
+    state[ 1] = X##be; \
+    state[ 2] = X##bi; \
+    state[ 3] = X##bo; \
+    state[ 4] = X##bu; \
+    state[ 5] = X##ga; \
+    state[ 6] = X##ge; \
+    state[ 7] = X##gi; \
+    state[ 8] = X##go; \
+    state[ 9] = X##gu; \
+    state[10] = X##ka; \
+    state[11] = X##ke; \
+    state[12] = X##ki; \
+    state[13] = X##ko; \
+    state[14] = X##ku; \
+    state[15] = X##ma; \
+    state[16] = X##me; \
+    state[17] = X##mi; \
+    state[18] = X##mo; \
+    state[19] = X##mu; \
+    state[20] = X##sa; \
+    state[21] = X##se; \
+    state[22] = X##si; \
+    state[23] = X##so; \
+    state[24] = X##su; \
+
+#define copyStateVariables(X, Y) \
+    X##ba = Y##ba; \
+    X##be = Y##be; \
+    X##bi = Y##bi; \
+    X##bo = Y##bo; \
+    X##bu = Y##bu; \
+    X##ga = Y##ga; \
+    X##ge = Y##ge; \
+    X##gi = Y##gi; \
+    X##go = Y##go; \
+    X##gu = Y##gu; \
+    X##ka = Y##ka; \
+    X##ke = Y##ke; \
+    X##ki = Y##ki; \
+    X##ko = Y##ko; \
+    X##ku = Y##ku; \
+    X##ma = Y##ma; \
+    X##me = Y##me; \
+    X##mi = Y##mi; \
+    X##mo = Y##mo; \
+    X##mu = Y##mu; \
+    X##sa = Y##sa; \
+    X##se = Y##se; \
+    X##si = Y##si; \
+    X##so = Y##so; \
+    X##su = Y##su; \
+
+
+#define rounds12 \
+    prepareTheta \
+    thetaRhoPiChiIotaPrepareTheta(12, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(13, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(14, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(15, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(16, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(17, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(18, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(19, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(20, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(21, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(22, A, E) \
+    thetaRhoPiChiIota(23, E, A) \
+
+namespace K12xkcp
+{
+    
+    void KeccakP1600_Initialize(void *state)
+    {
+        setMem(state, 200, 0);
+    }
+
+
+
+    void KeccakP1600_AddBytesInLane(void *state, unsigned int lanePosition, const unsigned char *data, unsigned int offset, unsigned int length)
+    {
+    #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+        uint64_t lane;
+        if (length == 0)
+            return;
+        if (length == 1)
+            lane = data[0];
+        else {
+            lane = 0;
+            copyMem(&lane, data, length);
+        }
+        lane <<= offset*8;
+    #else
+        uint64_t lane = 0;
+        unsigned int i;
+        for(i=0; i<length; i++)
+            lane |= ((uint64_t)data[i]) << ((i+offset)*8);
+    #endif
+        ((uint64_t*)state)[lanePosition] ^= lane;
+    }
+
+
+
+    static void KeccakP1600_AddLanes(void *state, const unsigned char *data, unsigned int laneCount)
+    {
+    #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+        unsigned int i = 0;
+    #ifdef NO_MISALIGNED_ACCESSES
+        /* If either pointer is misaligned, fall back to byte-wise xor. */
+        if (((((uintptr_t)state) & 7) != 0) || ((((uintptr_t)data) & 7) != 0)) {
+        for (i = 0; i < laneCount * 8; i++) {
+            ((unsigned char*)state)[i] ^= data[i];
+        }
+        }
+        else
+    #endif
+        {
+        /* Otherwise... */
+        for( ; (i+8)<=laneCount; i+=8) {
+            ((uint64_t*)state)[i+0] ^= ((uint64_t*)data)[i+0];
+            ((uint64_t*)state)[i+1] ^= ((uint64_t*)data)[i+1];
+            ((uint64_t*)state)[i+2] ^= ((uint64_t*)data)[i+2];
+            ((uint64_t*)state)[i+3] ^= ((uint64_t*)data)[i+3];
+            ((uint64_t*)state)[i+4] ^= ((uint64_t*)data)[i+4];
+            ((uint64_t*)state)[i+5] ^= ((uint64_t*)data)[i+5];
+            ((uint64_t*)state)[i+6] ^= ((uint64_t*)data)[i+6];
+            ((uint64_t*)state)[i+7] ^= ((uint64_t*)data)[i+7];
+        }
+        for( ; (i+4)<=laneCount; i+=4) {
+            ((uint64_t*)state)[i+0] ^= ((uint64_t*)data)[i+0];
+            ((uint64_t*)state)[i+1] ^= ((uint64_t*)data)[i+1];
+            ((uint64_t*)state)[i+2] ^= ((uint64_t*)data)[i+2];
+            ((uint64_t*)state)[i+3] ^= ((uint64_t*)data)[i+3];
+        }
+        for( ; (i+2)<=laneCount; i+=2) {
+            ((uint64_t*)state)[i+0] ^= ((uint64_t*)data)[i+0];
+            ((uint64_t*)state)[i+1] ^= ((uint64_t*)data)[i+1];
+        }
+        if (i<laneCount) {
+            ((uint64_t*)state)[i+0] ^= ((uint64_t*)data)[i+0];
+        }
+        }
+    #else
+        unsigned int i;
+        const uint8_t *curData = data;
+        for(i=0; i<laneCount; i++, curData+=8) {
+            uint64_t lane = (uint64_t)curData[0]
+                | ((uint64_t)curData[1] <<  8)
+                | ((uint64_t)curData[2] << 16)
+                | ((uint64_t)curData[3] << 24)
+                | ((uint64_t)curData[4] << 32)
+                | ((uint64_t)curData[5] << 40)
+                | ((uint64_t)curData[6] << 48)
+                | ((uint64_t)curData[7] << 56);
+            ((uint64_t*)state)[i] ^= lane;
+        }
+    #endif
+    }
+
+
+    void KeccakP1600_AddByte(void *state, unsigned char byte, unsigned int offset)
+    {
+    #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+        ((unsigned char*)(state))[offset] ^= byte;
+    #else
+        uint64_t lane = byte;
+        lane <<= (offset%8)*8;
+        ((uint64_t*)state)[offset/8] ^= lane;
+    #endif
+    }
+    
+    #define SnP_AddBytes(state, data, offset, length, SnP_AddLanes, SnP_AddBytesInLane, SnP_laneLengthInBytes) \
+        { \
+            if ((offset) == 0) { \
+                SnP_AddLanes(state, data, (length)/SnP_laneLengthInBytes); \
+                SnP_AddBytesInLane(state, \
+                    (length)/SnP_laneLengthInBytes, \
+                    (data)+((length)/SnP_laneLengthInBytes)*SnP_laneLengthInBytes, \
+                    0, \
+                    (length)%SnP_laneLengthInBytes); \
+            } \
+            else { \
+                unsigned int _sizeLeft = (length); \
+                unsigned int _lanePosition = (offset)/SnP_laneLengthInBytes; \
+                unsigned int _offsetInLane = (offset)%SnP_laneLengthInBytes; \
+                const unsigned char *_curData = (data); \
+                while(_sizeLeft > 0) { \
+                    unsigned int _bytesInLane = SnP_laneLengthInBytes - _offsetInLane; \
+                    if (_bytesInLane > _sizeLeft) \
+                        _bytesInLane = _sizeLeft; \
+                    SnP_AddBytesInLane(state, _lanePosition, _curData, _offsetInLane, _bytesInLane); \
+                    _sizeLeft -= _bytesInLane; \
+                    _lanePosition++; \
+                    _offsetInLane = 0; \
+                    _curData += _bytesInLane; \
+                } \
+            } \
+        }
+
+    void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length)
+    {
+        SnP_AddBytes(state, data, offset, length, KeccakP1600_AddLanes, KeccakP1600_AddBytesInLane, 8);
+    }
+
+
+    void KeccakP1600_Permute_12rounds(void *state)
+    {
+        declareABCDE
+        /* #ifndef KeccakP1600_fullUnrolling */
+        /* unsigned int i; */
+        /* #endif */
+        uint64_t *stateAsLanes = (uint64_t*)state;
+
+        copyFromState(A, stateAsLanes)
+        rounds12
+        copyToState(stateAsLanes, A)
+    }
+
+
+    void KeccakP1600_ExtractBytesInLane(const void *state, unsigned int lanePosition, unsigned char *data, unsigned int offset, unsigned int length)
+    {
+        uint64_t lane = ((uint64_t*)state)[lanePosition];
+    #ifdef KeccakP1600_useLaneComplementing
+        if ((lanePosition == 1) || (lanePosition == 2) || (lanePosition == 8) || (lanePosition == 12) || (lanePosition == 17) || (lanePosition == 20))
+            lane = ~lane;
+    #endif
+    #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+        {
+            uint64_t lane1[1];
+            lane1[0] = lane;
+            copyMem(data, (uint8_t*)lane1+offset, length);
+        }
+    #else
+        unsigned int i;
+        lane >>= offset*8;
+        for(i=0; i<length; i++) {
+            data[i] = lane & 0xFF;
+            lane >>= 8;
+        }
+    #endif
+    }
+
+    
+    #if (PLATFORM_BYTE_ORDER != IS_LITTLE_ENDIAN)
+    static void fromWordToBytes(uint8_t *bytes, const uint64_t word)
+    {
+        unsigned int i;
+
+        for(i=0; i<(64/8); i++)
+            bytes[i] = (word >> (8*i)) & 0xFF;
+    }
+    #endif
+
+    void KeccakP1600_ExtractLanes(const void *state, unsigned char *data, unsigned int laneCount)
+    {
+    #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+        copyMem(data, state, laneCount*8);
+    #else
+        unsigned int i;
+
+        for(i=0; i<laneCount; i++)
+            fromWordToBytes(data+(i*8), ((const uint64_t*)state)[i]);
+    #endif
+    #ifdef KeccakP1600_useLaneComplementing
+        if (laneCount > 1) {
+            ((uint64_t*)data)[ 1] = ~((uint64_t*)data)[ 1];
+            if (laneCount > 2) {
+                ((uint64_t*)data)[ 2] = ~((uint64_t*)data)[ 2];
+                if (laneCount > 8) {
+                    ((uint64_t*)data)[ 8] = ~((uint64_t*)data)[ 8];
+                    if (laneCount > 12) {
+                        ((uint64_t*)data)[12] = ~((uint64_t*)data)[12];
+                        if (laneCount > 17) {
+                            ((uint64_t*)data)[17] = ~((uint64_t*)data)[17];
+                            if (laneCount > 20) {
+                                ((uint64_t*)data)[20] = ~((uint64_t*)data)[20];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    #endif
+    }
+
+    /* ---------------------------------------------------------------- */
+
+    #define SnP_ExtractBytes(state, data, offset, length, SnP_ExtractLanes, SnP_ExtractBytesInLane, SnP_laneLengthInBytes) \
+        { \
+            if ((offset) == 0) { \
+                SnP_ExtractLanes(state, data, (length)/SnP_laneLengthInBytes); \
+                SnP_ExtractBytesInLane(state, \
+                    (length)/SnP_laneLengthInBytes, \
+                    (data)+((length)/SnP_laneLengthInBytes)*SnP_laneLengthInBytes, \
+                    0, \
+                    (length)%SnP_laneLengthInBytes); \
+            } \
+            else { \
+                unsigned int _sizeLeft = (length); \
+                unsigned int _lanePosition = (offset)/SnP_laneLengthInBytes; \
+                unsigned int _offsetInLane = (offset)%SnP_laneLengthInBytes; \
+                unsigned char *_curData = (data); \
+                while(_sizeLeft > 0) { \
+                    unsigned int _bytesInLane = SnP_laneLengthInBytes - _offsetInLane; \
+                    if (_bytesInLane > _sizeLeft) \
+                        _bytesInLane = _sizeLeft; \
+                    SnP_ExtractBytesInLane(state, _lanePosition, _curData, _offsetInLane, _bytesInLane); \
+                    _sizeLeft -= _bytesInLane; \
+                    _lanePosition++; \
+                    _offsetInLane = 0; \
+                    _curData += _bytesInLane; \
+                } \
+            } \
+        }
+
+
+    void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length)
+    {
+        SnP_ExtractBytes(state, data, offset, length, KeccakP1600_ExtractLanes, KeccakP1600_ExtractBytesInLane, 8);
+    }
+
+    /* ---------------------------------------------------------------- */
+
+    #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+    #define HTOLE64(x) (x)
+    #else
+    #define HTOLE64(x) (\
+    ((x & 0xff00000000000000ull) >> 56) | \
+    ((x & 0x00ff000000000000ull) >> 40) | \
+    ((x & 0x0000ff0000000000ull) >> 24) | \
+    ((x & 0x000000ff00000000ull) >> 8)  | \
+    ((x & 0x00000000ff000000ull) << 8)  | \
+    ((x & 0x0000000000ff0000ull) << 24) | \
+    ((x & 0x000000000000ff00ull) << 40) | \
+    ((x & 0x00000000000000ffull) << 56))
+    #endif
+
+    #define addInput21(X, input, laneCount) \
+        if (laneCount == 21) { \
+            X##ba ^= HTOLE64(input[ 0]); \
+            X##be ^= HTOLE64(input[ 1]); \
+            X##bi ^= HTOLE64(input[ 2]); \
+            X##bo ^= HTOLE64(input[ 3]); \
+            X##bu ^= HTOLE64(input[ 4]); \
+            X##ga ^= HTOLE64(input[ 5]); \
+            X##ge ^= HTOLE64(input[ 6]); \
+            X##gi ^= HTOLE64(input[ 7]); \
+            X##go ^= HTOLE64(input[ 8]); \
+            X##gu ^= HTOLE64(input[ 9]); \
+            X##ka ^= HTOLE64(input[10]); \
+            X##ke ^= HTOLE64(input[11]); \
+            X##ki ^= HTOLE64(input[12]); \
+            X##ko ^= HTOLE64(input[13]); \
+            X##ku ^= HTOLE64(input[14]); \
+            X##ma ^= HTOLE64(input[15]); \
+            X##me ^= HTOLE64(input[16]); \
+            X##mi ^= HTOLE64(input[17]); \
+            X##mo ^= HTOLE64(input[18]); \
+            X##mu ^= HTOLE64(input[19]); \
+            X##sa ^= HTOLE64(input[20]); \
+        } \
+
+    #define addInput17(X, input, laneCount) \
+        if (laneCount == 17) { \
+            X##ba ^= HTOLE64(input[ 0]); \
+            X##be ^= HTOLE64(input[ 1]); \
+            X##bi ^= HTOLE64(input[ 2]); \
+            X##bo ^= HTOLE64(input[ 3]); \
+            X##bu ^= HTOLE64(input[ 4]); \
+            X##ga ^= HTOLE64(input[ 5]); \
+            X##ge ^= HTOLE64(input[ 6]); \
+            X##gi ^= HTOLE64(input[ 7]); \
+            X##go ^= HTOLE64(input[ 8]); \
+            X##gu ^= HTOLE64(input[ 9]); \
+            X##ka ^= HTOLE64(input[10]); \
+            X##ke ^= HTOLE64(input[11]); \
+            X##ki ^= HTOLE64(input[12]); \
+            X##ko ^= HTOLE64(input[13]); \
+            X##ku ^= HTOLE64(input[14]); \
+            X##ma ^= HTOLE64(input[15]); \
+            X##me ^= HTOLE64(input[16]); \
+        } \
+
+    #include <assert.h>
+
+    size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
+    {
+        size_t originalDataByteLen = dataByteLen;
+
+        declareABCDE
+        /* #ifndef KeccakP1600_fullUnrolling */
+        /* unsigned int i; */
+        /* #endif */
+        uint64_t *stateAsLanes = (uint64_t*)state;
+        uint64_t *inDataAsLanes = (uint64_t*)data;
+
+        assert(laneCount == 21 || laneCount == 17);
+
+        if (laneCount == 21) {
+            copyFromState(A, stateAsLanes)
+            while(dataByteLen >= laneCount*8) {
+                addInput21(A, inDataAsLanes, laneCount)
+                rounds12
+                inDataAsLanes += laneCount;
+                dataByteLen -= laneCount*8;
+            }
+            copyToState(stateAsLanes, A)
+        } else if (laneCount == 17) {
+            copyFromState(A, stateAsLanes)
+            while(dataByteLen >= laneCount*8) {
+                addInput17(A, inDataAsLanes, laneCount)
+                rounds12
+                inDataAsLanes += laneCount;
+                dataByteLen -= laneCount*8;
+            }
+            copyToState(stateAsLanes, A)
+        }
+
+        return originalDataByteLen - dataByteLen;
+    }
+}
+#endif

--- a/src/K12/kangaroo_twelve_xkcp.h
+++ b/src/K12/kangaroo_twelve_xkcp.h
@@ -4,6 +4,8 @@
 
 #include "platform/memory.h"
 
+namespace XKCP{
+
 typedef unsigned char uint8_t;
 typedef unsigned long long uint64_t;
 
@@ -783,7 +785,7 @@ static const unsigned long long KeccakF1600RoundConstants[24] = {
     Cu = Abu^Agu^Aku^Amu^Asu; \
 
 
-#define thetaRhoPiChiIotaPrepareTheta(i, A, E) \
+#define XKCPthetaRhoPiChiIotaPrepareTheta(i, A, E) \
     Da = Cu^ROL64(Ce, 1); \
     De = Ca^ROL64(Ci, 1); \
     Di = Ce^ROL64(Co, 1); \
@@ -899,7 +901,7 @@ static const unsigned long long KeccakF1600RoundConstants[24] = {
 
 /* --- Code for round */
 /* --- 64-bit lanes mapped to 64-bit words */
-#define thetaRhoPiChiIota(i, A, E) \
+#define XKCPthetaRhoPiChiIota(i, A, E) \
     Da = Cu^ROL64(Ce, 1); \
     De = Ca^ROL64(Ci, 1); \
     Di = Ce^ROL64(Co, 1); \
@@ -989,7 +991,7 @@ static const unsigned long long KeccakF1600RoundConstants[24] = {
 \
 
 
-#define copyFromState(X, state) \
+#define XKCPcopyFromState(X, state) \
     X##ba = state[ 0]; \
     X##be = state[ 1]; \
     X##bi = state[ 2]; \
@@ -1016,7 +1018,7 @@ static const unsigned long long KeccakF1600RoundConstants[24] = {
     X##so = state[23]; \
     X##su = state[24]; \
 
-#define copyToState(state, X) \
+#define XKCPcopyToState(state, X) \
     state[ 0] = X##ba; \
     state[ 1] = X##be; \
     state[ 2] = X##bi; \
@@ -1071,20 +1073,20 @@ static const unsigned long long KeccakF1600RoundConstants[24] = {
     X##su = Y##su; \
 
 
-#define rounds12 \
+#define XKCProunds12 \
     prepareTheta \
-    thetaRhoPiChiIotaPrepareTheta(12, A, E) \
-    thetaRhoPiChiIotaPrepareTheta(13, E, A) \
-    thetaRhoPiChiIotaPrepareTheta(14, A, E) \
-    thetaRhoPiChiIotaPrepareTheta(15, E, A) \
-    thetaRhoPiChiIotaPrepareTheta(16, A, E) \
-    thetaRhoPiChiIotaPrepareTheta(17, E, A) \
-    thetaRhoPiChiIotaPrepareTheta(18, A, E) \
-    thetaRhoPiChiIotaPrepareTheta(19, E, A) \
-    thetaRhoPiChiIotaPrepareTheta(20, A, E) \
-    thetaRhoPiChiIotaPrepareTheta(21, E, A) \
-    thetaRhoPiChiIotaPrepareTheta(22, A, E) \
-    thetaRhoPiChiIota(23, E, A) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(12, A, E) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(13, E, A) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(14, A, E) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(15, E, A) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(16, A, E) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(17, E, A) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(18, A, E) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(19, E, A) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(20, A, E) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(21, E, A) \
+    XKCPthetaRhoPiChiIotaPrepareTheta(22, A, E) \
+    XKCPthetaRhoPiChiIota(23, E, A) \
 
 namespace K12xkcp
 {
@@ -1230,9 +1232,9 @@ namespace K12xkcp
         /* #endif */
         uint64_t *stateAsLanes = (uint64_t*)state;
 
-        copyFromState(A, stateAsLanes)
-        rounds12
-        copyToState(stateAsLanes, A)
+        XKCPcopyFromState(A, stateAsLanes)
+        XKCProunds12
+        XKCPcopyToState(stateAsLanes, A)
     }
 
 
@@ -1400,7 +1402,7 @@ namespace K12xkcp
             X##me ^= HTOLE64(input[16]); \
         } \
 
-    #include <assert.h>
+    /* #include <assert.h>  */
 
     size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
     {
@@ -1413,29 +1415,30 @@ namespace K12xkcp
         uint64_t *stateAsLanes = (uint64_t*)state;
         uint64_t *inDataAsLanes = (uint64_t*)data;
 
-        assert(laneCount == 21 || laneCount == 17);
+        /* ASSERT(laneCount == 21 || laneCount == 17); */
 
         if (laneCount == 21) {
-            copyFromState(A, stateAsLanes)
+            XKCPcopyFromState(A, stateAsLanes)
             while(dataByteLen >= laneCount*8) {
                 addInput21(A, inDataAsLanes, laneCount)
-                rounds12
+                XKCProunds12
                 inDataAsLanes += laneCount;
                 dataByteLen -= laneCount*8;
             }
-            copyToState(stateAsLanes, A)
+            XKCPcopyToState(stateAsLanes, A)
         } else if (laneCount == 17) {
-            copyFromState(A, stateAsLanes)
+            XKCPcopyFromState(A, stateAsLanes)
             while(dataByteLen >= laneCount*8) {
                 addInput17(A, inDataAsLanes, laneCount)
-                rounds12
+                XKCProunds12
                 inDataAsLanes += laneCount;
                 dataByteLen -= laneCount*8;
             }
-            copyToState(stateAsLanes, A)
+            XKCPcopyToState(stateAsLanes, A)
         }
 
         return originalDataByteLen - dataByteLen;
     }
 }
 #endif
+}

--- a/src/K12/kangaroo_twelve_xkcp.h
+++ b/src/K12/kangaroo_twelve_xkcp.h
@@ -687,7 +687,7 @@ namespace K12xkcp
         KeccakP_DeclareVars
         unsigned long long* stateAsLanes = (unsigned long long*)state;
 
-        XKCPAVX512copyFromStatestateAsLanes);
+        XKCPAVX512copyFromState(stateAsLanes);
         XKCPAVX512rounds12;
         XKCPAVX512copyToState(stateAsLanes);
     }

--- a/src/Qubic.vcxproj
+++ b/src/Qubic.vcxproj
@@ -77,6 +77,7 @@
     <ClInclude Include="platform\concurrency.h" />
     <ClInclude Include="four_q.h" />
     <ClInclude Include="kangaroo_twelve.h" />
+    <ClInclude Include="K12/kangaroo_twelve_xkcp.h" />
     <ClInclude Include="platform\custom_stack.h" />
     <ClInclude Include="platform\debugging.h" />
     <ClInclude Include="platform\file_io.h" />

--- a/src/network_messages/tick.h
+++ b/src/network_messages/tick.h
@@ -30,10 +30,12 @@ struct Tick
     m256i transactionDigest;
     m256i expectedNextTickTransactionDigest;
 
+    m256i saltedTransactionBodyDigest;
+
     unsigned char signature[SIGNATURE_SIZE];
 };
 
-static_assert(sizeof(Tick) == 8 + 8 + 16 + 6 * 32 + 2 * 32 + SIGNATURE_SIZE, "Something is wrong with the struct size.");
+static_assert(sizeof(Tick) == 8 + 8 + 16 + 6 * 32 + 2 * 32 + 32 + SIGNATURE_SIZE, "Something is wrong with the struct size.");
 
 
 struct BroadcastTick

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4296,24 +4296,28 @@ static unsigned int countCurrentTickVote()
 }
 
 // This function scans through all transactions digest in next tickData
-// and look for those txs in local memory (pending txs). If a transaction doesn't exist, it will try to update requestedTickTransactions
+// and look for those txs in local memory (pending txs and tickstorage). If a transaction doesn't exist, it will try to update requestedTickTransactions
 // I main loop (MAIN thread), it will try to fetch missing txs based on the data inside requestedTickTransactions
 // Current code assumes the limits:
 // - 1 tx per source publickey per tick
 // - 128 txs per computor publickey per tick
+// Note requestedTickTransactions.transactionFlags are set to 0 for tx we want to request and 1 for tx we are not interested in
 static void prepareNextTickTransactions()
 {
     const unsigned int nextTick = system.tick + 1;
     const unsigned int nextTickIndex = ts.tickToIndexCurrentEpoch(nextTick);
 
     nextTickTransactionsSemaphore = 1; // signal a flag for displaying on the console log
-    bs->SetMem(requestedTickTransactions.requestedTickTransactions.transactionFlags, sizeof(requestedTickTransactions.requestedTickTransactions.transactionFlags), 0);
+
+
+    // unknownTransactions is set to 1 if a transaction is missing in the local storage
     unsigned long long unknownTransactions[NUMBER_OF_TRANSACTIONS_PER_TICK / 64];
     bs->SetMem(unknownTransactions, sizeof(unknownTransactions), 0);
     const auto* tsNextTickTransactionOffsets = ts.tickTransactionOffsets.getByTickIndex(nextTickIndex);
     
     // This function maybe called multiple times per tick due to lack of data (txs or votes)
     // Here we do a simple pre scan to check txs via tsNextTickTransactionOffsets (already processed - aka already copying from pendingTransaction array to tickTransaction)
+    // Mark all transaction that are not in the tickStorage as missing
     for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
     {
         if (!isZero(nextTickData.transactionDigests[i]))
@@ -4348,6 +4352,7 @@ static void prepareNextTickTransactions()
 
     if (numberOfKnownNextTickTransactions != numberOfNextTickTransactions)
     {
+        // Checks if any of the missing transactions is available in the computorPendingTransaction and remove unknownTransaction flag if found
         for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS * MAX_NUMBER_OF_PENDING_TRANSACTIONS_PER_COMPUTOR; i++)
         {
             Transaction* pendingTransaction = (Transaction*)&computorPendingTransactions[i * MAX_TRANSACTION_SIZE];
@@ -4387,6 +4392,7 @@ static void prepareNextTickTransactions()
                 RELEASE(computorPendingTransactionsLock);
             }
         }
+        // Checks if any of the missing transactions is available in the entityPendingTransaction and remove unknownTransaction flag if found
         for (unsigned int i = 0; i < SPECTRUM_CAPACITY; i++)
         {
             Transaction* pendingTransaction = (Transaction*)&entityPendingTransactions[i * MAX_TRANSACTION_SIZE];
@@ -4427,14 +4433,20 @@ static void prepareNextTickTransactions()
             }
         }
 
+        // At this point unknownTransactions is set to 1 for all transactions that are unknown
         // Update requestedTickTransactions the list of txs that not exist in memory so the MAIN loop can try to fetch them from peers
-        for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
-        {
-            if (!isZero(nextTickData.transactionDigests[i]))
+        // We prepare the transactionFlags so that missing transactions are set to 0 (initialized to all 1)
+        // As processNextTickTransactions returns tx for which the flag ist set to 0 (tx with flag set to 1 are not returned)
+
+        // We check if the last tickTransactionRequest it already sent
+        if(requestedTickTransactions.requestedTickTransactions.tick == 0){
+            // Initialize transactionFlags to one so that by default we do not request any transaction
+            bs->SetMem(requestedTickTransactions.requestedTickTransactions.transactionFlags, sizeof(requestedTickTransactions.requestedTickTransactions.transactionFlags), 0xff);
+            for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
             {
-                if (!(unknownTransactions[i >> 6] & (1ULL << (i & 63))))
+                if (unknownTransactions[i >> 6] & (1ULL << (i & 63)))
                 {
-                    requestedTickTransactions.requestedTickTransactions.transactionFlags[i >> 3] |= (1 << (i & 7));
+                    requestedTickTransactions.requestedTickTransactions.transactionFlags[i >> 3] &= ~(1 << (i & 7));
                 }
             }
         }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4474,6 +4474,8 @@ static XKCP::KangarooTwelve_Instance computeTxBodyDigestBase(const int tick)
 
     for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
     {
+        // TODO: Optimization to check: We have the ts locked for the whole K12_Update.
+        //       It might be worth to copy the transaction and release lock before update the K12 state.
         ts.tickTransactions.acquireLock();
 
         if (tsTransactionOffsets[i]) {
@@ -4483,10 +4485,6 @@ static XKCP::KangarooTwelve_Instance computeTxBodyDigestBase(const int tick)
                 XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char *>(transaction), transaction->totalSize());
             }
         }
-
-        // const Transaction* transaction = ts.tickTransactions(tsTransactionOffsets[i]);
-
-        // XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char*>(transaction), transaction->totalSize());
 
         ts.tickTransactions.releaseLock();
     }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -32,7 +32,6 @@
 
 #include "K12/kangaroo_twelve_xkcp.h"
 #include "kangaroo_twelve.h"
-
 #include "four_q.h"
 #include "score.h"
 
@@ -91,8 +90,7 @@ struct Processor : public CustomStack
     void* buffer;
 };
 
-static bool logVote = false;
-static bool logK12 = false;
+
 
 
 static const unsigned short revenuePoints[1 + 1024] = { 0, 710, 1125, 1420, 1648, 1835, 1993, 2129, 2250, 2358, 2455, 2545, 2627, 2702, 2773, 2839, 2901, 2960, 3015, 3068, 3118, 3165, 3211, 3254, 3296, 3336, 3375, 3412, 3448, 3483, 3516, 3549, 3580, 3611, 3641, 3670, 3698, 3725, 3751, 3777, 3803, 3827, 3851, 3875, 3898, 3921, 3943, 3964, 3985, 4006, 4026, 4046, 4066, 4085, 4104, 4122, 4140, 4158, 4175, 4193, 4210, 4226, 4243, 4259, 4275, 4290, 4306, 4321, 4336, 4350, 4365, 4379, 4393, 4407, 4421, 4435, 4448, 4461, 4474, 4487, 4500, 4512, 4525, 4537, 4549, 4561, 4573, 4585, 4596, 4608, 4619, 4630, 4641, 4652, 4663, 4674, 4685, 4695, 4705, 4716, 4726, 4736, 4746, 4756, 4766, 4775, 4785, 4795, 4804, 4813, 4823, 4832, 4841, 4850, 4859, 4868, 4876, 4885, 4894, 4902, 4911, 4919, 4928, 4936, 4944, 4952, 4960, 4968, 4976, 4984, 4992, 5000, 5008, 5015, 5023, 5031, 5038, 5046, 5053, 5060, 5068, 5075, 5082, 5089, 5096, 5103, 5110, 5117, 5124, 5131, 5138, 5144, 5151, 5158, 5164, 5171, 5178, 5184, 5191, 5197, 5203, 5210, 5216, 5222, 5228, 5235, 5241, 5247, 5253, 5259, 5265, 5271, 5277, 5283, 5289, 5295, 5300, 5306, 5312, 5318, 5323, 5329, 5335, 5340, 5346, 5351, 5357, 5362, 5368, 5373, 5378, 5384, 5389, 5394, 5400, 5405, 5410, 5415, 5420, 5425, 5431, 5436, 5441, 5446, 5451, 5456, 5461, 5466, 5471, 5475, 5480, 5485, 5490, 5495, 5500, 5504, 5509, 5514, 5518, 5523, 5528, 5532, 5537, 5542, 5546, 5551, 5555, 5560, 5564, 5569, 5573, 5577, 5582, 5586, 5591, 5595, 5599, 5604, 5608, 5612, 5616, 5621, 5625, 5629, 5633, 5637, 5642, 5646, 5650, 5654, 5658, 5662, 5666, 5670, 5674, 5678, 5682, 5686, 5690, 5694, 5698, 5702, 5706, 5710, 5714, 5718, 5721, 5725, 5729, 5733, 5737, 5740, 5744, 5748, 5752, 5755, 5759, 5763, 5766, 5770, 5774, 5777, 5781, 5785, 5788, 5792, 5795, 5799, 5802, 5806, 5809, 5813, 5816, 5820, 5823, 5827, 5830, 5834, 5837, 5841, 5844, 5847, 5851, 5854, 5858, 5861, 5864, 5868, 5871, 5874, 5878, 5881, 5884, 5887, 5891, 5894, 5897, 5900, 5904, 5907, 5910, 5913, 5916, 5919, 5923, 5926, 5929, 5932, 5935, 5938, 5941, 5944, 5948, 5951, 5954, 5957, 5960, 5963, 5966, 5969, 5972, 5975, 5978, 5981, 5984, 5987, 5990, 5993, 5996, 5999, 6001, 6004, 6007, 6010, 6013, 6016, 6019, 6022, 6025, 6027, 6030, 6033, 6036, 6039, 6041, 6044, 6047, 6050, 6053, 6055, 6058, 6061, 6064, 6066, 6069, 6072, 6075, 6077, 6080, 6083, 6085, 6088, 6091, 6093, 6096, 6099, 6101, 6104, 6107, 6109, 6112, 6115, 6117, 6120, 6122, 6125, 6128, 6130, 6133, 6135, 6138, 6140, 6143, 6145, 6148, 6151, 6153, 6156, 6158, 6161, 6163, 6166, 6168, 6170, 6173, 6175, 6178, 6180, 6183, 6185, 6188, 6190, 6193, 6195, 6197, 6200, 6202, 6205, 6207, 6209, 6212, 6214, 6216, 6219, 6221, 6224, 6226, 6228, 6231, 6233, 6235, 6238, 6240, 6242, 6244, 6247, 6249, 6251, 6254, 6256, 6258, 6260, 6263, 6265, 6267, 6269, 6272, 6274, 6276, 6278, 6281, 6283, 6285, 6287, 6289, 6292, 6294, 6296, 6298, 6300, 6303, 6305, 6307, 6309, 6311, 6313, 6316, 6318, 6320, 6322, 6324, 6326, 6328, 6330, 6333, 6335, 6337, 6339, 6341, 6343, 6345, 6347, 6349, 6351, 6353, 6356, 6358, 6360, 6362, 6364, 6366, 6368, 6370, 6372, 6374, 6376, 6378, 6380, 6382, 6384, 6386, 6388, 6390, 6392, 6394, 6396, 6398, 6400, 6402, 6404, 6406, 6408, 6410, 6412, 6414, 6416, 6418, 6420, 6421, 6423, 6425, 6427, 6429, 6431, 6433, 6435, 6437, 6439, 6441, 6443, 6444, 6446, 6448, 6450, 6452, 6454, 6456, 6458, 6459, 6461, 6463, 6465, 6467, 6469, 6471, 6472, 6474, 6476, 6478, 6480, 6482, 6483, 6485, 6487, 6489, 6491, 6493, 6494, 6496, 6498, 6500, 6502, 6503, 6505, 6507, 6509, 6510, 6512, 6514, 6516, 6518, 6519, 6521, 6523, 6525, 6526, 6528, 6530, 6532, 6533, 6535, 6537, 6538, 6540, 6542, 6544, 6545, 6547, 6549, 6550, 6552, 6554, 6556, 6557, 6559, 6561, 6562, 6564, 6566, 6567, 6569, 6571, 6572, 6574, 6576, 6577, 6579, 6581, 6582, 6584, 6586, 6587, 6589, 6591, 6592, 6594, 6596, 6597, 6599, 6600, 6602, 6604, 6605, 6607, 6609, 6610, 6612, 6613, 6615, 6617, 6618, 6620, 6621, 6623, 6625, 6626, 6628, 6629, 6631, 6632, 6634, 6636, 6637, 6639, 6640, 6642, 6643, 6645, 6647, 6648, 6650, 6651, 6653, 6654, 6656, 6657, 6659, 6660, 6662, 6663, 6665, 6667, 6668, 6670, 6671, 6673, 6674, 6676, 6677, 6679, 6680, 6682, 6683, 6685, 6686, 6688, 6689, 6691, 6692, 6694, 6695, 6697, 6698, 6699, 6701, 6702, 6704, 6705, 6707, 6708, 6710, 6711, 6713, 6714, 6716, 6717, 6718, 6720, 6721, 6723, 6724, 6726, 6727, 6729, 6730, 6731, 6733, 6734, 6736, 6737, 6739, 6740, 6741, 6743, 6744, 6746, 6747, 6748, 6750, 6751, 6753, 6754, 6755, 6757, 6758, 6760, 6761, 6762, 6764, 6765, 6767, 6768, 6769, 6771, 6772, 6773, 6775, 6776, 6778, 6779, 6780, 6782, 6783, 6784, 6786, 6787, 6788, 6790, 6791, 6793, 6794, 6795, 6797, 6798, 6799, 6801, 6802, 6803, 6805, 6806, 6807, 6809, 6810, 6811, 6813, 6814, 6815, 6816, 6818, 6819, 6820, 6822, 6823, 6824, 6826, 6827, 6828, 6830, 6831, 6832, 6833, 6835, 6836, 6837, 6839, 6840, 6841, 6842, 6844, 6845, 6846, 6848, 6849, 6850, 6851, 6853, 6854, 6855, 6856, 6858, 6859, 6860, 6862, 6863, 6864, 6865, 6867, 6868, 6869, 6870, 6872, 6873, 6874, 6875, 6877, 6878, 6879, 6880, 6882, 6883, 6884, 6885, 6886, 6888, 6889, 6890, 6891, 6893, 6894, 6895, 6896, 6897, 6899, 6900, 6901, 6902, 6904, 6905, 6906, 6907, 6908, 6910, 6911, 6912, 6913, 6914, 6916, 6917, 6918, 6919, 6920, 6921, 6923, 6924, 6925, 6926, 6927, 6929, 6930, 6931, 6932, 6933, 6934, 6936, 6937, 6938, 6939, 6940, 6941, 6943, 6944, 6945, 6946, 6947, 6948, 6950, 6951, 6952, 6953, 6954, 6955, 6957, 6958, 6959, 6960, 6961, 6962, 6963, 6965, 6966, 6967, 6968, 6969, 6970, 6971, 6972, 6974, 6975, 6976, 6977, 6978, 6979, 6980, 6981, 6983, 6984, 6985, 6986, 6987, 6988, 6989, 6990, 6991, 6993, 6994, 6995, 6996, 6997, 6998, 6999, 7000, 7001, 7003, 7004, 7005, 7006, 7007, 7008, 7009, 7010, 7011, 7012, 7013, 7015, 7016, 7017, 7018, 7019, 7020, 7021, 7022, 7023, 7024, 7025, 7026, 7027, 7029, 7030, 7031, 7032, 7033, 7034, 7035, 7036, 7037, 7038, 7039, 7040, 7041, 7042, 7043, 7044, 7046, 7047, 7048, 7049, 7050, 7051, 7052, 7053, 7054, 7055, 7056, 7057, 7058, 7059, 7060, 7061, 7062, 7063, 7064, 7065, 7066, 7067, 7068, 7069, 7070, 7071, 7073, 7074, 7075, 7076, 7077, 7078, 7079, 7080, 7081, 7082, 7083, 7084, 7085, 7086, 7087, 7088, 7089, 7090, 7091, 7092, 7093, 7094, 7095, 7096, 7097, 7098, 7099 };
@@ -155,7 +153,7 @@ const unsigned long long contractStateDigestsSizeInBytes = sizeof(contractStateD
 // targetNextTickDataDigestIsKnown == false means there is no consensus on next tick data yet
 static bool targetNextTickDataDigestIsKnown = false;
 static m256i targetNextTickDataDigest;
-// rdtsc of ticks
+// rdtsc (timestamp) of ticks
 static unsigned long long tickTicks[11];
 
 static m256i releasedPublicKeys[NUMBER_OF_COMPUTORS];
@@ -206,9 +204,6 @@ static SpecialCommandGetMiningScoreRanking<MAX_NUMBER_OF_MINERS> requestMiningSc
 
 static unsigned long long customMiningMessageCounters[NUMBER_OF_COMPUTORS] = { 0 };
 
-
-// KangarooTwelve Instance to avoid recomputation of the base state with all tx bodies
-XKCP::KangarooTwelve_Instance txBodyBaseNextTick;
 
 // variables and declare for persisting state
 static volatile int requestPersistingNodeState = 0;
@@ -969,7 +964,6 @@ static void processRequestQuorumTick(Peer* peer, RequestResponseHeader* header)
         // Todo: This function may be optimized by moving the checking of voteFlags in the first loop, reducing the number of calls to random().
         unsigned short computorIndices[NUMBER_OF_COMPUTORS];
         unsigned short numberOfComputorIndices;
-        int numEnq = 0;
         for (numberOfComputorIndices = 0; numberOfComputorIndices < NUMBER_OF_COMPUTORS; numberOfComputorIndices++)
         {
             computorIndices[numberOfComputorIndices] = numberOfComputorIndices;
@@ -981,26 +975,17 @@ static void processRequestQuorumTick(Peer* peer, RequestResponseHeader* header)
             if (!(request->quorumTick.voteFlags[computorIndices[index] >> 3] & (1 << (computorIndices[index] & 7))))
             {
                 // Todo: We should acquire ts.ticks lock here if tick >= system.tick
-
                 const Tick* tsTick = tsCompTicks + computorIndices[index];
                 if (tsTick->epoch == tickEpoch)
                 {
                     ts.ticks.acquireLock(computorIndices[index]);
                     enqueueResponse(peer, sizeof(Tick), BroadcastTick::type, header->dejavu(), tsTick);
                     ts.ticks.releaseLock(computorIndices[index]);
-                    numEnq++;
                 }
             }
 
             computorIndices[index] = computorIndices[--numberOfComputorIndices];
         }
-
-        CHAR16 dbgMsg[200];
-        setText(dbgMsg, L"SQT ");
-        appendNumber(dbgMsg, request->quorumTick.tick, FALSE);
-        appendText(dbgMsg, L" sent: ");
-        appendNumber(dbgMsg, numEnq, FALSE);
-        addDebugMessage(dbgMsg);
     }
     enqueueResponse(peer, 0, EndResponse::type, header->dejavu(), NULL);
 }
@@ -2474,8 +2459,7 @@ static void processTick(unsigned long long processorNumber)
     getUniverseDigest(etalonTick.saltedUniverseDigest);
     getComputerDigest(etalonTick.saltedComputerDigest);
 
-
-    // If node is MAIN has ID of tickleader for system.tick + TICK_TRANSACTIONS_PUBLICATION_OFFSET
+    // If node is MAIN and has ID of tickleader for system.tick + TICK_TRANSACTIONS_PUBLICATION_OFFSET
     // prepare tickData and enqueue it
     for (unsigned int i = 0; i < numberOfOwnComputorIndices; i++)
     {
@@ -4489,9 +4473,9 @@ static void prepareNextTickTransactions()
 
 
 // Computes the digest of all tx bodies of a certain tick and saves it in etalonTick
-//static m256i computeTxBodyDigestBase(const int tick)
 static void computeTxBodyDigestBase(const int tick)
 {
+    ASSERT(nextTickData.epoch == system.epoch); // nextTickData need to be valid
     constexpr size_t outputLen = 32; // output length in bytes
 
     XKCP::KangarooTwelve_Instance kt;
@@ -4500,33 +4484,6 @@ static void computeTxBodyDigestBase(const int tick)
     const unsigned int tickIndex = ts.tickToIndexCurrentEpoch(tick);
     const auto* tsTransactionOffsets = ts.tickTransactionOffsets.getByTickIndex(tickIndex);
 
-
-    int numTx = 0; // Counter for debuging
-    int numTxTd = 0; // Counter for debuging
-    CHAR16 digestChars[60 + 1];
-
-    if(logK12)
-    {
-        for(const auto &tx : nextTickData.transactionDigests)
-        {
-            if(!isZero(tx))
-            {
-                numTxTd++;
-                setText(message, L"txtd ");
-                appendNumber(message, numTxTd, false);
-                getIdentity(tx.m256i_u8, digestChars, true);
-                appendText(message, digestChars);
-                appendText(message, L".");
-                addDebugMessage(message);
-            }
-        }
-
-        setText(message, L"tickdata tx: ");
-        appendNumber(message, numTxTd, TRUE);
-        appendText(message, L".");
-        addDebugMessage(message);
-    }
-
     for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
     {
         if (!isZero(nextTickData.transactionDigests[i]))
@@ -4534,8 +4491,7 @@ static void computeTxBodyDigestBase(const int tick)
             // TODO: Optimization to check: We have the ts locked for the whole K12_Update.
             //       It might be worth to copy the transaction and release lock before update the K12 state.
             // TODO: Here we check each Tx against the nextTickData again (before we did it in prepareNextTickTransactions
-            //       Might be worth to do only do it once by saving flagging/removing tx which are in ts.tickTransactions
-            //       but not in nextTickData
+            //       Might be worth to do only do it once.
             ts.tickTransactions.acquireLock();
 
             if (tsTransactionOffsets[i]) {
@@ -4552,22 +4508,25 @@ static void computeTxBodyDigestBase(const int tick)
                             ret = XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char *>(transaction), transaction->totalSize());
                             if (ret == 0)
                             {
-                                numTx++;
                                 break;
                             }
+#if !defined(NDEBUG)
                             else
                             {
-                                setText(message, L"!!!!!!!!!!!!!XKCP FAILED!!!!!!!!!");
+                                setText(message, L"txBodyDigest: XKCP failed to create hash of tx");
                                 addDebugMessage(message);
                             }
+#endif
                         }
                     }
                 }
+#if !defined(NDEBUG)
                 else
                 {
-                    setText(message, L"!!!!!!!!!!!!!TX FAILED VALIDATION!!!!!!!!!");
+                    setText(message, L"txBodyDigest: Transaction verification failed");
                     addDebugMessage(message);
                 }
+#endif
             }
 
             ts.tickTransactions.releaseLock();
@@ -4578,21 +4537,14 @@ static void computeTxBodyDigestBase(const int tick)
     while(ret == 1)
     {
         ret = XKCP::KangarooTwelve_Final(&kt, etalonTick.saltedTransactionBodyDigest.m256i_u8, (const unsigned char *)"", 0);
+#if !defined(NDEBUG)
         if(ret == 1)
         {
-            setText(message, L"!!!!!!!!!!!!!XKCP FINALIZE FAILED!!!!!!!!!");
+            setText(message, L"txBodyDigest: XKCP failed to finalize hash");
             addDebugMessage(message);
         }
+#endif
     }
-
-    if(logK12)
-    {
-        setText(message, L"Hashed tx: ");
-        appendNumber(message, numTx, TRUE);
-        appendText(message, L".");
-        addDebugMessage(message);
-    }
-    //return digest;
 }
 
 
@@ -4634,18 +4586,6 @@ static void broadcastTickVotes()
         // - if own votes don't get echoed back, that indicates this node has internet/topo issue, and need to reissue vote (F9)
         // - all votes need to be processed in a single place of code (for further handling)
         // - all votes are treated equally (own votes and their votes)
-    }
-
-    if(logVote)
-    {
-        setText(message, L"Broadcast vote for tick: ");
-        appendNumber(message, broadcastTick.tick.tick, TRUE);
-        appendText(message, L" txBodyDiges: ");
-        CHAR16 digestChars[60 + 1];
-        getIdentity(etalonTick.saltedTransactionBodyDigest.m256i_u8, digestChars, true);
-        appendText(message, digestChars);
-        appendText(message, L".");
-        addDebugMessage(message);
     }
 }
 
@@ -4703,8 +4643,10 @@ static void updateVotesCount(unsigned int& tickNumberOfComputors, unsigned int& 
                                         voteCounter.registerNewVote(tick->tick, tick->computorIndex);
                                     }
                                 }
-                                else // ignore transactionbodyDigest if out expectedNextTicktransactionDigest is zero
+                                else
                                 {
+                                    // ignore transactionBodyDigest if etalonTick.expectedNextTicktransactionDigest is zero
+                                    // so node that already voted can recover from misalignment state
                                     tickNumberOfComputors++;
                                     // to avoid submitting invalid votes (eg: all zeroes with valid signature)
                                     // only count votes that matched etalonTick
@@ -4976,31 +4918,31 @@ static void tickProcessor(void*)
                         {
                             // if this node is faster than most, targetNextTickDataDigest is unknown at this point because of lack of votes
                             // Thus, expectedNextTickTransactionDigest it not updated yet
-                            // If it targetNextTickDataDigest is known expectedNextTickTransactionDigest is set above already.
+                            // If targetNextTickDataDigest is known expectedNextTickTransactionDigest is set above already.
                             KangarooTwelve(&nextTickData, sizeof(TickData), &etalonTick.expectedNextTickTransactionDigest, 32);
                         }
                     }
                     else
                     {
                         etalonTick.expectedNextTickTransactionDigest = m256i::zero();
+                        etalonTick.saltedTransactionBodyDigest = m256i::zero();
                     }
-
 
                     if (system.tick > system.latestCreatedTick || system.tick == system.initialTick)
                     {
-                        computeTxBodyDigestBase(nextTick); //Sets etalonTick
+                        if (nextTickData.epoch == system.epoch)
+                        {
+                            computeTxBodyDigestBase(nextTick);
+                        }
 
                         if (mainAuxStatus & 1)
                         {
                             broadcastTickVotes();
                         }
 
-                        // Avoid spamming votes after initial tick
                         if (system.tick != system.initialTick)
                         {
                             system.latestCreatedTick = system.tick;
-                            logVote = true;
-                            logK12 = true;
                         }
                     }
 
@@ -6072,67 +6014,6 @@ static void processKeyPresses()
     {
         switch (key.ScanCode)
         {
-
-        case 0x0B:
-        {
-            const unsigned int tickIndex = ts.tickToIndexCurrentEpoch(etalonTick.tick);
-            const auto *tsTransactionOffsets =
-                ts.tickTransactionOffsets.getByTickIndex(tickIndex);
-
-            int numTx = 0;
-            for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
-            {
-                numTx++;
-                ts.tickTransactions.acquireLock();
-
-                if (tsTransactionOffsets[i]) {
-                    const Transaction *transaction =
-                        ts.tickTransactions(tsTransactionOffsets[i]);
-                    if (transaction->checkValidity() && transaction->tick == etalonTick.tick)
-                        {
-
-                            const Transaction *transaction = ts.tickTransactions(tsTransactionOffsets[i]);
-
-                            CHAR16 digestChars[60 + 1];
-                            setText(message, L"Tx ");
-                            appendNumber(message, i, false);
-                            appendText(message, L": ");
-
-                            unsigned char digest[32];
-                            KangarooTwelve(transaction, transaction->totalSize(), digest, sizeof(digest));
-                            getIdentity(digest, digestChars, true);
-                            appendText(message, digestChars);
-                            appendText(message, L".\n");
-                            logToConsole(message);
-                    }
-                }
-                ts.tickTransactions.releaseLock();
-            }
-            setText(message, L"Num Tx: ");
-            appendNumber(message, numTx,false);
-            logToConsole(message);
-
-            setText(message, L"TX Diges: ");
-            logToConsole(message);
-
-            for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
-            {
-
-                if (!isZero(nextTickData.transactionDigests[i]))
-                {
-                    CHAR16 digestChars[60 + 1];
-                    setText(message, L"TxTickData ");
-                    appendNumber(message, i, false);
-                    appendText(message, L": ");
-
-                    getIdentity(&nextTickData.transactionDigests[i].m256i_u8[0], digestChars, true);
-                    appendText(message, digestChars);
-                    appendText(message, L".\n");
-                    logToConsole(message);
-                }
-            }
-        }
-        break;
         /*
         *
         * F2 Key
@@ -6232,7 +6113,6 @@ static void processKeyPresses()
             appendNumber(message, resourceTestingDigest, false);
             appendText(message, L".");
             logToConsole(message);
-
 
             unsigned int numberOfPublishedSolutions = 0, numberOfRecordedSolutions = 0, numberOfObsoleteSolutions = 0;
             for (unsigned int i = 0; i < system.numberOfSolutions; i++)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -761,7 +761,7 @@ static void processBroadcastFutureTickData(Peer* peer, RequestResponseHeader* he
         {
             if (!isZero(request->tickData.transactionDigests[i]))
             {
-                // Check if same transactionDigest is present in the tickData
+                // Check if same transactionDigest is present twice
                 for (unsigned int j = 0; j < i; j++)
                 {
                     if (request->tickData.transactionDigests[i] == request->tickData.transactionDigests[j])

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4568,7 +4568,7 @@ static void updateVotesCount(unsigned int& tickNumberOfComputors, unsigned int& 
                             KangarooTwelve64To32(saltedData, &saltedDigest);
                             if (tick->saltedComputerDigest == saltedDigest)
                             {
-                                saltedData[0] = etalonTick.saltedTransactionBodyDigest;
+                                saltedData[1] = etalonTick.saltedTransactionBodyDigest;
                                 KangarooTwelve64To32(saltedData, &saltedDigest);
                                 if(tick->saltedTransactionBodyDigest == saltedDigest)
                                 {
@@ -6024,7 +6024,7 @@ static void processKeyPresses()
             appendText(message, L".");
             logToConsole(message);
 
-            setText(message, L"Computer digest = ");
+            setText(message, L"TxBody digest = ");
             getIdentity(etalonTick.saltedTransactionBodyDigest.m256i_u8, digestChars, true);
             appendText(message, digestChars);
             appendText(message, L".");

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -30,8 +30,8 @@
 
 #include "text_output.h"
 
-#include "kangaroo_twelve.h"
 #include "K12/kangaroo_twelve_xkcp.h"
+#include "kangaroo_twelve.h"
 
 #include "four_q.h"
 #include "score.h"
@@ -91,7 +91,8 @@ struct Processor : public CustomStack
     void* buffer;
 };
 
-
+static bool logVote = false;
+static bool logK12 = false;
 
 
 static const unsigned short revenuePoints[1 + 1024] = { 0, 710, 1125, 1420, 1648, 1835, 1993, 2129, 2250, 2358, 2455, 2545, 2627, 2702, 2773, 2839, 2901, 2960, 3015, 3068, 3118, 3165, 3211, 3254, 3296, 3336, 3375, 3412, 3448, 3483, 3516, 3549, 3580, 3611, 3641, 3670, 3698, 3725, 3751, 3777, 3803, 3827, 3851, 3875, 3898, 3921, 3943, 3964, 3985, 4006, 4026, 4046, 4066, 4085, 4104, 4122, 4140, 4158, 4175, 4193, 4210, 4226, 4243, 4259, 4275, 4290, 4306, 4321, 4336, 4350, 4365, 4379, 4393, 4407, 4421, 4435, 4448, 4461, 4474, 4487, 4500, 4512, 4525, 4537, 4549, 4561, 4573, 4585, 4596, 4608, 4619, 4630, 4641, 4652, 4663, 4674, 4685, 4695, 4705, 4716, 4726, 4736, 4746, 4756, 4766, 4775, 4785, 4795, 4804, 4813, 4823, 4832, 4841, 4850, 4859, 4868, 4876, 4885, 4894, 4902, 4911, 4919, 4928, 4936, 4944, 4952, 4960, 4968, 4976, 4984, 4992, 5000, 5008, 5015, 5023, 5031, 5038, 5046, 5053, 5060, 5068, 5075, 5082, 5089, 5096, 5103, 5110, 5117, 5124, 5131, 5138, 5144, 5151, 5158, 5164, 5171, 5178, 5184, 5191, 5197, 5203, 5210, 5216, 5222, 5228, 5235, 5241, 5247, 5253, 5259, 5265, 5271, 5277, 5283, 5289, 5295, 5300, 5306, 5312, 5318, 5323, 5329, 5335, 5340, 5346, 5351, 5357, 5362, 5368, 5373, 5378, 5384, 5389, 5394, 5400, 5405, 5410, 5415, 5420, 5425, 5431, 5436, 5441, 5446, 5451, 5456, 5461, 5466, 5471, 5475, 5480, 5485, 5490, 5495, 5500, 5504, 5509, 5514, 5518, 5523, 5528, 5532, 5537, 5542, 5546, 5551, 5555, 5560, 5564, 5569, 5573, 5577, 5582, 5586, 5591, 5595, 5599, 5604, 5608, 5612, 5616, 5621, 5625, 5629, 5633, 5637, 5642, 5646, 5650, 5654, 5658, 5662, 5666, 5670, 5674, 5678, 5682, 5686, 5690, 5694, 5698, 5702, 5706, 5710, 5714, 5718, 5721, 5725, 5729, 5733, 5737, 5740, 5744, 5748, 5752, 5755, 5759, 5763, 5766, 5770, 5774, 5777, 5781, 5785, 5788, 5792, 5795, 5799, 5802, 5806, 5809, 5813, 5816, 5820, 5823, 5827, 5830, 5834, 5837, 5841, 5844, 5847, 5851, 5854, 5858, 5861, 5864, 5868, 5871, 5874, 5878, 5881, 5884, 5887, 5891, 5894, 5897, 5900, 5904, 5907, 5910, 5913, 5916, 5919, 5923, 5926, 5929, 5932, 5935, 5938, 5941, 5944, 5948, 5951, 5954, 5957, 5960, 5963, 5966, 5969, 5972, 5975, 5978, 5981, 5984, 5987, 5990, 5993, 5996, 5999, 6001, 6004, 6007, 6010, 6013, 6016, 6019, 6022, 6025, 6027, 6030, 6033, 6036, 6039, 6041, 6044, 6047, 6050, 6053, 6055, 6058, 6061, 6064, 6066, 6069, 6072, 6075, 6077, 6080, 6083, 6085, 6088, 6091, 6093, 6096, 6099, 6101, 6104, 6107, 6109, 6112, 6115, 6117, 6120, 6122, 6125, 6128, 6130, 6133, 6135, 6138, 6140, 6143, 6145, 6148, 6151, 6153, 6156, 6158, 6161, 6163, 6166, 6168, 6170, 6173, 6175, 6178, 6180, 6183, 6185, 6188, 6190, 6193, 6195, 6197, 6200, 6202, 6205, 6207, 6209, 6212, 6214, 6216, 6219, 6221, 6224, 6226, 6228, 6231, 6233, 6235, 6238, 6240, 6242, 6244, 6247, 6249, 6251, 6254, 6256, 6258, 6260, 6263, 6265, 6267, 6269, 6272, 6274, 6276, 6278, 6281, 6283, 6285, 6287, 6289, 6292, 6294, 6296, 6298, 6300, 6303, 6305, 6307, 6309, 6311, 6313, 6316, 6318, 6320, 6322, 6324, 6326, 6328, 6330, 6333, 6335, 6337, 6339, 6341, 6343, 6345, 6347, 6349, 6351, 6353, 6356, 6358, 6360, 6362, 6364, 6366, 6368, 6370, 6372, 6374, 6376, 6378, 6380, 6382, 6384, 6386, 6388, 6390, 6392, 6394, 6396, 6398, 6400, 6402, 6404, 6406, 6408, 6410, 6412, 6414, 6416, 6418, 6420, 6421, 6423, 6425, 6427, 6429, 6431, 6433, 6435, 6437, 6439, 6441, 6443, 6444, 6446, 6448, 6450, 6452, 6454, 6456, 6458, 6459, 6461, 6463, 6465, 6467, 6469, 6471, 6472, 6474, 6476, 6478, 6480, 6482, 6483, 6485, 6487, 6489, 6491, 6493, 6494, 6496, 6498, 6500, 6502, 6503, 6505, 6507, 6509, 6510, 6512, 6514, 6516, 6518, 6519, 6521, 6523, 6525, 6526, 6528, 6530, 6532, 6533, 6535, 6537, 6538, 6540, 6542, 6544, 6545, 6547, 6549, 6550, 6552, 6554, 6556, 6557, 6559, 6561, 6562, 6564, 6566, 6567, 6569, 6571, 6572, 6574, 6576, 6577, 6579, 6581, 6582, 6584, 6586, 6587, 6589, 6591, 6592, 6594, 6596, 6597, 6599, 6600, 6602, 6604, 6605, 6607, 6609, 6610, 6612, 6613, 6615, 6617, 6618, 6620, 6621, 6623, 6625, 6626, 6628, 6629, 6631, 6632, 6634, 6636, 6637, 6639, 6640, 6642, 6643, 6645, 6647, 6648, 6650, 6651, 6653, 6654, 6656, 6657, 6659, 6660, 6662, 6663, 6665, 6667, 6668, 6670, 6671, 6673, 6674, 6676, 6677, 6679, 6680, 6682, 6683, 6685, 6686, 6688, 6689, 6691, 6692, 6694, 6695, 6697, 6698, 6699, 6701, 6702, 6704, 6705, 6707, 6708, 6710, 6711, 6713, 6714, 6716, 6717, 6718, 6720, 6721, 6723, 6724, 6726, 6727, 6729, 6730, 6731, 6733, 6734, 6736, 6737, 6739, 6740, 6741, 6743, 6744, 6746, 6747, 6748, 6750, 6751, 6753, 6754, 6755, 6757, 6758, 6760, 6761, 6762, 6764, 6765, 6767, 6768, 6769, 6771, 6772, 6773, 6775, 6776, 6778, 6779, 6780, 6782, 6783, 6784, 6786, 6787, 6788, 6790, 6791, 6793, 6794, 6795, 6797, 6798, 6799, 6801, 6802, 6803, 6805, 6806, 6807, 6809, 6810, 6811, 6813, 6814, 6815, 6816, 6818, 6819, 6820, 6822, 6823, 6824, 6826, 6827, 6828, 6830, 6831, 6832, 6833, 6835, 6836, 6837, 6839, 6840, 6841, 6842, 6844, 6845, 6846, 6848, 6849, 6850, 6851, 6853, 6854, 6855, 6856, 6858, 6859, 6860, 6862, 6863, 6864, 6865, 6867, 6868, 6869, 6870, 6872, 6873, 6874, 6875, 6877, 6878, 6879, 6880, 6882, 6883, 6884, 6885, 6886, 6888, 6889, 6890, 6891, 6893, 6894, 6895, 6896, 6897, 6899, 6900, 6901, 6902, 6904, 6905, 6906, 6907, 6908, 6910, 6911, 6912, 6913, 6914, 6916, 6917, 6918, 6919, 6920, 6921, 6923, 6924, 6925, 6926, 6927, 6929, 6930, 6931, 6932, 6933, 6934, 6936, 6937, 6938, 6939, 6940, 6941, 6943, 6944, 6945, 6946, 6947, 6948, 6950, 6951, 6952, 6953, 6954, 6955, 6957, 6958, 6959, 6960, 6961, 6962, 6963, 6965, 6966, 6967, 6968, 6969, 6970, 6971, 6972, 6974, 6975, 6976, 6977, 6978, 6979, 6980, 6981, 6983, 6984, 6985, 6986, 6987, 6988, 6989, 6990, 6991, 6993, 6994, 6995, 6996, 6997, 6998, 6999, 7000, 7001, 7003, 7004, 7005, 7006, 7007, 7008, 7009, 7010, 7011, 7012, 7013, 7015, 7016, 7017, 7018, 7019, 7020, 7021, 7022, 7023, 7024, 7025, 7026, 7027, 7029, 7030, 7031, 7032, 7033, 7034, 7035, 7036, 7037, 7038, 7039, 7040, 7041, 7042, 7043, 7044, 7046, 7047, 7048, 7049, 7050, 7051, 7052, 7053, 7054, 7055, 7056, 7057, 7058, 7059, 7060, 7061, 7062, 7063, 7064, 7065, 7066, 7067, 7068, 7069, 7070, 7071, 7073, 7074, 7075, 7076, 7077, 7078, 7079, 7080, 7081, 7082, 7083, 7084, 7085, 7086, 7087, 7088, 7089, 7090, 7091, 7092, 7093, 7094, 7095, 7096, 7097, 7098, 7099 };
@@ -764,6 +765,7 @@ static void processBroadcastFutureTickData(Peer* peer, RequestResponseHeader* he
         {
             if (!isZero(request->tickData.transactionDigests[i]))
             {
+                // Check if same transactionDigest is present in the tickData
                 for (unsigned int j = 0; j < i; j++)
                 {
                     if (request->tickData.transactionDigests[i] == request->tickData.transactionDigests[j])
@@ -961,6 +963,7 @@ static void processRequestQuorumTick(Peer* peer, RequestResponseHeader* header)
         // Todo: This function may be optimized by moving the checking of voteFlags in the first loop, reducing the number of calls to random().
         unsigned short computorIndices[NUMBER_OF_COMPUTORS];
         unsigned short numberOfComputorIndices;
+        int numEnq = 0;
         for (numberOfComputorIndices = 0; numberOfComputorIndices < NUMBER_OF_COMPUTORS; numberOfComputorIndices++)
         {
             computorIndices[numberOfComputorIndices] = numberOfComputorIndices;
@@ -972,15 +975,26 @@ static void processRequestQuorumTick(Peer* peer, RequestResponseHeader* header)
             if (!(request->quorumTick.voteFlags[computorIndices[index] >> 3] & (1 << (computorIndices[index] & 7))))
             {
                 // Todo: We should acquire ts.ticks lock here if tick >= system.tick
+
                 const Tick* tsTick = tsCompTicks + computorIndices[index];
                 if (tsTick->epoch == tickEpoch)
                 {
+                    ts.ticks.acquireLock(computorIndices[index]);
                     enqueueResponse(peer, sizeof(Tick), BroadcastTick::type, header->dejavu(), tsTick);
+                    ts.ticks.releaseLock(computorIndices[index]);
+                    numEnq++;
                 }
             }
 
             computorIndices[index] = computorIndices[--numberOfComputorIndices];
         }
+
+        CHAR16 dbgMsg[200];
+        setText(dbgMsg, L"SQT ");
+        appendNumber(dbgMsg, request->quorumTick.tick, FALSE);
+        appendText(dbgMsg, L" sent: ");
+        appendNumber(dbgMsg, numEnq, FALSE);
+        addDebugMessage(dbgMsg);
     }
     enqueueResponse(peer, 0, EndResponse::type, header->dejavu(), NULL);
 }
@@ -2454,6 +2468,9 @@ static void processTick(unsigned long long processorNumber)
     getUniverseDigest(etalonTick.saltedUniverseDigest);
     getComputerDigest(etalonTick.saltedComputerDigest);
 
+
+    // If node is MAIN has ID of tickleader for system.tick + TICK_TRANSACTIONS_PUBLICATION_OFFSET
+    // prepare tickData and enqueue it
     for (unsigned int i = 0; i < numberOfOwnComputorIndices; i++)
     {
         if ((system.tick + TICK_TRANSACTIONS_PUBLICATION_OFFSET) % NUMBER_OF_COMPUTORS == ownComputorIndices[i])
@@ -4465,8 +4482,9 @@ static void prepareNextTickTransactions()
 }
 
 
-// Computes the digest of all tx bodies of a certain tick
-static XKCP::KangarooTwelve_Instance computeTxBodyDigestBase(const int tick)
+// Computes the digest of all tx bodies of a certain tick and saves it in etalonTick
+//static m256i computeTxBodyDigestBase(const int tick)
+static void computeTxBodyDigestBase(const int tick)
 {
     constexpr size_t outputLen = 32; // output length in bytes
 
@@ -4476,23 +4494,99 @@ static XKCP::KangarooTwelve_Instance computeTxBodyDigestBase(const int tick)
     const unsigned int tickIndex = ts.tickToIndexCurrentEpoch(tick);
     const auto* tsTransactionOffsets = ts.tickTransactionOffsets.getByTickIndex(tickIndex);
 
-    for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
-    {
-        // TODO: Optimization to check: We have the ts locked for the whole K12_Update.
-        //       It might be worth to copy the transaction and release lock before update the K12 state.
-        ts.tickTransactions.acquireLock();
 
-        if (tsTransactionOffsets[i]) {
-            const Transaction *transaction =
-                ts.tickTransactions(tsTransactionOffsets[i]);
-            if (transaction->checkValidity() && transaction->tick == tick) {
-                XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char *>(transaction), transaction->totalSize());
+    int numTx = 0; // Counter for debuging
+    int numTxTd = 0; // Counter for debuging
+    CHAR16 digestChars[60 + 1];
+
+    if(logK12)
+    {
+        for(const auto &tx : nextTickData.transactionDigests)
+        {
+            if(!isZero(tx))
+            {
+                numTxTd++;
+                setText(message, L"txtd ");
+                appendNumber(message, numTxTd, false);
+                getIdentity(tx.m256i_u8, digestChars, true);
+                appendText(message, digestChars);
+                appendText(message, L".");
+                addDebugMessage(message);
             }
         }
 
-        ts.tickTransactions.releaseLock();
+        setText(message, L"tickdata tx: ");
+        appendNumber(message, numTxTd, TRUE);
+        appendText(message, L".");
+        addDebugMessage(message);
     }
-    return kt;
+
+    for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
+    {
+        if (!isZero(nextTickData.transactionDigests[i]))
+        {
+            // TODO: Optimization to check: We have the ts locked for the whole K12_Update.
+            //       It might be worth to copy the transaction and release lock before update the K12 state.
+            // TODO: Here we check each Tx against the nextTickData again (before we did it in prepareNextTickTransactions
+            //       Might be worth to do only do it once by saving flagging/removing tx which are in ts.tickTransactions
+            //       but not in nextTickData
+            ts.tickTransactions.acquireLock();
+
+            if (tsTransactionOffsets[i]) {
+                const Transaction* transaction = ts.tickTransactions(tsTransactionOffsets[i]);
+
+                if (transaction->checkValidity() && transaction->tick == tick) {
+                    unsigned char digest[32];
+                    KangarooTwelve(transaction, transaction->totalSize(), digest, sizeof(digest));
+                    if (digest == nextTickData.transactionDigests[i])
+                    {
+                        int ret = 1;
+                        while(ret == 1)
+                        {
+                            ret = XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char *>(transaction), transaction->totalSize());
+                            if (ret == 0)
+                            {
+                                numTx++;
+                                break;
+                            }
+                            else
+                            {
+                                setText(message, L"!!!!!!!!!!!!!XKCP FAILED!!!!!!!!!");
+                                addDebugMessage(message);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    setText(message, L"!!!!!!!!!!!!!TX FAILED VALIDATION!!!!!!!!!");
+                    addDebugMessage(message);
+                }
+            }
+
+            ts.tickTransactions.releaseLock();
+        }
+    }
+
+    int ret = 1;
+    while(ret == 1)
+    {
+        ret = XKCP::KangarooTwelve_Final(&kt, etalonTick.saltedTransactionBodyDigest.m256i_u8, (const unsigned char *)"", 0);
+        if(ret == 1)
+        {
+            setText(message, L"!!!!!!!!!!!!!XKCP FINALIZE FAILED!!!!!!!!!");
+            addDebugMessage(message);
+        }
+    }
+
+    if(logK12)
+    {
+        setText(message, L"Hashed tx: ");
+        appendNumber(message, numTx, TRUE);
+        appendText(message, L".");
+        addDebugMessage(message);
+    }
+    //return digest;
 }
 
 
@@ -4528,11 +4622,24 @@ static void broadcastTickVotes()
         broadcastTick.tick.computorIndex ^= BroadcastTick::type;
         sign(computorSubseeds[ownComputorIndicesMapping[i]].m256i_u8, computorPublicKeys[ownComputorIndicesMapping[i]].m256i_u8, digest, broadcastTick.tick.signature);
 
+
         enqueueResponse(NULL, sizeof(broadcastTick), BroadcastTick::type, 0, &broadcastTick);
         // NOTE: here we don't copy these votes to memory, instead we wait other nodes echoing these votes back because:
         // - if own votes don't get echoed back, that indicates this node has internet/topo issue, and need to reissue vote (F9)
         // - all votes need to be processed in a single place of code (for further handling)
         // - all votes are treated equally (own votes and their votes)
+    }
+
+    if(logVote)
+    {
+        setText(message, L"Broadcast vote for tick: ");
+        appendNumber(message, broadcastTick.tick.tick, TRUE);
+        appendText(message, L" txBodyDiges: ");
+        CHAR16 digestChars[60 + 1];
+        getIdentity(etalonTick.saltedTransactionBodyDigest.m256i_u8, digestChars, true);
+        appendText(message, digestChars);
+        appendText(message, L".");
+        addDebugMessage(message);
     }
 }
 
@@ -4723,7 +4830,7 @@ static void tickProcessor(void*)
 
             bool tickDataSuits; // a flag to tell if tickData is suitable to be included with this node states
             if (!targetNextTickDataDigestIsKnown) // Next tick digest is still unknown
-            {   
+            {
                 if (nextTickData.epoch != system.epoch // tick data is valid (not yet invalidated)
                     && gFutureTickTotalNumberOfComputors <= NUMBER_OF_COMPUTORS - QUORUM // future tick vote less than 225
                     && __rdtsc() - tickTicks[sizeof(tickTicks) / sizeof(tickTicks[0]) - 1] < TARGET_TICK_DURATION * frequency / 1000) // tick duration not exceed TARGET_TICK_DURATION
@@ -4861,31 +4968,34 @@ static void tickProcessor(void*)
                         etalonTick.expectedNextTickTransactionDigest = m256i::zero();
                     }
 
+
                     if (system.tick > system.latestCreatedTick || system.tick == system.initialTick)
                     {
-                        txBodyBaseNextTick = computeTxBodyDigestBase(nextTick);
-                        //                            XKCP::KangarooTwelve_Update(&txBody_base_nextTick, saltedData[0].m256i_u8, 32);
-                        XKCP::KangarooTwelve_Final(&txBodyBaseNextTick, etalonTick.saltedTransactionBodyDigest.m256i_u8, (const unsigned char *)"", 0);
+                        computeTxBodyDigestBase(nextTick); //Sets etalonTick
+
                         if (mainAuxStatus & 1)
                         {
                             broadcastTickVotes();
                         }
 
+                        // Avoid spamming votes after initial tick
                         if (system.tick != system.initialTick)
                         {
                             system.latestCreatedTick = system.tick;
+                            logVote = true;
+                            logK12 = true;
                         }
                     }
 
                     unsigned int tickNumberOfComputors = 0, tickTotalNumberOfComputors = 0;
                     updateVotesCount(tickNumberOfComputors, tickTotalNumberOfComputors);
-                    
+
                     gTickNumberOfComputors = tickNumberOfComputors;
                     gTickTotalNumberOfComputors = tickTotalNumberOfComputors;
 
                     if (tickNumberOfComputors >= QUORUM)
                     {
-                        tryForceEmptyNextTick();                        
+                        tryForceEmptyNextTick();
 
                         if (targetNextTickDataDigestIsKnown)
                         {
@@ -5945,6 +6055,67 @@ static void processKeyPresses()
     {
         switch (key.ScanCode)
         {
+
+        case 0x0B:
+        {
+            const unsigned int tickIndex = ts.tickToIndexCurrentEpoch(etalonTick.tick);
+            const auto *tsTransactionOffsets =
+                ts.tickTransactionOffsets.getByTickIndex(tickIndex);
+
+            int numTx = 0;
+            for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
+            {
+                numTx++;
+                ts.tickTransactions.acquireLock();
+
+                if (tsTransactionOffsets[i]) {
+                    const Transaction *transaction =
+                        ts.tickTransactions(tsTransactionOffsets[i]);
+                    if (transaction->checkValidity() && transaction->tick == etalonTick.tick)
+                        {
+
+                            const Transaction *transaction = ts.tickTransactions(tsTransactionOffsets[i]);
+
+                            CHAR16 digestChars[60 + 1];
+                            setText(message, L"Tx ");
+                            appendNumber(message, i, false);
+                            appendText(message, L": ");
+
+                            unsigned char digest[32];
+                            KangarooTwelve(transaction, transaction->totalSize(), digest, sizeof(digest));
+                            getIdentity(digest, digestChars, true);
+                            appendText(message, digestChars);
+                            appendText(message, L".\n");
+                            logToConsole(message);
+                    }
+                }
+                ts.tickTransactions.releaseLock();
+            }
+            setText(message, L"Num Tx: ");
+            appendNumber(message, numTx,false);
+            logToConsole(message);
+
+            setText(message, L"TX Diges: ");
+            logToConsole(message);
+
+            for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
+            {
+
+                if (!isZero(nextTickData.transactionDigests[i]))
+                {
+                    CHAR16 digestChars[60 + 1];
+                    setText(message, L"TxTickData ");
+                    appendNumber(message, i, false);
+                    appendText(message, L": ");
+
+                    getIdentity(&nextTickData.transactionDigests[i].m256i_u8[0], digestChars, true);
+                    appendText(message, digestChars);
+                    appendText(message, L".\n");
+                    logToConsole(message);
+                }
+            }
+        }
+        break;
         /*
         *
         * F2 Key
@@ -5953,7 +6124,7 @@ static void processKeyPresses()
         * Version, faulty Computors, Last Tick Date,
         * Digest of spectrum, universe, and computer, number of transactions and solutions processed
         */
-        case 0x0C: // 
+        case 0x0C:
         {
             setText(message, L"Qubic ");
             appendQubicVersion(message);

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4476,9 +4476,17 @@ static XKCP::KangarooTwelve_Instance computeTxBodyDigestBase(const int tick)
     {
         ts.tickTransactions.acquireLock();
 
-        const Transaction* transaction = ts.tickTransactions(tsTransactionOffsets[i]);
+        if (tsTransactionOffsets[i]) {
+            const Transaction *transaction =
+                ts.tickTransactions(tsTransactionOffsets[i]);
+            if (transaction->checkValidity() && transaction->tick == tick) {
+                XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char *>(transaction), transaction->totalSize());
+            }
+        }
 
-        XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char*>(transaction), transaction->totalSize());
+        // const Transaction* transaction = ts.tickTransactions(tsTransactionOffsets[i]);
+
+        // XKCP::KangarooTwelve_Update(&kt, reinterpret_cast<const unsigned char*>(transaction), transaction->totalSize());
 
         ts.tickTransactions.releaseLock();
     }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4861,11 +4861,11 @@ static void tickProcessor(void*)
 
                     if (system.tick > system.latestCreatedTick || system.tick == system.initialTick)
                     {
+                        txBody_base_nextTick = computeTxBodyDigestBase(nextTick);
+                        //                            XKCP::KangarooTwelve_Update(&txBody_base_nextTick, saltedData[0].m256i_u8, 32);
+                        XKCP::KangarooTwelve_Final(&txBody_base_nextTick, etalonTick.saltedTransactionBodyDigest.m256i_u8, (const unsigned char *)"", 0);
                         if (mainAuxStatus & 1)
                         {
-                            txBody_base_nextTick = computeTxBodyDigestBase(nextTick);
-                            //                            XKCP::KangarooTwelve_Update(&txBody_base_nextTick, saltedData[0].m256i_u8, 32);
-                            XKCP::KangarooTwelve_Final(&txBody_base_nextTick, etalonTick.saltedTransactionBodyDigest.m256i_u8, (const unsigned char *)"", 0);
                             broadcastTickVotes();
                         }
 

--- a/test/kangaroo_twelve.cpp
+++ b/test/kangaroo_twelve.cpp
@@ -1,6 +1,7 @@
 #define NO_UEFI
 
 #include "../src/K12/kangaroo_twelve_xkcp.h"
+#include "../src/kangaroo_twelve.h"
 #include "../src/platform/memory.h"
 #include <intrin.h>
 #include "gtest/gtest.h"
@@ -35,5 +36,57 @@ TEST(TestCoreK12, PerformanceDigest32Of1GB)
     double gigaBytePerSec = bytePerMilliSec * (1000.0 / bytesPerGigaByte);
     std::cout << "K12 of 1 GB to 32 Byte digest: " << gigaBytePerSec << " GB/sec = " << 1.0 / gigaBytePerSec << " sec/GB" << std::endl;
 
+    delete [] inputPtr;
+}
+
+TEST(TestCoreK12, CompareK12Implementations)
+{
+    constexpr size_t bytesPerGigaByte = 1024 * 1024 * 1024;
+    constexpr size_t repN = 1;
+    constexpr size_t inputN = bytesPerGigaByte;
+    constexpr size_t outputN = 32;
+
+    char* inputPtr = new char[inputN];
+    for (size_t i = 0; i < 100; ++i)
+    {
+        unsigned int pos, val;
+        _rdrand32_step(&pos);
+        _rdrand32_step(&val);
+        inputPtr[pos % inputN] = val & 0xff;
+    }
+    char outputArrayXKCP[outputN];
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < repN; ++i)
+        XKCP::KangarooTwelve((unsigned char *) inputPtr, inputN, (unsigned char*) outputArrayXKCP, outputN);
+    auto durationMilliSec = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime);
+
+    double bytePerMilliSec = double(repN * inputN) / double(durationMilliSec.count());
+    double gigaBytePerSec = bytePerMilliSec * (1000.0 / bytesPerGigaByte);
+    std::cout << "K12 of 1 GB to 32 Byte digest: " << gigaBytePerSec << " GB/sec = " << 1.0 / gigaBytePerSec << " sec/GB" << std::endl;
+    std::cout << "Digest of xkcp implementation: ";
+    for (int i = 0; i < sizeof(outputArrayXKCP); i++){
+        std::cout << std::hex << std::setfill('0') << std::setw(2)
+                  << (static_cast<int>(outputArrayXKCP[i]) & 0xff);
+    }
+    std::cout << std::endl;
+
+    char outputArray[outputN];
+    startTime = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < repN; ++i)
+        KangarooTwelve((unsigned char *) inputPtr, inputN, (unsigned char*) outputArray, outputN);
+    durationMilliSec = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime);
+
+    bytePerMilliSec = double(repN * inputN) / double(durationMilliSec.count());
+    gigaBytePerSec = bytePerMilliSec * (1000.0 / bytesPerGigaByte);
+    std::cout << "K12 of 1 GB to 32 Byte digest: " << gigaBytePerSec << " GB/sec = " << 1.0 / gigaBytePerSec << " sec/GB" << std::endl;
+    std::cout << "Digest of native implementation: ";
+
+    for (int i = 0; i < sizeof(outputArray); i++){
+        std::cout << std::hex << std::setfill('0') << std::setw(2) 
+                  << (static_cast<int>(outputArray[i]) & 0xff);
+    }
+    std::cout << std::endl;
+    ASSERT_EQ(memcmp(outputArrayXKCP, outputArray, outputN), 0);
     delete [] inputPtr;
 }

--- a/test/kangaroo_twelve.cpp
+++ b/test/kangaroo_twelve.cpp
@@ -1,10 +1,12 @@
 #define NO_UEFI
 
-#include "../src/kangaroo_twelve.h"
-
+#include "../src/K12/kangaroo_twelve_xkcp.h"
+#include "../src/platform/memory.h"
+#include <intrin.h>
 #include "gtest/gtest.h"
 
 #include <chrono>
+#include <iostream>
 
 
 TEST(TestCoreK12, PerformanceDigest32Of1GB)
@@ -26,7 +28,7 @@ TEST(TestCoreK12, PerformanceDigest32Of1GB)
 
     auto startTime = std::chrono::high_resolution_clock::now();
     for (size_t i = 0; i < repN; ++i)
-        KangarooTwelve(inputPtr, inputN, outputArray, outputN);
+        KangarooTwelve((unsigned char *) inputPtr, inputN, (unsigned char*) outputArray, outputN);
     auto durationMilliSec = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime);
 
     double bytePerMilliSec = double(repN * inputN) / double(durationMilliSec.count());

--- a/test/kangaroo_twelve.cpp
+++ b/test/kangaroo_twelve.cpp
@@ -28,7 +28,7 @@ TEST(TestCoreK12, PerformanceDigest32Of1GB)
 
     auto startTime = std::chrono::high_resolution_clock::now();
     for (size_t i = 0; i < repN; ++i)
-        KangarooTwelve((unsigned char *) inputPtr, inputN, (unsigned char*) outputArray, outputN);
+        XKCP::KangarooTwelve((unsigned char *) inputPtr, inputN, (unsigned char*) outputArray, outputN);
     auto durationMilliSec = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime);
 
     double bytePerMilliSec = double(repN * inputN) / double(durationMilliSec.count());

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -90,7 +90,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OpenMPSupport>true</OpenMPSupport>
-      <AdditionalIncludeDirectories>../src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../src/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -90,7 +90,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OpenMPSupport>true</OpenMPSupport>
-      <AdditionalIncludeDirectories>../src/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This PR adds an additional digest which acts as proof that a node has all transactions proposed by the tickleader.

As soon as a node has all transactions the tickleader proposes to include it will compute it's txBodyDigest by hashing all transaction bodies. While checking for consensus for the current tick this new txBodyDigest will be ignored for the consensus finding but a node only counts the vote of an other node if the txBodyDigest matches with his own version in the `etalontick`.

Additionally this PR includes the xkcp K12 algorithm that allows us to hash the transactionBodies while keeping the K12 state in memory until all transactions are hashed.