### PR TITLE
Add custom mining revenue recording.

### DIFF
--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -38,12 +38,12 @@ struct CustomMiningTask
 {
     unsigned long long taskIndex; // ever increasing number (unix timestamp in ms)
 
-    unsigned char m_blob[408]; // Job data from pool
-    unsigned long long m_size;  // length of the blob
-    unsigned long long m_target; // Pool difficulty
-    unsigned long long m_height; // Block height
-    unsigned char m_seed[32]; // Seed hash for XMR
-    unsigned int m_extraNonce;
+    unsigned char blob[408]; // Job data from pool
+    unsigned long long size;  // length of the blob
+    unsigned long long target; // Pool difficulty
+    unsigned long long height; // Block height
+    unsigned char seed[32]; // Seed hash for XMR
+    unsigned int extraNonce;
 };
 
 struct CustomMiningSolution
@@ -64,7 +64,7 @@ class CustomMiningSharesCounter
 private:
     unsigned int _shareCount[NUMBER_OF_COMPUTORS];
     unsigned long long _accumulatedSharesCount[NUMBER_OF_COMPUTORS];
-    unsigned int buffer[NUMBER_OF_COMPUTORS];
+    unsigned int _buffer[NUMBER_OF_COMPUTORS];
 protected:
     unsigned int extract10Bit(const unsigned char* data, unsigned int idx)
     {
@@ -100,7 +100,7 @@ protected:
     }
 
 public:
-    static constexpr unsigned int CustomMiningSolutionCounterDataSize = sizeof(_shareCount) + sizeof(_accumulatedSharesCount);
+    static constexpr unsigned int _customMiningSolutionCounterDataSize = sizeof(_shareCount) + sizeof(_accumulatedSharesCount);
     void init()
     {
         setMem(_shareCount, sizeof(_shareCount), 0);
@@ -116,16 +116,16 @@ public:
     void compressNewSharesPacket(unsigned int ownComputorIdx, unsigned char customMiningShareCountPacket[CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES])
     {
         setMem(customMiningShareCountPacket, sizeof(customMiningShareCountPacket), 0);
-        setMem(buffer, sizeof(buffer), 0);
+        setMem(_buffer, sizeof(_buffer), 0);
         for (int j = 0; j < NUMBER_OF_COMPUTORS; j++)
         {
-            buffer[j] = _shareCount[j];
+            _buffer[j] = _shareCount[j];
         }
 
-        buffer[ownComputorIdx] = 0; // remove self-report
+        _buffer[ownComputorIdx] = 0; // remove self-report
         for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
         {
-            update10Bit(customMiningShareCountPacket, i, buffer[i]);
+            update10Bit(customMiningShareCountPacket, i, _buffer[i]);
         }
     }
 

--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -32,20 +32,6 @@ struct CustomMiningSolutionTransaction : public Transaction
     {
         return CUSTOM_MINING_SHARE_COUNTER_INPUT_TYPE;
     }
-
-    static constexpr long long minAmount()
-    {
-        return 0;
-    }
-
-    static constexpr unsigned short minInputSize()
-    {
-        return sizeof(miningSeed) + sizeof(nonce);
-    }
-
-    m256i miningSeed;
-    m256i nonce;
-    unsigned char signature[SIGNATURE_SIZE];
 };
 
 struct CustomMiningTask

--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -131,23 +131,8 @@ public:
 
     bool validateNewSharesPacket(const unsigned char* customMiningShareCountPacket, unsigned int computorIdx)
     {
-        //unsigned long long sum = 0;
-        //for (int i = 0; i < NUMBER_OF_COMPUTORS; i++)
-        //{
-        //    buffer[i] = extract10Bit(customMiningShareCountPacket, i);
-        //    if (buffer[i] > NUMBER_OF_COMPUTORS)
-        //    {
-        //        return false;
-        //    }
-        //    sum += buffer[i];
-        //}
-        //// check #0: sum of all vote must be >= 675*451 (vote of the tick leader is removed)
-        //if (sum < (NUMBER_OF_COMPUTORS - 1) * QUORUM)
-        //{
-        //    return false;
-        //}
-        // check #1: own number of vote must be zero
-        if (buffer[computorIdx] != 0)
+        // check #1: own number of share must be zero
+        if (extract10Bit(customMiningShareCountPacket, computorIdx) != 0)
         {
             return false;
         }

--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -1,21 +1,202 @@
+#include "platform/memory.h"
+#include "network_messages/transactions.h"
+
 struct MiningSolutionTransaction : public Transaction
 {
-	static constexpr unsigned char transactionType()
-	{
-		return 2; // TODO: Set actual value
-	}
+    static constexpr unsigned char transactionType()
+    {
+        return 2; // TODO: Set actual value
+    }
 
-	static constexpr long long minAmount()
-	{
-		return SOLUTION_SECURITY_DEPOSIT;
-	}
+    static constexpr long long minAmount()
+    {
+        return SOLUTION_SECURITY_DEPOSIT;
+    }
 
-	static constexpr unsigned short minInputSize()
-	{
-		return sizeof(miningSeed) + sizeof(nonce);
-	}
+    static constexpr unsigned short minInputSize()
+    {
+        return sizeof(miningSeed) + sizeof(nonce);
+    }
 
-	m256i miningSeed;
-	m256i nonce;
-	unsigned char signature[SIGNATURE_SIZE];
+    m256i miningSeed;
+    m256i nonce;
+    unsigned char signature[SIGNATURE_SIZE];
+};
+
+constexpr int CUSTOM_MINING_SHARE_COUNTER_INPUT_TYPE = 8;
+constexpr int TICK_CUSTOM_MINING_SHARE_COUNTER_PUBLICATION_OFFSET = 4;
+
+struct CustomMiningSolutionTransaction : public Transaction
+{
+    static constexpr unsigned char transactionType()
+    {
+        return CUSTOM_MINING_SHARE_COUNTER_INPUT_TYPE;
+    }
+
+    static constexpr long long minAmount()
+    {
+        return 0;
+    }
+
+    static constexpr unsigned short minInputSize()
+    {
+        return sizeof(miningSeed) + sizeof(nonce);
+    }
+
+    m256i miningSeed;
+    m256i nonce;
+    unsigned char signature[SIGNATURE_SIZE];
+};
+
+struct CustomMiningTask
+{
+    unsigned long long taskIndex; // ever increasing number (unix timestamp in ms)
+
+    unsigned char m_blob[408]; // Job data from pool
+    unsigned long long m_size;  // length of the blob
+    unsigned long long m_target; // Pool difficulty
+    unsigned long long m_height; // Block height
+    unsigned char m_seed[32]; // Seed hash for XMR
+    unsigned int m_extraNonce;
+};
+
+struct CustomMiningSolution
+{
+    unsigned long long taskIndex; // should match the index from task
+    unsigned int nonce;         // xmrig::JobResult.nonce
+    m256i result;               // xmrig::JobResult.result, 32 bytes
+};
+
+#define CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES 848
+#define CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP 10
+static_assert((1 << CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP) >= NUMBER_OF_COMPUTORS, "Invalid number of bit per datum");
+static_assert(CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES * 8 >= NUMBER_OF_COMPUTORS * CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP, "Invalid data size");
+
+class CustomMiningSharesCounter
+{
+private:
+    unsigned int _shareCount[NUMBER_OF_COMPUTORS];
+    unsigned long long _accumulatedSharesCount[NUMBER_OF_COMPUTORS];
+    unsigned int buffer[NUMBER_OF_COMPUTORS];
+protected:
+    unsigned int extract10Bit(const unsigned char* data, unsigned int idx)
+    {
+        //TODO: simplify this
+        unsigned int byte0 = data[idx + (idx >> 2)];
+        unsigned int byte1 = data[idx + (idx >> 2) + 1];
+        unsigned int last_bit0 = 8 - (idx & 3) * 2;
+        unsigned int first_bit1 = 10 - last_bit0;
+        unsigned int res = (byte0 & ((1 << last_bit0) - 1)) << first_bit1;
+        res |= (byte1 >> (8 - first_bit1));
+        return res;
+    }
+    void update10Bit(unsigned char* data, unsigned int idx, unsigned int value)
+    {
+        //TODO: simplify this
+        unsigned char& byte0 = data[idx + (idx >> 2)];
+        unsigned char& byte1 = data[idx + (idx >> 2) + 1];
+        unsigned int last_bit0 = 8 - (idx & 3) * 2;
+        unsigned int first_bit1 = 10 - last_bit0;
+        unsigned char mask0 = ~((1 << last_bit0) - 1);
+        unsigned char mask1 = ((1 << (8 - first_bit1)) - 1);
+        byte0 &= mask0;
+        byte1 &= mask1;
+        unsigned char ubyte0 = (value >> first_bit1);
+        unsigned char ubyte1 = (value & ((1 << first_bit1) - 1)) << (8 - first_bit1);
+        byte0 |= ubyte0;
+        byte1 |= ubyte1;
+    }
+
+    void accumulateSharesCount(unsigned int computorIdx, unsigned int value)
+    {
+        _accumulatedSharesCount[computorIdx] += value;
+    }
+
+public:
+    static constexpr unsigned int CustomMiningSolutionCounterDataSize = sizeof(_shareCount) + sizeof(_accumulatedSharesCount);
+    void init()
+    {
+        setMem(_shareCount, sizeof(_shareCount), 0);
+        setMem(_accumulatedSharesCount, sizeof(_accumulatedSharesCount), 0);
+    }
+
+    void registerNewShareCount(const unsigned int* sharesCount)
+    {
+        for (int j = 0; j < NUMBER_OF_COMPUTORS; j++)
+        {
+            _shareCount[j] = sharesCount[j];
+            accumulateSharesCount(j, sharesCount[j]);
+        }
+    }
+
+    // get and compress number of shares of 676 computors to 676x10 bit numbers
+    void compressNewSharesPacket(unsigned int ownComputorIdx, unsigned char votePacket[CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES])
+    {
+        setMem(votePacket, sizeof(votePacket), 0);
+        setMem(buffer, sizeof(buffer), 0);
+        for (int j = 0; j < NUMBER_OF_COMPUTORS; j++)
+        {
+            buffer[j] = _shareCount[j];
+        }
+
+        buffer[ownComputorIdx] = 0; // remove self-report
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            update10Bit(votePacket, i, buffer[i]);
+        }
+    }
+
+    bool validateNewSharesPacket(const unsigned char* votePacket, unsigned int computorIdx)
+    {
+        //unsigned long long sum = 0;
+        //for (int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        //{
+        //    buffer[i] = extract10Bit(votePacket, i);
+        //    if (buffer[i] > NUMBER_OF_COMPUTORS)
+        //    {
+        //        return false;
+        //    }
+        //    sum += buffer[i];
+        //}
+        //// check #0: sum of all vote must be >= 675*451 (vote of the tick leader is removed)
+        //if (sum < (NUMBER_OF_COMPUTORS - 1) * QUORUM)
+        //{
+        //    return false;
+        //}
+        // check #1: own number of vote must be zero
+        if (buffer[computorIdx] != 0)
+        {
+            return false;
+        }
+        return true;
+    }
+
+    void addShares(const unsigned char* newSharePacket, unsigned int computorIdx)
+    {
+        if (validateNewSharesPacket(newSharePacket, computorIdx))
+        {
+            for (int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+            {
+                unsigned int shareCount = extract10Bit(newSharePacket, i);
+                accumulateSharesCount(i, shareCount);
+            }
+        }
+    }
+
+    unsigned long long getSharesCount(unsigned int computorIdx)
+    {
+        return _accumulatedSharesCount[computorIdx];
+    }
+
+    void saveAllDataToArray(unsigned char* dst)
+    {
+        copyMem(dst, &_shareCount[0], sizeof(_shareCount));
+        copyMem(dst + sizeof(_shareCount), &_accumulatedSharesCount[0], sizeof(_accumulatedSharesCount));
+    }
+
+    void loadAllDataFromArray(const unsigned char* src)
+    {
+        copyMem(&_shareCount[0], src, sizeof(_shareCount));
+        copyMem(&_accumulatedSharesCount[0], src + sizeof(_shareCount), sizeof(_accumulatedSharesCount));
+    }
 };

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -72,7 +72,6 @@ static unsigned short SPECTRUM_FILE_NAME[] = L"spectrum.???";
 static unsigned short UNIVERSE_FILE_NAME[] = L"universe.???";
 static unsigned short SCORE_CACHE_FILE_NAME[] = L"score.???";
 static unsigned short CONTRACT_FILE_NAME[] = L"contract????.???";
-static unsigned short CUSTOM_MINING_REVENUE_FILE_NAME[] = L"custom_revenue";
 static unsigned short CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME[] = L"custom_revenue.eoe";
 
 #define DATA_LENGTH 256

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -72,6 +72,8 @@ static unsigned short SPECTRUM_FILE_NAME[] = L"spectrum.???";
 static unsigned short UNIVERSE_FILE_NAME[] = L"universe.???";
 static unsigned short SCORE_CACHE_FILE_NAME[] = L"score.???";
 static unsigned short CONTRACT_FILE_NAME[] = L"contract????.???";
+static unsigned short CUSTOM_MINING_REVENUE_FILE_NAME[] = L"custom_revenue";
+static unsigned short CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME[] = L"custom_revenue.eoe";
 
 #define DATA_LENGTH 256
 #define NUMBER_OF_HIDDEN_NEURONS 3000

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -2771,7 +2771,7 @@ static void processTick(unsigned long long processorNumber)
                 payload.transaction.destinationPublicKey = m256i::zero();
                 payload.transaction.amount = 0;
                 payload.transaction.tick = system.tick + publishingTickOffset;
-                payload.transaction.inputType = CUSTOM_MINING_SHARE_COUNTER_INPUT_TYPE;
+                payload.transaction.inputType = CustomMiningSolutionTransaction::transactionType();
                 payload.transaction.inputSize = sizeof(payload.packedScore);
                 gCustomMiningSharesCounter.compressNewSharesPacket(ownComputorIndices[i], payload.packedScore);
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5421,7 +5421,7 @@ static bool saveSystem(CHAR16* directory)
 static bool saveCustomMiningRevenue(CHAR16* directory)
 {
     const unsigned long long beginningTick = __rdtsc();
-    CHAR16* fn = (epochTransitionState == 1) ? CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME : CUSTOM_MINING_REVENUE_FILE_NAME;
+    CHAR16* fn = CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME;
     long long savedSize = asyncSave(fn, sizeof(gRevenueScoreWithCustomMining), (unsigned char*)&gRevenueScoreWithCustomMining, directory);
     if (savedSize == sizeof(system))
     {

--- a/src/system.h
+++ b/src/system.h
@@ -36,9 +36,7 @@ struct System
     } solutions[MAX_NUMBER_OF_SOLUTIONS];
 
     m256i futureComputors[NUMBER_OF_COMPUTORS];
-
-    unsigned long long revenueWithCustomMining[NUMBER_OF_COMPUTORS];
 };
-static_assert(sizeof(System) == 20 + 8 + 8 + 8 + 4 + 96 * MAX_NUMBER_OF_SOLUTIONS + 32 * NUMBER_OF_COMPUTORS + 8 * NUMBER_OF_COMPUTORS, "Unexpected size");
+static_assert(sizeof(System) == 20 + 8 + 8 + 8 + 4 + 96 * MAX_NUMBER_OF_SOLUTIONS + 32 * NUMBER_OF_COMPUTORS, "Unexpected size");
 
 GLOBAL_VAR_DECL System system;

--- a/src/system.h
+++ b/src/system.h
@@ -36,7 +36,9 @@ struct System
     } solutions[MAX_NUMBER_OF_SOLUTIONS];
 
     m256i futureComputors[NUMBER_OF_COMPUTORS];
+
+    unsigned long long revenueWithCustomMining[NUMBER_OF_COMPUTORS];
 };
-static_assert(sizeof(System) == 20 + 8 + 8 + 8 + 4 + 96 * MAX_NUMBER_OF_SOLUTIONS + 32 * NUMBER_OF_COMPUTORS, "Unexpected size");
+static_assert(sizeof(System) == 20 + 8 + 8 + 8 + 4 + 96 * MAX_NUMBER_OF_SOLUTIONS + 32 * NUMBER_OF_COMPUTORS + 8 * NUMBER_OF_COMPUTORS, "Unexpected size");
 
 GLOBAL_VAR_DECL System system;

--- a/tools/python/custom_mining_revenue.py
+++ b/tools/python/custom_mining_revenue.py
@@ -1,0 +1,75 @@
+import csv
+import sys
+
+NUMBER_OF_COMPUTORS = 676
+UINT64_SIZE = 8
+
+def computeNewScore(oldScore, customScore):
+    new_score = oldScore * customScore
+    return new_score
+
+class RevenueScore:
+    def __init__(self):
+        self.old_final_score = [0] * NUMBER_OF_COMPUTORS
+        self.custom_mining_score = [0] * NUMBER_OF_COMPUTORS
+
+def bytes_to_uint64(byte_data):
+    """Convert 8 bytes (little-endian) to an unsigned 64-bit integer."""
+    value = 0
+    for i in range(UINT64_SIZE):
+        value |= byte_data[i] << (i * 8)
+    return value
+
+def dump_custom_mining_share_to_csv(input_file, output_file):
+    custom_mining_rev = RevenueScore()
+
+    try:
+        with open(input_file, "rb") as file:
+            # Read old final scores
+            for i in range(NUMBER_OF_COMPUTORS):
+                byte_data = file.read(UINT64_SIZE)
+                if len(byte_data) != UINT64_SIZE:
+                    raise ValueError("Unexpected end of file.")
+                custom_mining_rev.old_final_score[i] = bytes_to_uint64(byte_data)
+
+            # Read custom mining scores
+            for i in range(NUMBER_OF_COMPUTORS):
+                byte_data = file.read(UINT64_SIZE)
+                if len(byte_data) != UINT64_SIZE:
+                    raise ValueError("Unexpected end of file.")
+                custom_mining_rev.custom_mining_score[i] = bytes_to_uint64(byte_data)
+
+    except FileNotFoundError:
+        print(f"Error: Cannot open file '{input_file}'")
+        exit(1)
+
+    try:
+        with open(output_file, "w", newline="") as file:
+            writer = csv.writer(file)
+            
+            # Write header
+            writer.writerow(["Index", "OldFinalScore", "CustomMiningScore", "NewScore"])
+
+            # Write data
+            for i in range(NUMBER_OF_COMPUTORS):
+                old_score = custom_mining_rev.old_final_score[i]
+                custom_score = custom_mining_rev.custom_mining_score[i]
+                new_score = computeNewScore(old_score, custom_score)
+                writer.writerow([i, old_score, custom_score, new_score])
+
+        print(f"CSV file '{output_file}' written successfully.")
+
+    except Exception as e:
+        print(f"Error writing file '{output_file}': {e}")
+        exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python/python3 custom_mining_revenue.py <input_file> <output_file>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+
+    dump_custom_mining_share_to_csv(input_file, output_file)


### PR DESCRIPTION
This PR does not impact revenue yet. Its primary purpose is to run the full process of collecting custom mining shares and saving them to a file. This data will help refine the formula for revenue calculations.

Currently, the implementation assumes that the shares submitted by computers are valid. Cross-validation will be added in a future update. In general, the pool will verify submitted solutions, sign them, and submit them back to the network.