### PR TITLE
Fix include guard for qintin.h in case clang sets _MSC_VER

### DIFF
--- a/lib/platform_common/qintrin.h
+++ b/lib/platform_common/qintrin.h
@@ -2,7 +2,7 @@
 
 // Header file for the inclusion of plartform specific x86/x64 intrinsics header files.
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 #include <intrin.h>
 #else
 #include <immintrin.h>


### PR DESCRIPTION
This PR adjusts the include guard in qintrin.h to explicitly check for `__clang__`, since there are cases where clang set `_MSV_VER`