### PR TITLE
Gradually flush for async file io.

### DIFF
--- a/src/platform/concurrency.h
+++ b/src/platform/concurrency.h
@@ -14,3 +14,4 @@
 #define ATOMIC_STORE8(target, val) _InterlockedExchange8(&target, val)
 #define ATOMIC_INC64(target) _InterlockedIncrement64(&target)
 #define ATOMIC_AND64(target, val) _InterlockedAnd64(&target, val)
+#define ATOMIC_STORE64(target, val) _InterlockedExchange64(&target, val)

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -21,7 +21,7 @@
 
 // Size of buffer for non-blocking save, this size will divided into ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS.
 // Can set by zeros to save memory and don't use non-block save
-static constexpr unsigned long long ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE = 8 * 1024 * 1024 * 1024ULL; // Set 0 if don't need non-blocking save
+static constexpr unsigned long long ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE = 0;//8 * 1024 * 1024 * 1024ULL; // Set 0 if don't need non-blocking save
 static constexpr int ASYNC_FILE_IO_BLOCKING_MAX_QUEUE_ITEMS_2FACTOR = 10;
 static constexpr int ASYNC_FILE_IO_MAX_QUEUE_ITEMS_2FACTOR = 4;
 static constexpr int ASYNC_FILE_IO_MAX_FILE_NAME = 64;

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -416,7 +416,7 @@ int partition(PairStruct<KeyType, ValueType>* arr, int left, int right)
     return i + 1;
 }
 
-// Find k largest elements in the array and but them in the left
+// Find k largest elements in the array and put them in the left
 template<typename KeyType, typename ValueType>
 void findKLargest(PairStruct<KeyType, ValueType>* arr, int k, int dataSize)
 {

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -7050,11 +7050,12 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                 // Flush the file system. Only flush one item at a time to avoid the main loop stay too long
                 // Even if the time is not satisfied, when still flush at least some items to make sure the save/load not stuck forever
                 // TODO: profile the read/write speed of the file system at the begining and adjust the number of items to flush
+                int remainedItem = 1;
                 do
                 {
-                    flushAsyncFileIOBuffer(1);
-                } 
-                while ((__rdtsc() - curTimeTick) * 1000000 / frequency < TARGET_MAINTHREAD_LOOP_DURATION);
+                    remainedItem = flushAsyncFileIOBuffer(1);
+                }
+                while (remainedItem > 0 && ((__rdtsc() - curTimeTick) * 1000000 / frequency < TARGET_MAINTHREAD_LOOP_DURATION));
             }
 
             saveSystem();

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -77,6 +77,7 @@
 #define TICK_VOTE_COUNTER_PUBLICATION_OFFSET 4 // Must be at least 3+: 1+ for tx propagation + 1 for tickData propagation + 1 for vote propagation
 #define MIN_MINING_SOLUTIONS_PUBLICATION_OFFSET 3 // Must be 3+
 #define TIME_ACCURACY 5000
+constexpr unsigned long long TARGET_MAINTHREAD_LOOP_DURATION = 30; // mcs, it is the target duration of the main thread loop
 
 
 struct Processor : public CustomStack
@@ -7046,8 +7047,14 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
 #if !defined(NDEBUG)
                 printDebugMessages();
 #endif
-                // Flush the file system
-                flushAsyncFileIOBuffer();
+                // Flush the file system. Only flush one item at a time to avoid the main loop stay too long
+                // Even if the time is not satisfied, when still flush at least some items to make sure the save/load not stuck forever
+                // TODO: profile the read/write speed of the file system at the begining and adjust the number of items to flush
+                do
+                {
+                    flushAsyncFileIOBuffer(1);
+                } 
+                while ((__rdtsc() - curTimeTick) * 1000000 / frequency < TARGET_MAINTHREAD_LOOP_DURATION);
             }
 
             saveSystem();

--- a/test/file_io.cpp
+++ b/test/file_io.cpp
@@ -321,9 +321,7 @@ bool verifyResult(int id, bool largeFile = false)
     return testPass;
 }
 
-#if 0
-
-TEST(TestAsyncFileIO, AsyncNonBlockingSaveFile)
+int runTestAsyncSaveFile(bool blocking, bool largeFile, bool limitItem)
 {
     fileSystem.initTestData();
 
@@ -332,7 +330,38 @@ TEST(TestAsyncFileIO, AsyncNonBlockingSaveFile)
     for (int i = 0; i < THREAD_COUNT; i++)
     {
         threadFinish[i] = 0;
-        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, false, false));
+        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, blocking, largeFile));
+    }
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+    int readyCount = 0;
+    while (readyCount < THREAD_COUNT)
+    {
+        // Don't flush right away. Wait sometimes for simulate
+        if (limitItem)
+        {
+            flushAsyncFileIOBuffer(2);
+        }
+        else
+        {
+            unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
+            if (waitingTimeInMs > 1000)
+            {
+                startTime = std::chrono::high_resolution_clock::now();
+                flushAsyncFileIOBuffer();
+            }
+        }
+
+        readyCount = 0;
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            char readyFlag = 0;
+            readyFlag = threadFinish[i];
+            if (readyFlag)
+            {
+                readyCount++;
+            }
+        }
     }
 
     for (int i = 0; i < THREAD_COUNT; i++)
@@ -342,277 +371,174 @@ TEST(TestAsyncFileIO, AsyncNonBlockingSaveFile)
             threadVec[i]->join();
         }
     }
-    // Actually write happen here
-    flushAsyncFileIOBuffer();
+
+    // Non blocking, need to flush all data
+    if (!blocking)
+    {
+        flushAsyncFileIOBuffer();
+    }
 
     // Verify result
     int testPass = 0;
     for (int i = 0; i < THREAD_COUNT; i++)
     {
-        if (verifyResult(i))
+        if (verifyResult(i, largeFile))
         {
             testPass++;
         }
     }
-    EXPECT_EQ(testPass, THREAD_COUNT);
+    return testPass;
+}
+
+
+int runTestAsyncLoadFile(bool blocking, bool largeFile, bool limitItem)
+{
+    prepareAsyncLoadFile(largeFile);
+
+    // Run the test
+    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        threadFinish[i] = 0;
+        threadVec[i].reset(new std::thread(runAsyncLoadFile, i, largeFile));
+    }
+    auto startTime = std::chrono::high_resolution_clock::now();
+    int readyCount = 0;
+    while (readyCount < THREAD_COUNT)
+    {
+        // Don't flush right away. Wait sometimes for simulate
+        if (limitItem)
+        {
+            flushAsyncFileIOBuffer(2);
+        }
+        else
+        {
+            unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
+            if (waitingTimeInMs > 1000)
+            {
+                startTime = std::chrono::high_resolution_clock::now();
+                flushAsyncFileIOBuffer();
+            }
+        }
+
+        readyCount = 0;
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            char readyFlag = 0;
+            readyFlag = threadFinish[i];
+            if (readyFlag)
+            {
+                readyCount++;
+            }
+        }
+    }
+
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (threadVec[i]->joinable())
+        {
+            threadVec[i]->join();
+        }
+    }
+
+    // Verify result
+    int testPass = 0;
+    for (int i = 0; i < THREAD_COUNT; i++)
+    {
+        if (verifyResult(i, largeFile))
+        {
+            testPass++;
+        }
+    }
+    return testPass;
+}
+
+TEST(TestAsyncFileIO, AsyncNonBlockingSaveFile)
+{
+    if (ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE > 0)
+    {
+        EXPECT_EQ(runTestAsyncSaveFile(false, false, false), THREAD_COUNT);
+    }
+    else
+    {
+        EXPECT_TRUE(true);
+    }
 }
 
 TEST(TestAsyncFileIO, AsyncNonBlockingSaveLargeFile)
 {
-    fileSystem.initTestData();
-
-    // Run the test
-    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
-    for (int i = 0; i < THREAD_COUNT; i++)
+    if (ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE > 0)
     {
-        threadFinish[i] = 0;
-        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, false, true));
+        EXPECT_EQ(runTestAsyncSaveFile(false, true, false), THREAD_COUNT);
     }
-
-    for (int i = 0; i < THREAD_COUNT; i++)
+    else
     {
-        if (threadVec[i]->joinable())
-        {
-            threadVec[i]->join();
-        }
+        EXPECT_TRUE(true);
     }
-    // Actually write happen here
-    flushAsyncFileIOBuffer();
-
-    // Verify result
-    int testPass = 0;
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (verifyResult(i, true))
-        {
-            testPass++;
-        }
-    }
-    EXPECT_EQ(testPass, THREAD_COUNT);
 }
 
-#endif
+TEST(TestAsyncFileIO, AsyncNonBlockingSaveFileWithLimitItems)
+{
+    if (ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE > 0)
+    {
+        EXPECT_EQ(runTestAsyncSaveFile(false, false, true), THREAD_COUNT);
+    }
+    else
+    {
+        EXPECT_TRUE(true);
+    }
+}
+
+TEST(TestAsyncFileIO, AsyncNonBlockingSaveLargeFileWithLimitItems)
+{
+    if (ASYNC_FILE_IO_WRITE_QUEUE_BUFFER_SIZE > 0)
+    {
+        EXPECT_EQ(runTestAsyncSaveFile(false, true, true), THREAD_COUNT);
+    }
+    else
+    {
+        EXPECT_TRUE(true);
+    }
+}
+
 
 TEST(TestAsyncFileIO, AsyncSaveFile)
 {
-    fileSystem.initTestData();
-
-    // Run the test
-    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        threadFinish[i] = 0;
-        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, true, false));
-    }
-
-    auto startTime = std::chrono::high_resolution_clock::now();
-    int readyCount = 0;
-    while (readyCount < THREAD_COUNT)
-    {
-        // Don't flush right away. Wait sometimes for simulate
-        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
-        if (waitingTimeInMs > 10000)
-        {
-            startTime = std::chrono::high_resolution_clock::now();
-            flushAsyncFileIOBuffer();
-        }
-
-        readyCount = 0;
-        for (int i = 0; i < THREAD_COUNT; i++)
-        {
-            char readyFlag = 0;
-            readyFlag = threadFinish[i];
-            if (readyFlag)
-            {
-                readyCount++;
-            }
-        }
-    }
-
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (threadVec[i]->joinable())
-        {
-            threadVec[i]->join();
-        }
-    }
-
-    // Verify result
-    int testPass = 0;
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (verifyResult(i))
-        {
-            testPass++;
-        }
-    }
-    EXPECT_EQ(testPass, THREAD_COUNT);
+    EXPECT_EQ(runTestAsyncSaveFile(true, false, false), THREAD_COUNT);
 }
 
 TEST(TestAsyncFileIO, AsyncSaveLargeFile)
 {
-    fileSystem.initTestData();
+    EXPECT_EQ(runTestAsyncSaveFile(true, true, false), THREAD_COUNT);
+}
 
-    // Run the test
-    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        threadFinish[i] = 0;
-        threadVec[i].reset(new std::thread(runAsyncSaveFile, i, true, true));
-    }
+TEST(TestAsyncFileIO, AsyncSaveFileWithLimitItems)
+{
+    EXPECT_EQ(runTestAsyncSaveFile(true, false, true), THREAD_COUNT);
+}
 
-    auto startTime = std::chrono::high_resolution_clock::now();
-    int readyCount = 0;
-    while (readyCount < THREAD_COUNT)
-    {
-        // Don't flush right away. Wait sometimes for simulate
-        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
-        if (waitingTimeInMs > 10000)
-        {
-            startTime = std::chrono::high_resolution_clock::now();
-            flushAsyncFileIOBuffer();
-        }
-
-        readyCount = 0;
-        for (int i = 0; i < THREAD_COUNT; i++)
-        {
-            char readyFlag = 0;
-            readyFlag = threadFinish[i];
-            if (readyFlag)
-            {
-                readyCount++;
-            }
-        }
-    }
-
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (threadVec[i]->joinable())
-        {
-            threadVec[i]->join();
-        }
-    }
-
-    // Verify result
-    int testPass = 0;
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (verifyResult(i, true))
-        {
-            testPass++;
-        }
-    }
-    EXPECT_EQ(testPass, THREAD_COUNT);
+TEST(TestAsyncFileIO, AsyncSaveLargeFileWithLimitItems)
+{
+    EXPECT_EQ(runTestAsyncSaveFile(true, true, true), THREAD_COUNT);
 }
 
 TEST(TestAsyncFileIO, AsyncLoadFile)
 {
-    prepareAsyncLoadFile(false);
-
-    // Run the test
-    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        threadFinish[i] = 0;
-        threadVec[i].reset(new std::thread(runAsyncLoadFile, i, false));
-    }
-
-    auto startTime = std::chrono::high_resolution_clock::now();
-    int readyCount = 0;
-    while (readyCount < THREAD_COUNT)
-    {
-        // Don't flush right away. Wait sometimes for simulate
-        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
-        if (waitingTimeInMs > 10000)
-        {
-            startTime = std::chrono::high_resolution_clock::now();
-            flushAsyncFileIOBuffer();
-        }
-
-        readyCount = 0;
-        for (int i = 0; i < THREAD_COUNT; i++)
-        {
-            char readyFlag = 0;
-            readyFlag = threadFinish[i];
-            if (readyFlag)
-            {
-                readyCount++;
-            }
-        }
-    }
-
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (threadVec[i]->joinable())
-        {
-            threadVec[i]->join();
-        }
-    }
-
-    // Verify result
-    int testPass = 0;
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (verifyResult(i))
-        {
-            testPass++;
-        }
-    }
-    EXPECT_EQ(testPass, THREAD_COUNT);
+    EXPECT_EQ(runTestAsyncLoadFile(true, false, false), THREAD_COUNT);
 }
 
 TEST(TestAsyncFileIO, AsyncLoadLargeFile)
 {
-    prepareAsyncLoadFile(true);
-
-    // Run the test
-    std::vector<std::unique_ptr<std::thread>> threadVec(THREAD_COUNT);
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        threadFinish[i] = 0;
-        threadVec[i].reset(new std::thread(runAsyncLoadFile, i, true));
-    }
-
-    auto startTime = std::chrono::high_resolution_clock::now();
-    int readyCount = 0;
-    while (readyCount < THREAD_COUNT)
-    {
-        // Don't flush right away. Wait sometimes for simulate
-        unsigned long long waitingTimeInMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startTime).count();
-        if (waitingTimeInMs > 10000)
-        {
-            startTime = std::chrono::high_resolution_clock::now();
-            flushAsyncFileIOBuffer();
-        }
-
-        readyCount = 0;
-        for (int i = 0; i < THREAD_COUNT; i++)
-        {
-            char readyFlag = 0;
-            readyFlag = threadFinish[i];
-            if (readyFlag)
-            {
-                readyCount++;
-            }
-        }
-    }
-
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (threadVec[i]->joinable())
-        {
-            threadVec[i]->join();
-        }
-    }
-
-    // Verify result
-    int testPass = 0;
-    for (int i = 0; i < THREAD_COUNT; i++)
-    {
-        if (verifyResult(i, true))
-        {
-            testPass++;
-        }
-    }
-    EXPECT_EQ(testPass, THREAD_COUNT);
+    EXPECT_EQ(runTestAsyncLoadFile(true, true, false), THREAD_COUNT);
 }
+
+TEST(TestAsyncFileIO, AsyncLoadFileWithLimitItems)
+{
+    EXPECT_EQ(runTestAsyncLoadFile(true, false, true), THREAD_COUNT);
+}
+
+TEST(TestAsyncFileIO, AsyncLoadLargeFileWithLimitItems)
+{
+    EXPECT_EQ(runTestAsyncLoadFile(true, true, true), THREAD_COUNT);
+}
+

--- a/test/file_io.cpp
+++ b/test/file_io.cpp
@@ -569,3 +569,116 @@ TEST(TestAsyncFileIO, FindKLargest)
     }
 }
 
+TEST(TestAsyncFileIO, FindKLargestOneItemArray)
+{
+    constexpr int NUMBER_OF_ELEMENTS = 1;
+    constexpr int K_NUMBER = 1;
+
+    PairStruct<unsigned int, long long> priorityArray[NUMBER_OF_ELEMENTS];
+    priorityArray[0]._value = random(1000);
+
+    // Find K largest in priorityArray
+    findKLargest(priorityArray, K_NUMBER, NUMBER_OF_ELEMENTS);
+
+    // Comparison. Expect all K left items are greater than remained items
+    for (int i = 0; i < K_NUMBER; i++)
+    {
+        for (int j = K_NUMBER; j < NUMBER_OF_ELEMENTS; j++)
+        {
+            EXPECT_GE(priorityArray[i]._value, priorityArray[j]._value);
+        }
+    }
+}
+
+TEST(TestAsyncFileIO, FindKLargestDuplicatedItems)
+{
+    constexpr int NUMBER_OF_ELEMENTS = 1000;
+    constexpr int K_NUMBER = 100;
+
+    PairStruct<unsigned int, long long> priorityArray[NUMBER_OF_ELEMENTS];
+
+    // Generate the elements
+    const int value = random(NUMBER_OF_ELEMENTS);
+    for (int i = 0; i < NUMBER_OF_ELEMENTS; i++)
+    {
+        priorityArray[i]._key = i;
+        priorityArray[i]._value = value;
+    }
+
+    // Find K largest in priorityArray
+    findKLargest(priorityArray, K_NUMBER, NUMBER_OF_ELEMENTS);
+
+    // Comparison. Expect all K left items are greater than remained items
+    for (int i = 0; i < K_NUMBER; i++)
+    {
+        for (int j = K_NUMBER; j < NUMBER_OF_ELEMENTS; j++)
+        {
+            EXPECT_GE(priorityArray[i]._value, priorityArray[j]._value);
+        }
+    }
+}
+
+TEST(TestAsyncFileIO, FindKLargestK1)
+{
+    constexpr int NUMBER_OF_ELEMENTS = 1000;
+    constexpr int K_NUMBER = 1;
+
+    PairStruct<unsigned int, long long> priorityArray[NUMBER_OF_ELEMENTS];
+
+    // Generate the elements
+    for (int i = 0; i < NUMBER_OF_ELEMENTS; i++)
+    {
+        priorityArray[i]._key = i;
+        priorityArray[i]._value = random(NUMBER_OF_ELEMENTS);
+    }
+
+    // Find K largest in priorityArray
+    findKLargest(priorityArray, K_NUMBER, NUMBER_OF_ELEMENTS);
+
+    // Comparison. The first item is the largest one
+    for (int j = 1; j < NUMBER_OF_ELEMENTS; j++)
+    {
+        EXPECT_GE(priorityArray[0]._value, priorityArray[j]._value);
+    }
+}
+
+TEST(TestAsyncFileIO, FindKLargestKDuplicated)
+{
+    constexpr int NUMBER_OF_ELEMENTS = 1000;
+    constexpr int K_NUMBER = 100;
+
+    PairStruct<unsigned int, long long> priorityArray[NUMBER_OF_ELEMENTS];
+
+    // Generate the elements
+    std::vector<long long> numbers(NUMBER_OF_ELEMENTS);
+
+    // Constant value for first K_NUMBER + 1 element
+    const int value = NUMBER_OF_ELEMENTS + 1;
+    for (int i =0; i < K_NUMBER + 1; i++)
+    {
+        priorityArray[i]._value = value;
+    }
+    for (int i = K_NUMBER + 1; i < NUMBER_OF_ELEMENTS; i++)
+    {
+        priorityArray[i]._value = random(NUMBER_OF_ELEMENTS);
+    }
+
+    // Shuffle the array
+    for (int i = 0; i < NUMBER_OF_ELEMENTS; i++)
+    {
+        int newLocation = random(NUMBER_OF_ELEMENTS);
+        long long tempValue = priorityArray[i]._value;
+        priorityArray[i]._value = priorityArray[newLocation]._value;
+        priorityArray[newLocation]._value = tempValue;
+    }
+
+    // Find K largest in priorityArray
+    findKLargest(priorityArray, K_NUMBER, NUMBER_OF_ELEMENTS);
+
+    // Comparison. The first item is the largest one
+    for (int j = 0; j < K_NUMBER; j++)
+    {
+        EXPECT_EQ(priorityArray[j]._value, value);
+    }
+}
+

--- a/test/file_io.cpp
+++ b/test/file_io.cpp
@@ -542,3 +542,30 @@ TEST(TestAsyncFileIO, AsyncLoadLargeFileWithLimitItems)
     EXPECT_EQ(runTestAsyncLoadFile(true, true, true), THREAD_COUNT);
 }
 
+TEST(TestAsyncFileIO, FindKLargest)
+{
+    constexpr int NUMBER_OF_ELEMENTS = 2025;
+    constexpr int K_NUMBER = 245;
+
+    PairStruct<unsigned int, long long> priorityArray[NUMBER_OF_ELEMENTS];
+
+    // Generate the elements
+    for (int i = 0; i < NUMBER_OF_ELEMENTS; i++)
+    {
+        priorityArray[i]._key = i;
+        priorityArray[i]._value = random(NUMBER_OF_ELEMENTS);
+    }
+   
+    // Find K largest in priorityArray
+    findKLargest(priorityArray, K_NUMBER, NUMBER_OF_ELEMENTS);
+    
+    // Comparison. Expect all K left items are greater than remained items
+    for (int i = 0; i < K_NUMBER; i++)
+    {
+        for (int j = K_NUMBER; j < NUMBER_OF_ELEMENTS; j++)
+        {
+            EXPECT_GE(priorityArray[i]._value, priorityArray[j]._value);
+        }
+    }
+}
+


### PR DESCRIPTION
Support gradual flushing of operators to prevent the main loop from waiting too long when I/O operations are heavy.
- Items will be flushed based on priority, where priority is currently determined by the item's age.








