### PR TITLE
Add burning of asset shares

### DIFF
--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -444,7 +444,7 @@ static bool transferShareOwnershipAndPossession(int sourceOwnershipIndex, int so
     int* destinationOwnershipIndex, int* destinationPossessionIndex,
     bool lock)
 {
-    if (numberOfShares <= 0 || isZero(destinationPublicKey))
+    if (numberOfShares <= 0)
     {
         return false;
     }
@@ -454,6 +454,8 @@ static bool transferShareOwnershipAndPossession(int sourceOwnershipIndex, int so
         ACQUIRE(universeLock);
     }
 
+    ASSERT(sourceOwnershipIndex >= 0 && sourceOwnershipIndex < ASSETS_CAPACITY);
+    ASSERT(sourcePossessionIndex >= 0 && sourcePossessionIndex < ASSETS_CAPACITY);
     if (assets[sourceOwnershipIndex].varStruct.ownership.type != OWNERSHIP || assets[sourceOwnershipIndex].varStruct.ownership.numberOfShares < numberOfShares
         || assets[sourcePossessionIndex].varStruct.possession.type != POSSESSION || assets[sourcePossessionIndex].varStruct.possession.numberOfShares < numberOfShares
         || assets[sourcePossessionIndex].varStruct.possession.ownershipIndex != sourceOwnershipIndex)
@@ -466,6 +468,61 @@ static bool transferShareOwnershipAndPossession(int sourceOwnershipIndex, int so
         return false;
     }
 
+    // Special case: all-zero destination means burning shares
+    if (isZero(destinationPublicKey))
+    {
+        // Don't allow burning of contract shares
+        const unsigned int issuanceIndex = assets[sourceOwnershipIndex].varStruct.ownership.issuanceIndex;
+        ASSERT(issuanceIndex < ASSETS_CAPACITY);
+        const auto& issuance = assets[issuanceIndex].varStruct.issuance;
+        ASSERT(issuance.type == ISSUANCE);
+        if (isZero(issuance.publicKey))
+        {
+            if (lock)
+            {
+                RELEASE(universeLock);
+            }
+
+            return false;
+        }
+
+        // Burn by subtracting shares from source records
+        assets[sourceOwnershipIndex].varStruct.ownership.numberOfShares -= numberOfShares;
+        assets[sourcePossessionIndex].varStruct.possession.numberOfShares -= numberOfShares;
+        assetChangeFlags[sourceOwnershipIndex >> 6] |= (1ULL << (sourceOwnershipIndex & 63));
+        assetChangeFlags[sourcePossessionIndex >> 6] |= (1ULL << (sourcePossessionIndex & 63));
+
+        if (lock)
+        {
+            RELEASE(universeLock);
+        }
+
+        AssetOwnershipChange assetOwnershipChange;
+        assetOwnershipChange.sourcePublicKey = assets[sourceOwnershipIndex].varStruct.ownership.publicKey;
+        assetOwnershipChange.destinationPublicKey = destinationPublicKey;
+        assetOwnershipChange.issuerPublicKey = issuance.publicKey;
+        assetOwnershipChange.numberOfShares = numberOfShares;
+        *((unsigned long long*) & assetOwnershipChange.name) = *((unsigned long long*) & issuance.name); // Order must be preserved!
+        assetOwnershipChange.numberOfDecimalPlaces = issuance.numberOfDecimalPlaces; // Order must be preserved!
+        *((unsigned long long*) & assetOwnershipChange.unitOfMeasurement) = *((unsigned long long*) & issuance.unitOfMeasurement); // Order must be preserved!
+        logger.logAssetOwnershipChange(assetOwnershipChange);
+
+        AssetPossessionChange assetPossessionChange;
+        assetPossessionChange.sourcePublicKey = assets[sourcePossessionIndex].varStruct.possession.publicKey;
+        assetPossessionChange.destinationPublicKey = destinationPublicKey;
+        assetPossessionChange.issuerPublicKey = issuance.publicKey;
+        assetPossessionChange.numberOfShares = numberOfShares;
+        *((unsigned long long*) & assetPossessionChange.name) = *((unsigned long long*) & issuance.name); // Order must be preserved!
+        assetPossessionChange.numberOfDecimalPlaces = issuance.numberOfDecimalPlaces; // Order must be preserved!
+        *((unsigned long long*) & assetPossessionChange.unitOfMeasurement) = *((unsigned long long*) & issuance.unitOfMeasurement); // Order must be preserved!
+        logger.logAssetPossessionChange(assetPossessionChange);
+
+        return true;
+    }
+
+    // Default case: transfer shares to destinationPublicKey
+    ASSERT(destinationOwnershipIndex != nullptr);
+    ASSERT(destinationPossessionIndex != nullptr);
     *destinationOwnershipIndex = destinationPublicKey.m256i_u32[0] & (ASSETS_CAPACITY - 1);
 iteration:
     if (assets[*destinationOwnershipIndex].varStruct.ownership.type == EMPTY

--- a/src/contract_core/qpi_asset_impl.h
+++ b/src/contract_core/qpi_asset_impl.h
@@ -755,11 +755,18 @@ iteration:
                                 if (assets[possessionIndex].varStruct.possession.numberOfShares >= numberOfShares)
                                 {
                                     int destinationOwnershipIndex, destinationPossessionIndex;
-                                    ::transferShareOwnershipAndPossession(ownershipIndex, possessionIndex, newOwnerAndPossessor, numberOfShares, &destinationOwnershipIndex, &destinationPossessionIndex, false);
+                                    if (!::transferShareOwnershipAndPossession(ownershipIndex, possessionIndex, newOwnerAndPossessor, numberOfShares, &destinationOwnershipIndex, &destinationPossessionIndex, false))
+                                    {
+                                        RELEASE(universeLock);
 
-                                    RELEASE(universeLock);
+                                        return INVALID_AMOUNT;
+                                    }
+                                    else
+                                    {
+                                        RELEASE(universeLock);
 
-                                    return assets[possessionIndex].varStruct.possession.numberOfShares;
+                                        return assets[possessionIndex].varStruct.possession.numberOfShares;
+                                    }
                                 }
                                 else
                                 {

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -1523,8 +1523,8 @@ namespace QPI
 			const id& owner,
 			const id& possessor,
 			sint64 numberOfShares,
-			const id& newOwnerAndPossessor
-		) const; // Returns remaining number of possessed shares satisfying all the conditions; if the value is less than 0 then the attempt has failed, in this case the absolute value equals to the insufficient number
+			const id& newOwnerAndPossessor // New owner and possessor. Pass NULL_ID to burn shares (not allowed for contract shares).
+		) const; // Returns remaining number of possessed shares satisfying all the conditions; if the value is less than 0, the attempt has failed, in this case the absolute value equals to the insufficient number, INVALID_AMOUNT indicates another error
 
 		// Access proposal procedures with qpi(proposalVotingObject).proc().
 		template <typename ProposerAndVoterHandlingType, typename ProposalDataType>

--- a/test/assets.cpp
+++ b/test/assets.cpp
@@ -606,6 +606,50 @@ TEST(TestCoreAssets, AssetIterators)
     // check consistency after rebuild/cleanup of hash map
     assetsEndEpoch();
     test.checkAssetsConsistency();
+
+    {
+        // Test burning of shares
+        for (int i = 0; i < issuancesCount; ++i)
+        {
+            for (int j = 3; j >= 1; j--)
+            {
+                // iterate all possession records and burn 1/j part of the shares
+                long long expectedTotalShares = 0;
+                for (AssetPossessionIterator iter(issuances[i].id); !iter.reachedEnd(); iter.next())
+                {
+                    const long long numOfSharesPossessedInitially = iter.numberOfPossessedShares();
+                    const long long numOfSharesOwnedInitially = iter.numberOfOwnedShares();
+                    const long long numOfSharesToBurn = numOfSharesPossessedInitially / j;
+                    const long long numOfSharesPossessedAfterwards = numOfSharesPossessedInitially - numOfSharesToBurn;
+                    const long long numOfSharesOwnedAfterwards = numOfSharesOwnedInitially - numOfSharesToBurn;
+
+                    const bool success = transferShareOwnershipAndPossession(iter.ownershipIndex(), iter.possessionIndex(), NULL_ID, numOfSharesToBurn, nullptr, nullptr, false);
+
+                    if (isZero(issuances[i].id.issuer))
+                    {
+                        // burning fails for contract shares
+                        EXPECT_FALSE(success);
+                        EXPECT_EQ(numOfSharesPossessedInitially, iter.numberOfPossessedShares());
+                        EXPECT_EQ(numOfSharesOwnedInitially, iter.numberOfOwnedShares());
+                        expectedTotalShares += numOfSharesPossessedInitially;
+                    }
+                    else
+                    {
+                        // burning succeeds for non-contract asset shares
+                        EXPECT_TRUE(success);
+                        EXPECT_EQ(numOfSharesPossessedAfterwards, iter.numberOfPossessedShares());
+                        EXPECT_EQ(numOfSharesOwnedAfterwards, iter.numberOfOwnedShares());
+                        expectedTotalShares += numOfSharesPossessedAfterwards;
+                    }
+                }
+                EXPECT_EQ(expectedTotalShares, numberOfShares(issuances[i].id));
+            }
+        }
+    }
+
+    // check consistency after rebuild/cleanup of hash map
+    assetsEndEpoch();
+    test.checkAssetsConsistency();
 }
 
 TEST(TestCoreAssets, AssetTransferShareManagementRights)

--- a/test/contract_testex.cpp
+++ b/test/contract_testex.cpp
@@ -1291,3 +1291,38 @@ TEST(ContractTestEx, CallbackPostIncomingTransfer)
     EXPECT_EQ(itaB5.revenueDonationAmount, itaB1.revenueDonationAmount);
     EXPECT_EQ(itaC5.revenueDonationAmount, itaC1.revenueDonationAmount);
 }
+
+TEST(ContractTestEx, BurnAssets)
+{
+    ContractTestCallbackPostIncomingTransfer test;
+
+    increaseEnergy(USER1, 1234567890123llu);
+    increaseEnergy(TESTEXB_CONTRACT_ID, 19283764);
+
+    {
+        // issue contract shares
+        Asset asset{ NULL_ID, assetNameFromString("TESTEXB") };
+        std::vector<std::pair<m256i, unsigned int>> sharesTestExB{ {USER1, 356}, {TESTEXC_CONTRACT_ID, 200}, {TESTEXB_CONTRACT_ID, 100}, {TESTEXA_CONTRACT_ID, 20} };
+        issueContractShares(TESTEXB_CONTRACT_INDEX, sharesTestExB);
+        EXPECT_EQ(356, numberOfShares(asset, { USER1, QX_CONTRACT_INDEX }, { USER1, QX_CONTRACT_INDEX }));
+
+        // burning contract shares is supposed to fail
+        EXPECT_EQ(test.transferShareOwnershipAndPossessionQx(asset, USER1, NULL_ID, 100), 0);
+        EXPECT_EQ(356, numberOfShares(asset, { USER1, QX_CONTRACT_INDEX }, { USER1, QX_CONTRACT_INDEX }));
+    }
+
+    {
+        // issue non-contract asset shares
+        Asset asset{ USER1, assetNameFromString("BLOB") };
+        EXPECT_EQ(test.issueAssetQx(asset, 1000000, 0, 0), 1000000);
+        EXPECT_EQ(1000000, numberOfShares(asset));
+        EXPECT_EQ(1000000, numberOfShares(asset, { USER1, QX_CONTRACT_INDEX }));
+        EXPECT_EQ(1000000, numberOfShares(asset, { USER1, QX_CONTRACT_INDEX }, { USER1, QX_CONTRACT_INDEX }));
+
+        // burn non-contract shares
+        EXPECT_EQ(test.transferShareOwnershipAndPossessionQx(asset, USER1, NULL_ID, 100), 100);
+        EXPECT_EQ(1000000 - 100, numberOfShares(asset));
+        EXPECT_EQ(1000000 - 100, numberOfShares(asset, { USER1, QX_CONTRACT_INDEX }));
+        EXPECT_EQ(1000000 - 100, numberOfShares(asset, { USER1, QX_CONTRACT_INDEX }, { USER1, QX_CONTRACT_INDEX }));
+    }
+}


### PR DESCRIPTION
Extend transferShareOwnershipAndPossession() to support burning of asset shares by transferring to NULL_ID. Burning contract shares is forbidden.