### PR TITLE
Improve peers logic

### DIFF
--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -56,10 +56,10 @@ struct Peer
     BOOLEAN isIncommingConnection;
 
     // Extra data to determine if this peer is a fullnode
-    unsigned int receivedTickData; // indicate the tick number that this peer transfer valid tick/vote data
+    unsigned int lastActiveTick; // indicate the tick number that this peer transfer valid tick/vote data
     bool isFullNode() const
     {
-        return (receivedTickData >= system.tick - 100);
+        return (lastActiveTick >= system.tick - 100);
     }
 
     // set handler to null and all params to false/zeroes
@@ -74,7 +74,7 @@ struct Peer
         isClosing = FALSE;
         isIncommingConnection = FALSE;
         dataToTransmitSize = 0;
-        receivedTickData = 0;
+        lastActiveTick = 0;
     }
 };
 

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -81,6 +81,7 @@ struct Peer
 typedef struct
 {
     bool isHandshaked;
+    bool isFullnode;
     IPv4Address address;
 } PublicPeer;
 
@@ -412,9 +413,10 @@ static void penalizePublicPeerRejectedConnection(const IPv4Address& address)
     {
         if (publicPeers[i].address == address)
         {
-            if (publicPeers[i].isHandshaked)
+            if (publicPeers[i].isHandshaked || publicPeers[i].isFullnode)
             {
                 publicPeers[i].isHandshaked = false;
+                publicPeers[i].isFullnode = false;
             }
             else
             {
@@ -456,6 +458,7 @@ static void addPublicPeer(const IPv4Address& address)
     if (numberOfPublicPeers < MAX_NUMBER_OF_PUBLIC_PEERS)
     {
         publicPeers[numberOfPublicPeers].isHandshaked = false;
+        publicPeers[numberOfPublicPeers].isFullnode = false;
         publicPeers[numberOfPublicPeers++].address = address;
     }
 

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -837,13 +837,13 @@ static void peerReconnectIfInactive(unsigned int i, unsigned short port)
     EFI_STATUS status;
     if (!peers[i].tcp4Protocol)
     {
+        peers[i].reset();
         // peer slot without active connection
         if (i < NUMBER_OF_OUTGOING_CONNECTIONS)
         {
             // outgoing connection:
             // randomly select public peer and try to connect if we do not
             // yet have an outgoing connection to it
-
             peers[i].address = publicPeers[random(numberOfPublicPeers)].address;
             peers[i].isIncommingConnection = FALSE;
 
@@ -861,7 +861,6 @@ static void peerReconnectIfInactive(unsigned int i, unsigned short port)
                 {
                     if (peers[i].connectAcceptToken.NewChildHandle = getTcp4Protocol(peers[i].address.u8, port, &peers[i].tcp4Protocol))
                     {
-                        peers[i].reset();
                         peers[i].receiveData.FragmentTable[0].FragmentBuffer = peers[i].receiveBuffer;
 
                         if (status = peers[i].tcp4Protocol->Connect(peers[i].tcp4Protocol, (EFI_TCP4_CONNECTION_TOKEN*)&peers[i].connectAcceptToken))
@@ -890,7 +889,6 @@ static void peerReconnectIfInactive(unsigned int i, unsigned short port)
             // accept connections if peer list is not static
             if (!listOfPeersIsStatic)
             {
-                peers[i].reset();
                 peers[i].isIncommingConnection = TRUE;
                 peers[i].receiveData.FragmentTable[0].FragmentBuffer = peers[i].receiveBuffer;
 

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -58,7 +58,7 @@ struct Peer
 
 typedef struct
 {
-    bool isVerified;
+    bool isHandshaked;
     IPv4Address address;
 } PublicPeer;
 
@@ -382,9 +382,9 @@ static void penalizePublicPeerRejectedConnection(const IPv4Address& address)
     {
         if (publicPeers[i].address == address)
         {
-            if (publicPeers[i].isVerified)
+            if (publicPeers[i].isHandshaked)
             {
-                publicPeers[i].isVerified = false;
+                publicPeers[i].isHandshaked = false;
             }
             else
             {
@@ -425,7 +425,7 @@ static void addPublicPeer(const IPv4Address& address)
 
     if (numberOfPublicPeers < MAX_NUMBER_OF_PUBLIC_PEERS)
     {
-        publicPeers[numberOfPublicPeers].isVerified = false;
+        publicPeers[numberOfPublicPeers].isHandshaked = false;
         publicPeers[numberOfPublicPeers++].address = address;
     }
 

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -267,6 +267,20 @@ static void pushToSeveralFullNode(RequestResponseHeader* requestResponseHeader)
     pushCustom(requestResponseHeader, DISSEMINATION_MULTIPLIER, filterFullNode);
 }
 
+// Add message to sending buffer of some (limit by DISSEMINATION_MULTIPLIER) full node peer, can only called from main thread (not thread-safe).
+static void pushToFullNodes(RequestResponseHeader* requestResponseHeader, int numberOfReceivers)
+{
+    if (numberOfReceivers > DISSEMINATION_MULTIPLIER)
+    {
+        pushToSeveralFullNode(requestResponseHeader);
+    }
+    else
+    {
+        const bool filterFullNode = true;
+        pushCustom(requestResponseHeader, numberOfReceivers, filterFullNode);
+    }
+}
+
 // Add message to response queue of specific peer. If peer is NULL, it will be sent to random peers. Can be called from any thread.
 static void enqueueResponse(Peer* peer, RequestResponseHeader* responseHeader)
 {

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -57,9 +57,10 @@ struct Peer
 
     // Extra data to determine if this peer is a fullnode
     unsigned int latestTick;
+    unsigned int receivedTickData; // indicate the tick number that this peer transfer valid tick/vote data
     bool isFullNode() const
     {
-        return (latestTick >= system.tick - 100);
+        return (latestTick >= system.tick - 100) && (receivedTickData >= system.tick - 100);
     }
 
     // set handler to null and all params to false/zeroes
@@ -75,6 +76,7 @@ struct Peer
         isIncommingConnection = FALSE;
         dataToTransmitSize = 0;
         latestTick = 0;
+        receivedTickData = 0;
     }
 };
 

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -56,6 +56,9 @@ struct Peer
     BOOLEAN isIncommingConnection;
 
     // Extra data to determine if this peer is a fullnode
+    // Note: an **active fullnode** is a peer that is able to transmit valid tick data, tick vote to this node recently
+    // If a peer is an active fullnode, it will receive more requests from this node than others, as well as longer alive connection time.
+    // Here we also consider relayer as a fullnode (as long as it transmits new&valid tick data)
     unsigned int lastActiveTick; // indicate the tick number that this peer transfer valid tick/vote data
     bool isFullNode() const
     {

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -56,11 +56,10 @@ struct Peer
     BOOLEAN isIncommingConnection;
 
     // Extra data to determine if this peer is a fullnode
-    unsigned int latestTick;
     unsigned int receivedTickData; // indicate the tick number that this peer transfer valid tick/vote data
     bool isFullNode() const
     {
-        return (latestTick >= system.tick - 100) && (receivedTickData >= system.tick - 100);
+        return (receivedTickData >= system.tick - 100);
     }
 
     // set handler to null and all params to false/zeroes
@@ -75,7 +74,6 @@ struct Peer
         isClosing = FALSE;
         isIncommingConnection = FALSE;
         dataToTransmitSize = 0;
-        latestTick = 0;
         receivedTickData = 0;
     }
 };

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -7398,6 +7398,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             }
                         }
                         pushToAny(&requestedQuorumTick.header);
+                        pushToAnyFullNode(&requestedQuorumTick.header);
                     }
                     tickRequestingIndicator = gTickTotalNumberOfComputors;
                     if (futureTickRequestingIndicator == gFutureTickTotalNumberOfComputors
@@ -7415,6 +7416,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             }
                         }
                         pushToAny(&requestedQuorumTick.header);
+                        pushToAnyFullNode(&requestedQuorumTick.header);
                     }
                     futureTickRequestingIndicator = gFutureTickTotalNumberOfComputors;
 
@@ -7429,18 +7431,21 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                         requestedTickData.header.randomizeDejavu();
                         requestedTickData.requestTickData.requestedTickData.tick = system.tick + 1;
                         pushToAny(&requestedTickData.header);
+                        pushToAnyFullNode(&requestedTickData.header);
                     }
                     if (ts.tickData[system.tick + 2 - system.initialTick].epoch != system.epoch && isNewTickPlus2)
                     {
                         requestedTickData.header.randomizeDejavu();
                         requestedTickData.requestTickData.requestedTickData.tick = system.tick + 2;
                         pushToAny(&requestedTickData.header);
+                        pushToAnyFullNode(&requestedTickData.header);
                     }
 
                     if (requestedTickTransactions.requestedTickTransactions.tick)
                     {
                         requestedTickTransactions.header.randomizeDejavu();
                         pushToAny(&requestedTickTransactions.header);
+                        pushToAnyFullNode(&requestedTickData.header);
 
                         requestedTickTransactions.requestedTickTransactions.tick = 0;
                     }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -861,7 +861,7 @@ static void processBroadcastTick(Peer* peer, RequestResponseHeader* header)
             {
                 // Copy the sent tick to the tick storage
                 bs->CopyMem(tsTick, &request->tick, sizeof(Tick));
-                peer->receivedTickData = request->tick.tick;
+                peer->lastActiveTick = request->tick.tick;
             }
 
             ts.ticks.releaseLock(request->tick.computorIndex);
@@ -927,7 +927,7 @@ static void processBroadcastFutureTickData(Peer* peer, RequestResponseHeader* he
                             if (digest == targetNextTickDataDigest)
                             {
                                 bs->CopyMem(&td, &request->tickData, sizeof(TickData));
-                                peer->receivedTickData = request->tickData.tick;
+                                peer->lastActiveTick = request->tickData.tick;
                             }
                         }
                     }
@@ -956,7 +956,7 @@ static void processBroadcastFutureTickData(Peer* peer, RequestResponseHeader* he
                         else
                         {
                             bs->CopyMem(&td, &request->tickData, sizeof(TickData));
-                            peer->receivedTickData = request->tickData.tick;
+                            peer->lastActiveTick = request->tickData.tick;
                         }
                     }
                 }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -292,11 +292,6 @@ static struct
     RequestedTickTransactions requestedTickTransactions;
 } requestedTickTransactions;
 
-static struct
-{
-    RequestResponseHeader header;
-} requestedCurrentTick;
-
 static struct {
     unsigned char day;
     unsigned char hour;
@@ -7213,10 +7208,6 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                 logToConsole(L"WARNING: NUMBER_OF_SOLUTION_PROCESSORS should not be greater than half of the total processor number!");
             }
 
-            requestedCurrentTick.header.checkAndSetSize(sizeof(RequestResponseHeader));
-            requestedCurrentTick.header.randomizeDejavu();
-            requestedCurrentTick.header.setType(REQUEST_CURRENT_TICK_INFO);
-
             // -----------------------------------------------------
             // Main loop
             unsigned int salt;
@@ -7453,12 +7444,6 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                         pushToAnyFullNode(&requestedTickTransactions.header);
 
                         requestedTickTransactions.requestedTickTransactions.tick = 0;
-                    }
-
-                    {
-                        // asking current tick around
-                        requestedCurrentTick.header.randomizeDejavu();
-                        pushToSeveral(&requestedCurrentTick.header);
                     }
                 }
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -469,7 +469,7 @@ static void processExchangePublicPeers(Peer* peer, RequestResponseHeader* header
             {
                 if (peer->address == publicPeers[j].address)
                 {
-                    publicPeers[j].isVerified = true;
+                    publicPeers[j].isHandshaked = true;
 
                     break;
                 }
@@ -6080,7 +6080,7 @@ static bool initialize()
         const IPv4Address& peer_ip = *reinterpret_cast<const IPv4Address*>(knownPublicPeers[i]);
         addPublicPeer(peer_ip);
         if (numberOfPublicPeers > 0)
-            publicPeers[numberOfPublicPeers - 1].isVerified = true;
+            publicPeers[numberOfPublicPeers - 1].isHandshaked = true;
     }
     if (numberOfPublicPeers < 4)
     {
@@ -6233,7 +6233,7 @@ static void logInfo()
 
     for (unsigned int i = 0; i < numberOfPublicPeers; i++)
     {
-        if (publicPeers[i].isVerified)
+        if (publicPeers[i].isHandshaked)
         {
             numberOfVerifiedPublicPeers++;
         }
@@ -7235,7 +7235,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                         bool noVerifiedPublicPeers = true;
                         for (unsigned int k = 0; k < numberOfPublicPeers; k++)
                         {
-                            if (publicPeers[k].isVerified)
+                            if (publicPeers[k].isHandshaked)
                             {
                                 noVerifiedPublicPeers = false;
 
@@ -7253,7 +7253,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             {
                                 // randomly select verified public peers
                                 const unsigned int publicPeerIndex = random(numberOfPublicPeers);
-                                if (publicPeers[publicPeerIndex].isVerified)
+                                if (publicPeers[publicPeerIndex].isHandshaked)
                                 {
                                     request->peers[j] = publicPeers[publicPeerIndex].address;
                                 }


### PR DESCRIPTION
This PR introduces following changes in networking logic:
- nodes frequently asking peers for their current tick statuses
- add `isFullnode()` function: return true if a peer that has higher tick than local `system.tick` and it transmits valid tick data to this node
- when requesting missing important data (tick, vote, txs), it will also ask a full node (instead of a random peer only)
- avoid disconnecting to an active full node