### PR TITLE
Speed-up construction of tickData

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -2577,7 +2577,7 @@ static void processTick(unsigned long long processorNumber)
 
                     unsigned int j = 0;
 
-                    // Get indices of pending computor transactions that are supposed to by published now (decided by tick)
+                    // Get indices of pending computor transactions that are scheduled to be included in tickData
                     unsigned int numberOfEntityPendingTransactionIndices = 0;
                     for (unsigned int k = 0; k < NUMBER_OF_COMPUTORS * MAX_NUMBER_OF_PENDING_TRANSACTIONS_PER_COMPUTOR; k++)
                     {
@@ -2616,7 +2616,7 @@ static void processTick(unsigned long long processorNumber)
                         entityPendingTransactionIndices[index] = entityPendingTransactionIndices[--numberOfEntityPendingTransactionIndices];
                     }
 
-                    // Get indices of pending non-computor transactions that are supposed to by published now (decided by tick)
+                    // Get indices of pending non-computor transactions that are scheduled to be included in tickData
                     numberOfEntityPendingTransactionIndices = 0;
                     for (unsigned int k = 0; k < SPECTRUM_CAPACITY; k++)
                     {


### PR DESCRIPTION
With this patch, we now only consider tx for random selection that are scheduled for the tick we construct the TickData of.

Before this fix, the expensive function `random()` was called millions times, because `random()` was called before checking if a candidate slot contained a tx scheduled for the tick (or any tx at all).