### PR TITLE
Add plotform header file to surpress compiler warnings

### DIFF
--- a/lib/platform_common/compiler_warnings.h
+++ b/lib/platform_common/compiler_warnings.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// Class to suppress specific compiler warnings for specific sections of code.
+// Useful to hide warnings about unknown pragmas while using other compilers.
+
+// Example usage:
+// #include "lib/platform_common/compiler_warnings.h"
+//
+// int foo() {
+//     SUPPRESS_WARNINGS_BEGIN
+//     IGNORE_CAST_ALIGN_WARNING
+//     // Code that generates warnings
+//     SUPPRESS_WARNINGS_END
+//    return 0;
+// }
+
+
+#if defined(__clang__)
+    #define PRAGMA(x) _Pragma(#x)
+    #define WARNING_PUSH PRAGMA(clang diagnostic push)
+    #define WARNING_POP PRAGMA(clang diagnostic pop)
+    #define WARNING_IGNORE_CAST_ALIGN PRAGMA(clang diagnostic ignored "-Wcast-align")
+    #define WARNING_IGNORE_UNUSED PRAGMA(clang diagnostic ignored "-Wunused-parameter")
+
+#else
+    #define WARNING_PUSH
+    #define WARNING_POP
+    #define WARNING_IGNORE_CAST_ALIGN
+    #define WARNING_IGNORE_UNUSED
+#endif
+
+// Shortcuts
+#define SUPPRESS_WARNINGS_BEGIN WARNING_PUSH
+#define SUPPRESS_WARNINGS_END WARNING_POP
+#define IGNORE_CAST_ALIGN_WARNING WARNING_IGNORE_CAST_ALIGN
+


### PR DESCRIPTION
Header allows to surpress compiler specific warnings without yielding warnings/errors in other compilers.

Example:
We need to silent some warning in the clang build. This can be achieved with a `#pragma clang ...`. However this would yield warning when buidling with msvc since this pragma is not known. This header allows to suprress the warnings for clang without the need for guards around every pragma.

Related to #246 and #257 