### PR TITLE
Fix size of respose for console-logging special command

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1353,7 +1353,7 @@ static void processSpecialCommand(Peer* peer, RequestResponseHeader* header)
             {
                 const auto* _request = header->getPayload<SpecialCommandSetConsoleLoggingModeRequestAndResponse>();
                 consoleLoggingLevel = _request->loggingMode;
-                enqueueResponse(peer, sizeof(SpecialCommandToggleMainModeRequestAndResponse), SpecialCommand::type, header->dejavu(), _request);
+                enqueueResponse(peer, sizeof(SpecialCommandSetConsoleLoggingModeRequestAndResponse), SpecialCommand::type, header->dejavu(), _request);
             }
             break;
             }


### PR DESCRIPTION
Response of SpecialCommandSetConsoleLoggingMode used the wrong struct to calculate its size. Not a severe bug, as the size of the two struct is the same for the moment.