### PR TITLE
Optimize console-output part of main loop

### DIFF
--- a/src/network_messages/special_command.h
+++ b/src/network_messages/special_command.h
@@ -77,4 +77,12 @@ struct SpecialCommandGetMiningScoreRanking
 #define SPECIAL_COMMAND_FORCE_SWITCH_EPOCH 15ULL // F7
 #define SPECIAL_COMMAND_CONTINUE_SWITCH_EPOCH 16ULL // F10 (only log-enabled nodes need this)
 
+#define SPECIAL_COMMAND_SET_CONSOLE_LOGGING_MODE 17ULL // PAUSE key
+struct SpecialCommandSetConsoleLoggingModeRequestAndResponse
+{
+    unsigned long long everIncreasingNonceAndCommandType;
+    unsigned char loggingMode; // 0 disabled, 1 low computational cost, 2 full logging
+    unsigned char padding[7];
+};
+
 #pragma pack(pop)

--- a/src/platform/console_logging.h
+++ b/src/platform/console_logging.h
@@ -24,7 +24,7 @@ static inline void outputStringToConsole(const CHAR16* str)
 // Log message to console (with line break) on non-UEFI platform
 static void logToConsole(const CHAR16* message)
 {
-    if (disableConsoleLogging)
+    if (!consoleLoggingLevel)
         return;
     wprintf(L"%ls\n", message);
 }

--- a/src/platform/console_logging.h
+++ b/src/platform/console_logging.h
@@ -2,7 +2,7 @@
 
 #include "uefi.h"
 
-static bool disableConsoleLogging = false;
+static unsigned char consoleLoggingLevel = 1;
 
 // message buffers:
 // - message is for public use

--- a/src/platform/console_logging.h
+++ b/src/platform/console_logging.h
@@ -24,7 +24,7 @@ static inline void outputStringToConsole(const CHAR16* str)
 // Log message to console (with line break) on non-UEFI platform
 static void logToConsole(const CHAR16* message)
 {
-    if (!consoleLoggingLevel)
+    if (consoleLoggingLevel == 0)
         return;
     wprintf(L"%ls\n", message);
 }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -337,7 +337,7 @@ static void logToConsole(const CHAR16* message)
     bool logAsDebugMessage = epochTransitionState
                                 || system.tick - system.initialTick < 3
                                 || system.tick % 10 == 0
-                                || misalignedState == 1
+                                || misalignedState == 2
                                 || forceLogToConsoleAsAddDebugMessage
         ;
     if (logAsDebugMessage)
@@ -6937,15 +6937,20 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                     {
                         if (misalignedState == 0)
                         {
-                            // also log to debug.log
+                            // misaligned state detected the first time
                             misalignedState = 1;
                         }
+                        else if (misalignedState == 1)
+                        {
+                            // state persisting for at least a second -> also log to debug.log
+                            misalignedState = 2;
+                        }
                         logToConsole(L"MISALIGNED STATE DETECTED");
-                        if (misalignedState == 1)
+                        if (misalignedState == 2)
                         {
                             // print health status and stop repeated logging to debug.log
                             logHealthStatus();
-                            misalignedState = 2;
+                            misalignedState = 3;
                         }
                     }
                     else

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1337,6 +1337,14 @@ static void processSpecialCommand(Peer* peer, RequestResponseHeader* header)
                 enqueueResponse(peer, sizeof(SpecialCommand), SpecialCommand::type, header->dejavu(), request); // echo back to indicate success
             }
             break;
+
+            case SPECIAL_COMMAND_SET_CONSOLE_LOGGING_MODE:
+            {
+                const auto* _request = header->getPayload<SpecialCommandSetConsoleLoggingModeRequestAndResponse>();
+                consoleLoggingLevel = _request->loggingMode;
+                enqueueResponse(peer, sizeof(SpecialCommandToggleMainModeRequestAndResponse), SpecialCommand::type, header->dejavu(), _request);
+            }
+            break;
             }
         }
     }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -291,7 +291,7 @@ static struct {
 
 static void logToConsole(const CHAR16* message)
 {
-    if (disableConsoleLogging)
+    if (consoleLoggingLevel == 0)
     {
         return;
     }
@@ -5688,6 +5688,11 @@ static void deinitialize()
 
 static void logInfo()
 {
+    if (consoleLoggingLevel == 0)
+    {
+        return;
+    }
+
     unsigned long long numberOfWaitingBytes = 0;
 
     for (unsigned int i = 0; i < NUMBER_OF_OUTGOING_CONNECTIONS + NUMBER_OF_INCOMING_CONNECTIONS; i++)
@@ -5763,6 +5768,11 @@ static void logInfo()
     prevNumberOfDisseminatedRequests = numberOfDisseminatedRequests;
     prevNumberOfReceivedBytes = numberOfReceivedBytes;
     prevNumberOfTransmittedBytes = numberOfTransmittedBytes;
+
+    if (consoleLoggingLevel < 2)
+    {
+        return;
+    }
 
     setNumber(message, numberOfProcessors - 2, TRUE);
 
@@ -6413,11 +6423,11 @@ static void processKeyPresses()
 
         /*
         * PAUSE Key
-        * By Pressing the PAUSE Key you can toggle the log output
+        * By Pressing the PAUSE Key you can cycle through the log output verbosity level
         */
         case 0x48:
         {
-            disableConsoleLogging = !disableConsoleLogging;
+            consoleLoggingLevel = (consoleLoggingLevel + 1) % 3;
         }
         break;
         }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -6430,8 +6430,8 @@ static void processKeyPresses()
         break;
 
         /*
-        * PAUSE Key
-        * By Pressing the PAUSE Key you can cycle through the log output verbosity level
+        * PAUSE key
+        * By pressing the PAUSE key you can cycle through the log output verbosity level
         */
         case 0x48:
         {


### PR DESCRIPTION
- Add less-output mode as default
- Prevent unneeded calculations in logInfo()
- Add special command for setting console logging level remotely
- Log node health only if misalignment persists >1 second