### PR TITLE
Custom mining improve tx.

### DIFF
--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -194,3 +194,78 @@ void initCustomMining()
         gCustomMiningBroadcastTxBuffer[i].isBroadcasted = true;
     }
 }
+
+// Compute revenue of computors without donation
+void computeRev(
+    const unsigned long long* revenueScore,
+    unsigned long long* rev)
+{
+    // Sort revenue scores to get lowest score of quorum
+    unsigned long long sortedRevenueScore[QUORUM + 1];
+    bs->SetMem(sortedRevenueScore, sizeof(sortedRevenueScore), 0);
+    for (unsigned short computorIndex = 0; computorIndex < NUMBER_OF_COMPUTORS; computorIndex++)
+    {
+        sortedRevenueScore[QUORUM] = revenueScore[computorIndex];
+        unsigned int i = QUORUM;
+        while (i
+            && sortedRevenueScore[i - 1] < sortedRevenueScore[i])
+        {
+            const unsigned long long tmp = sortedRevenueScore[i - 1];
+            sortedRevenueScore[i - 1] = sortedRevenueScore[i];
+            sortedRevenueScore[i--] = tmp;
+        }
+    }
+    if (!sortedRevenueScore[QUORUM - 1])
+    {
+        sortedRevenueScore[QUORUM - 1] = 1;
+    }
+
+    // Compute revenue of computors and arbitrator
+    long long arbitratorRevenue = ISSUANCE_RATE;
+    constexpr long long issuancePerComputor = ISSUANCE_RATE / NUMBER_OF_COMPUTORS;
+    constexpr long long scalingThreshold = 0xFFFFFFFFFFFFFFFFULL / issuancePerComputor;
+    static_assert(MAX_NUMBER_OF_TICKS_PER_EPOCH <= 605020, "Redefine scalingFactor");
+    // maxRevenueScore for 605020 ticks = ((7099 * 605020) / 676) * 605020 * 675
+    constexpr unsigned scalingFactor = 208100; // >= (maxRevenueScore600kTicks / 0xFFFFFFFFFFFFFFFFULL) * issuancePerComputor =(approx)= 208078.5
+    for (unsigned int computorIndex = 0; computorIndex < NUMBER_OF_COMPUTORS; computorIndex++)
+    {
+        // Compute initial computor revenue, reducing arbitrator revenue
+        long long revenue;
+        if (revenueScore[computorIndex] >= sortedRevenueScore[QUORUM - 1])
+            revenue = issuancePerComputor;
+        else
+        {
+            if (revenueScore[computorIndex] > scalingThreshold)
+            {
+                // scale down to prevent overflow, then scale back up after division
+                unsigned long long scaledRev = revenueScore[computorIndex] / scalingFactor;
+                revenue = ((issuancePerComputor * scaledRev) / sortedRevenueScore[QUORUM - 1]);
+                revenue *= scalingFactor;
+            }
+            else
+            {
+                revenue = ((issuancePerComputor * ((unsigned long long)revenueScore[computorIndex])) / sortedRevenueScore[QUORUM - 1]);
+            }
+        }
+        rev[computorIndex] = revenue;
+    }
+}
+
+static unsigned long long customMiningScoreBuffer[NUMBER_OF_COMPUTORS];
+void computeRevWithCustomMining(
+    const unsigned long long* oldScore,
+    const unsigned long long* customMiningSharesCount,
+    unsigned long long* oldRev,
+    unsigned long long* customMiningRev)
+{
+    // Old score
+    computeRev(oldScore, oldRev);
+
+    // Revenue of custom mining shares combination
+    // Formula: newScore =  vote_count * tx * customMiningShare = revenueOldScore * customMiningShare
+    for (unsigned short computorIndex = 0; computorIndex < NUMBER_OF_COMPUTORS; computorIndex++)
+    {
+        customMiningScoreBuffer[computorIndex] = oldScore[computorIndex] * customMiningSharesCount[computorIndex];
+    }
+    computeRev(customMiningScoreBuffer, customMiningRev);
+}

--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -54,11 +54,27 @@ struct CustomMiningSolution
     m256i result;               // xmrig::JobResult.result, 32 bytes
 };
 
+
 #define CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES 848
 #define CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP 10
 static_assert((1 << CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP) >= NUMBER_OF_COMPUTORS, "Invalid number of bit per datum");
 static_assert(CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES * 8 >= NUMBER_OF_COMPUTORS * CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP, "Invalid data size");
 static char accumulatedSharedCountLock = 0;
+
+struct CustomMiningSharePayload
+{
+    Transaction transaction;
+    unsigned char packedScore[CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES];
+    unsigned char signature[SIGNATURE_SIZE];
+};
+
+struct BroadcastCustomMiningTransaction
+{
+    CustomMiningSharePayload payload;
+    bool isBroadcasted;
+};
+
+BroadcastCustomMiningTransaction gCustomMiningBroadcastTxBuffer[NUMBER_OF_COMPUTORS];
 
 class CustomMiningSharesCounter
 {
@@ -169,3 +185,12 @@ public:
         copyMem(&_accumulatedSharesCount[0], src + sizeof(_shareCount), sizeof(_accumulatedSharesCount));
     }
 };
+
+void initCustomMining()
+{
+    for (int i = 0; i < NUMBER_OF_COMPUTORS; ++i)
+    {
+        // Initialize the broadcast transaction buffer. Assume the all previous is broadcasted.
+        gCustomMiningBroadcastTxBuffer[i].isBroadcasted = true;
+    }
+}

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -242,6 +242,7 @@ struct
     unsigned int numberOfMiners;
     unsigned int numberOfTransactions;
     unsigned long long lastLogId;
+    unsigned char customMiningSharesCounterData[CustomMiningSharesCounter::_customMiningSolutionCounterDataSize];
 } nodeStateBuffer;
 #endif
 static bool saveComputer(CHAR16* directory = NULL);
@@ -4018,6 +4019,7 @@ static bool saveAllNodeStates()
     nodeStateBuffer.numberOfTransactions = numberOfTransactions;
     nodeStateBuffer.lastLogId = logger.logId;
     voteCounter.saveAllDataToArray(nodeStateBuffer.voteCounterData);
+    gCustomMiningSharesCounter.saveAllDataToArray(nodeStateBuffer.customMiningSharesCounterData);
 
     CHAR16 NODE_STATE_FILE_NAME[] = L"snapshotNodeMiningState";
     savedSize = save(NODE_STATE_FILE_NAME, sizeof(nodeStateBuffer), (unsigned char*)&nodeStateBuffer, directory);
@@ -4156,6 +4158,7 @@ static bool loadAllNodeStates()
     logger.logId = nodeStateBuffer.lastLogId;
     loadMiningSeedFromFile = true;
     voteCounter.loadAllDataFromArray(nodeStateBuffer.voteCounterData);
+    gCustomMiningSharesCounter.loadAllDataFromArray(nodeStateBuffer.customMiningSharesCounterData);
 
     // update own computor indices
     for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -212,8 +212,10 @@ static volatile char gIsInCustomMiningStateLock = 0;
 
 struct revenueScore
 {
-    unsigned long long _oldFinalScore[NUMBER_OF_COMPUTORS]; // old final score
-    unsigned long long _customMiningScore[NUMBER_OF_COMPUTORS]; // the new score with customming
+    unsigned long long oldFinalScore[NUMBER_OF_COMPUTORS]; // old final score
+    unsigned long long customMiningSharesCount[NUMBER_OF_COMPUTORS]; // the shares count with custom mining
+    unsigned long long currentRev[NUMBER_OF_COMPUTORS]; // old revenue
+    unsigned long long customMiningRev[NUMBER_OF_COMPUTORS]; // reveneu with custom mining
 } gRevenueScoreWithCustomMining;
 
 
@@ -3007,13 +3009,17 @@ static void endEpoch()
 
         // Experiment code. Expect it has not impact any reveneue yet, only record the revenue with custom solution and old score
         {
-            bs->CopyMem(gRevenueScoreWithCustomMining._oldFinalScore, revenueScore, sizeof(gRevenueScoreWithCustomMining._oldFinalScore));
+            bs->CopyMem(gRevenueScoreWithCustomMining.oldFinalScore, revenueScore, sizeof(gRevenueScoreWithCustomMining.oldFinalScore));
             // This function doesn't impact reveneue yet. Just counting the submitted solution for adjusting the fomula later
             for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
             {
-                unsigned long long shareScore = gCustomMiningSharesCounter.getSharesCount(i);
-                gRevenueScoreWithCustomMining._customMiningScore[i] = shareScore;
+                gRevenueScoreWithCustomMining.customMiningSharesCount[i] = gCustomMiningSharesCounter.getSharesCount(i);
             }
+            computeRevWithCustomMining(
+                gRevenueScoreWithCustomMining.oldFinalScore,
+                gRevenueScoreWithCustomMining.customMiningSharesCount,
+                gRevenueScoreWithCustomMining.currentRev,
+                gRevenueScoreWithCustomMining.customMiningRev);
         }
 
 


### PR DESCRIPTION
This PR,
- Allow save and load custom mining share counter along with save/load snapshot
- Smooth the custom mining tx to avoid network spike for weak node
- Integrate the revenue calculation with custom mining into custom_mining.eoe file