### PR TITLE
Add compiler specific includes for intrin.h/immintrin.h

### DIFF
--- a/lib/platform_common/qintrin.h
+++ b/lib/platform_common/qintrin.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// Header file for the inclusion of plartform specific x86/x64 intrinsics header files.
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <immintrin.h>
+#endif

--- a/src/K12/kangaroo_twelve_xkcp.h
+++ b/src/K12/kangaroo_twelve_xkcp.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 #include "platform/memory.h"
 

--- a/src/K12/kangaroo_twelve_xkcp.h
+++ b/src/K12/kangaroo_twelve_xkcp.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 #include "platform/memory.h"
 

--- a/src/four_q.h
+++ b/src/four_q.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
-
+#include <lib/platform_common/qintrin.h>
 
 #include "platform/common_types.h"
 #include "platform/memory.h"

--- a/src/four_q.h
+++ b/src/four_q.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
+
 
 #include "platform/common_types.h"
 #include "platform/memory.h"

--- a/src/kangaroo_twelve.h
+++ b/src/kangaroo_twelve.h
@@ -1,6 +1,11 @@
 #pragma once
 
+
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 #include "platform/memory.h"
 

--- a/src/kangaroo_twelve.h
+++ b/src/kangaroo_twelve.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <lib/platform_common/qintrin.h>
 
 #include "platform/memory.h"

--- a/src/kangaroo_twelve.h
+++ b/src/kangaroo_twelve.h
@@ -1,11 +1,7 @@
 #pragma once
 
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 #include "platform/memory.h"
 

--- a/src/network_messages/common_def.h
+++ b/src/network_messages/common_def.h
@@ -25,7 +25,11 @@
 // following line to "#if 1".
 #if defined(NETWORK_MESSAGES_WITHOUT_CORE_DEPENDENCIES)
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 typedef union m256i
 {

--- a/src/network_messages/common_def.h
+++ b/src/network_messages/common_def.h
@@ -25,11 +25,7 @@
 // following line to "#if 1".
 #if defined(NETWORK_MESSAGES_WITHOUT_CORE_DEPENDENCIES)
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 typedef union m256i
 {

--- a/src/network_messages/header.h
+++ b/src/network_messages/header.h
@@ -1,6 +1,11 @@
 #pragma once
 
+
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 struct RequestResponseHeader
 {

--- a/src/network_messages/header.h
+++ b/src/network_messages/header.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <lib/platform_common/qintrin.h>
 
 struct RequestResponseHeader

--- a/src/network_messages/header.h
+++ b/src/network_messages/header.h
@@ -1,11 +1,7 @@
 #pragma once
 
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 struct RequestResponseHeader
 {

--- a/src/platform/concurrency.h
+++ b/src/platform/concurrency.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 // Acquire lock, may block
 #define ACQUIRE_WITHOUT_DEBUG_LOGGING(lock) while (_InterlockedCompareExchange8(&lock, 1, 0)) _mm_pause()

--- a/src/platform/concurrency.h
+++ b/src/platform/concurrency.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 // Acquire lock, may block
 #define ACQUIRE_WITHOUT_DEBUG_LOGGING(lock) while (_InterlockedCompareExchange8(&lock, 1, 0)) _mm_pause()

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 #include "platform/assert.h"
 #ifdef NO_UEFI
 #include <cstdio>

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <lib/platform_common/qintrin.h>
-
 #include "platform/assert.h"
 #ifdef NO_UEFI
 #include <cstdio>

--- a/src/platform/file_io.h
+++ b/src/platform/file_io.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
+
 #include "platform/assert.h"
 #ifdef NO_UEFI
 #include <cstdio>

--- a/src/platform/m256.h
+++ b/src/platform/m256.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 // Used for all kinds of IDs, including in QPI and contracts.
 // Existing interface and behavior should never be changed! (However, it may be extended.)

--- a/src/platform/m256.h
+++ b/src/platform/m256.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 // Used for all kinds of IDs, including in QPI and contracts.
 // Existing interface and behavior should never be changed! (However, it may be extended.)

--- a/src/platform/random.h
+++ b/src/platform/random.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 inline static unsigned int random(const unsigned int range)
 {

--- a/src/platform/random.h
+++ b/src/platform/random.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 inline static unsigned int random(const unsigned int range)
 {

--- a/src/platform/read_write_lock.h
+++ b/src/platform/read_write_lock.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
+
 #include "debugging.h"
 #include "concurrency.h"
 

--- a/src/platform/read_write_lock.h
+++ b/src/platform/read_write_lock.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 #include "debugging.h"
 #include "concurrency.h"

--- a/src/platform/read_write_lock.h
+++ b/src/platform/read_write_lock.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <lib/platform_common/qintrin.h>
-
 #include "debugging.h"
 #include "concurrency.h"
 

--- a/src/platform/time_stamp_counter.h
+++ b/src/platform/time_stamp_counter.h
@@ -5,11 +5,7 @@
 
 #pragma once
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 #include "global_var.h"
 #include "console_logging.h"

--- a/src/platform/time_stamp_counter.h
+++ b/src/platform/time_stamp_counter.h
@@ -5,7 +5,11 @@
 
 #pragma once
 
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 #include "global_var.h"
 #include "console_logging.h"

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4,7 +4,6 @@
 #include "contract_core/contract_def.h"
 #include "contract_core/contract_exec.h"
 
-
 #include <lib/platform_common/qintrin.h>
 
 #include "network_messages/all.h"

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5,11 +5,7 @@
 #include "contract_core/contract_exec.h"
 
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 
 #include "network_messages/all.h"
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4,7 +4,12 @@
 #include "contract_core/contract_def.h"
 #include "contract_core/contract_exec.h"
 
+
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 
 #include "network_messages/all.h"
 

--- a/test/kangaroo_twelve.cpp
+++ b/test/kangaroo_twelve.cpp
@@ -3,7 +3,11 @@
 #include "../src/K12/kangaroo_twelve_xkcp.h"
 #include "../src/kangaroo_twelve.h"
 #include "../src/platform/memory.h"
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 #include "gtest/gtest.h"
 
 #include <chrono>

--- a/test/kangaroo_twelve.cpp
+++ b/test/kangaroo_twelve.cpp
@@ -3,11 +3,7 @@
 #include "../src/K12/kangaroo_twelve_xkcp.h"
 #include "../src/kangaroo_twelve.h"
 #include "../src/platform/memory.h"
-#if defined(_MSC_VER)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
+#include <lib/platform_common/qintrin.h>
 #include "gtest/gtest.h"
 
 #include <chrono>


### PR DESCRIPTION
This PR depends on #381. It changes the includes of `intrin.h` to compiler specific includes since clang does not support `intrin.h` directly but `immintrin.h`.