### PR TITLE
Hotfix: disable whitelisting

### DIFF
--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -103,6 +103,7 @@ static volatile char responseQueueHeadLock = 0;
 static volatile unsigned long long queueProcessingNumerator = 0, queueProcessingDenominator = 0;
 static volatile unsigned long long tickerLoopNumerator = 0, tickerLoopDenominator = 0;
 
+/*
 static bool isWhiteListPeer(unsigned char address[4])
 {
     for (unsigned int i = 0; i < NUMBER_OF_WHITE_LIST_PEERS; i++)
@@ -118,6 +119,7 @@ static bool isWhiteListPeer(unsigned char address[4])
     }
     return false;
 }
+*/
 
 static void closePeer(Peer* peer)
 {

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -482,7 +482,7 @@ static bool peerConnectionNewlyEstablished(unsigned int i)
                     else
                     {
                         /* GetModeData() freezes the node occasionally: the quick-fix is to disable whitelisting
-                        // Out of slot for preserse IPs. Only accept white list IPs
+                        // If number of unused incoming connection slots is low, only accept white list IPs
                         if (NUMBER_OF_INCOMING_CONNECTIONS - numberOfAcceptedIncommingConnection < NUMBER_OF_INCOMING_CONNECTIONS_RESERVED_FOR_WHITELIST_IPS)
                         {
                             EFI_TCP4_CONFIG_DATA tcp4ConfigData;

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -479,6 +479,7 @@ static bool peerConnectionNewlyEstablished(unsigned int i)
                     }
                     else
                     {
+                        /* GetModeData() freezes the node occasionally: the quick-fix is to disable whitelisting
                         // Out of slot for preserse IPs. Only accept white list IPs
                         if (NUMBER_OF_INCOMING_CONNECTIONS - numberOfAcceptedIncommingConnection < NUMBER_OF_INCOMING_CONNECTIONS_RESERVED_FOR_WHITELIST_IPS)
                         {
@@ -504,6 +505,7 @@ static bool peerConnectionNewlyEstablished(unsigned int i)
                             }
                         }
                         else
+                        */
                         {
                             peers[i].isConnectedAccepted = TRUE;
                         }

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -16,11 +16,13 @@ static const unsigned char knownPublicPeers[][4] = {
     {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
 };
 
+/* Whitelisting has been disabled, as requesting the IP of the incoming connection freezes the node occasionally
 // Enter static IPs that shall be prioritized in incoming connection
 // There are a connection slots reserved for those whitelist IPs
 static const unsigned char whiteListPeers[][4] = {
      {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
 };
+*/
 
 #define LOG_QU_TRANSFERS 0 // "0" disables logging, "1" enables it
 #define LOG_BURNINGS 0

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -18,7 +18,7 @@ static const unsigned char knownPublicPeers[][4] = {
 
 /* Whitelisting has been disabled, as requesting the IP of the incoming connection freezes the node occasionally
 // Enter static IPs that shall be prioritized in incoming connection
-// There are a connection slots reserved for those whitelist IPs
+// There are connection slots reserved for those whitelist IPs
 static const unsigned char whiteListPeers[][4] = {
      {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
 };


### PR DESCRIPTION
When used to request the IP of incoming connections, `GetModeData()` freezes the node occasionally. This call is only used for whitelisting. As a workaround to prevent these freezes, whitelisting is disabled.