### PR TITLE
Custom mining stats and revenue.

### DIFF
--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -334,6 +334,17 @@ class CustomMininingCache
     static_assert(collisionRetries < size, "Number of fetch retries in case of collision is too big!");
 public:
 
+    void init()
+    {
+        setMem((unsigned char*)cache, sizeof(cache), 0);
+        lock = 0;
+        hits = 0;
+        misses = 0;
+        collisions = 0;
+        verification = 0;
+        invalid = 0;
+    }
+
     /// Reset all cache entries
     void reset()
     {
@@ -1288,7 +1299,8 @@ struct CustomMiningTaskPartition
 };
 
 static CustomMiningTaskPartition gTaskPartition[NUMBER_OF_TASK_PARTITIONS];
-static CustomMininingCache<CustomMiningSolutionCacheEntry, MAX_NUMBER_OF_CUSTOM_MINING_SOLUTIONS, 20>* gSystemCustomMiningSolutionCache = NULL;
+// This declaration will emit a warning about initialization. But it can be skipped because we call init function in customMiningInitialize().
+static CustomMininingCache<CustomMiningSolutionCacheEntry, MAX_NUMBER_OF_CUSTOM_MINING_SOLUTIONS, 20> gSystemCustomMiningSolutionCache[NUMBER_OF_TASK_PARTITIONS];
 static CustomMiningStorage gCustomMiningStorage;
 static CustomMiningStats gCustomMiningStats;
 
@@ -1332,10 +1344,11 @@ int customMiningGetComputorID(unsigned int nonce, int partId)
 int customMiningInitialize()
 {
     gCustomMiningStorage.init();
-    allocPoolWithErrorLog(L"gSystemCustomMiningSolutionCache", 
-        NUMBER_OF_TASK_PARTITIONS *  sizeof(CustomMininingCache<CustomMiningSolutionCacheEntry, MAX_NUMBER_OF_CUSTOM_MINING_SOLUTIONS, 20>),
-        (void**) & gSystemCustomMiningSolutionCache,
-        __LINE__);
+    for (int i = 0; i < NUMBER_OF_TASK_PARTITIONS; i++)
+    {
+        gSystemCustomMiningSolutionCache[i].init();
+    }
+
     customMiningInitTaskPartitions();
 
     return 0;
@@ -1343,11 +1356,6 @@ int customMiningInitialize()
 
 int customMiningDeinitialize()
 {
-    if (gSystemCustomMiningSolutionCache)
-    {
-        freePool(gSystemCustomMiningSolutionCache);
-        gSystemCustomMiningSolutionCache = NULL;
-    }
     gCustomMiningStorage.deinit();
     return 0;
 }

--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -702,7 +702,7 @@ struct CustomMiningStats
         // Shares related
         long long shares;       // Total shares/solutions = unverifed/no-task + valid + invalid
         long long valid;        // Solutions are marked as valid by verififer
-        long long inValid;      // Solutions are marked as invalid by verififer
+        long long invalid;      // Solutions are marked as invalid by verififer
         long long duplicated;   // Duplicated solutions, ussually causes by solution message broadcasted or
 
         void reset()
@@ -711,7 +711,7 @@ struct CustomMiningStats
 
             ATOMIC_STORE64(shares, 0);
             ATOMIC_STORE64(valid, 0);
-            ATOMIC_STORE64(inValid, 0);
+            ATOMIC_STORE64(invalid, 0);
             ATOMIC_STORE64(duplicated, 0);
         }
     };
@@ -744,14 +744,14 @@ struct CustomMiningStats
         long long tasks = 0;
         long long shares = 0;
         long long valid = 0;
-        long long inValid = 0;
+        long long invalid = 0;
         long long duplicated = 0;
         for (int i = 0; i < NUMBER_OF_TASK_PARTITIONS; i++)
         {
             tasks += ATOMIC_LOAD64(phase[i].tasks);
             shares += ATOMIC_LOAD64(phase[i].shares);
             valid += ATOMIC_LOAD64(phase[i].valid);
-            inValid += ATOMIC_LOAD64(phase[i].inValid);
+            invalid += ATOMIC_LOAD64(phase[i].invalid);
             duplicated += ATOMIC_LOAD64(phase[i].duplicated);
         }
 
@@ -759,7 +759,7 @@ struct CustomMiningStats
         ATOMIC_ADD64(lastPhases.tasks, tasks);
         ATOMIC_ADD64(lastPhases.shares, shares);
         ATOMIC_ADD64(lastPhases.valid, valid);
-        ATOMIC_ADD64(lastPhases.inValid, inValid);
+        ATOMIC_ADD64(lastPhases.invalid, invalid);
         ATOMIC_ADD64(lastPhases.duplicated, duplicated);
 
         // Reset phase number
@@ -781,7 +781,7 @@ struct CustomMiningStats
             customMiningTasks += ATOMIC_LOAD64(phase[i].tasks);
             customMiningShares += ATOMIC_LOAD64(phase[i].shares);
             customMiningValidShares += ATOMIC_LOAD64(phase[i].valid);
-            customMiningInvalidShares += ATOMIC_LOAD64(phase[i].inValid);
+            customMiningInvalidShares += ATOMIC_LOAD64(phase[i].invalid);
             customMiningDuplicated += ATOMIC_LOAD64(phase[i].duplicated);
         }
 
@@ -799,7 +799,7 @@ struct CustomMiningStats
 
         long long customMiningEpochTasks = customMiningTasks + ATOMIC_LOAD64(lastPhases.tasks);
         long long customMiningEpochShares = customMiningShares + ATOMIC_LOAD64(lastPhases.shares);
-        long long customMiningEpochInvalidShares = customMiningInvalidShares + ATOMIC_LOAD64(lastPhases.inValid);
+        long long customMiningEpochInvalidShares = customMiningInvalidShares + ATOMIC_LOAD64(lastPhases.invalid);
         long long customMiningEpochValidShares = customMiningValidShares + ATOMIC_LOAD64(lastPhases.valid);
         long long customMiningEpochDuplicated = customMiningDuplicated + ATOMIC_LOAD64(lastPhases.duplicated);
 
@@ -809,9 +809,9 @@ struct CustomMiningStats
         appendText(message, L" | Shares: ");
         appendNumber(message, customMiningEpochShares, false);
         appendText(message, L" | Valid: ");
-        appendNumber(message, customMiningEpochInvalidShares, false);
-        appendText(message, L" | Invalid: ");
         appendNumber(message, customMiningEpochValidShares, false);
+        appendText(message, L" | Invalid: ");
+        appendNumber(message, customMiningEpochInvalidShares, false);
         appendText(message, L" | Duplicated: ");
         appendNumber(message, customMiningEpochDuplicated, false);
     }
@@ -1171,8 +1171,6 @@ private:
     DataType* _data;
     unsigned long long* _indices;
     unsigned long long _storageIndex;
-    unsigned long long _phaseCount;
-    unsigned long long _phaseIndex;
 
     unsigned char* _dataBuffer[MAX_NUMBER_OF_PROCESSORS];
 };

--- a/src/platform/concurrency.h
+++ b/src/platform/concurrency.h
@@ -76,3 +76,6 @@ public:
 #define ATOMIC_INC64(target) _InterlockedIncrement64(&target)
 #define ATOMIC_AND64(target, val) _InterlockedAnd64(&target, val)
 #define ATOMIC_STORE64(target, val) _InterlockedExchange64(&target, val)
+#define ATOMIC_LOAD64(target) _InterlockedCompareExchange64(&target, 0, 0)
+#define ATOMIC_ADD64(target, val) _InterlockedExchangeAdd64(&target, val)
+#define ATOMIC_MAX64(target, val) atomicMax64(&target, val)

--- a/src/platform/concurrency_impl.h
+++ b/src/platform/concurrency_impl.h
@@ -79,3 +79,17 @@ void BusyWaitingTracker::pause()
 }
 
 #endif
+// Atomic max
+void atomicMax64(long long* dest, long long value)
+{
+    long long old = *dest;
+    while (value > old)
+    {
+        long long prev = _InterlockedCompareExchange64(dest, value, old);
+        if (prev == old)
+        {
+            break;
+        }
+        old = prev;
+    }
+}

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -564,7 +564,7 @@ static void processBroadcastMessage(const unsigned long long processorNumber, Re
 
                             if (CustomMiningTaskStorage::OK == taskAddSts)
                             {
-                                ATOMIC_INC64(gCustomMiningStats.phase.tasks);
+                                ATOMIC_INC64(gCustomMiningStats.phase[partId].tasks);
                             }
                         }
                     }
@@ -634,8 +634,8 @@ static void processBroadcastMessage(const unsigned long long processorNumber, Re
                                     const unsigned int missCount = gSystemCustomMiningSolutionCache[partId].missCount();
                                     const unsigned int collision = gSystemCustomMiningSolutionCache[partId].collisionCount();
 
-                                    ATOMIC_STORE64(gCustomMiningStats.phase.shares, missCount);
-                                    ATOMIC_STORE64(gCustomMiningStats.phase.duplicated, hitCount);
+                                    ATOMIC_STORE64(gCustomMiningStats.phase[partId].shares, missCount);
+                                    ATOMIC_STORE64(gCustomMiningStats.phase[partId].duplicated, hitCount);
                                     ATOMIC_MAX64(gCustomMiningStats.maxCollisionShareCount, collision);
 
                                 }
@@ -1410,13 +1410,13 @@ static void processRequestedCustomMiningSolutionVerificationRequest(Peer* peer, 
                         RELEASE(gCustomMiningSharesCountLock);
 
                         // Save the number of invalid share count
-                        ATOMIC_INC64(gCustomMiningStats.phase.inValid);
+                        ATOMIC_INC64(gCustomMiningStats.phase[partId].inValid);
 
                         respond.status = RespondCustomMiningSolutionVerification::invalid;
                     }
                     else
                     {
-                        ATOMIC_INC64(gCustomMiningStats.phase.valid);
+                        ATOMIC_INC64(gCustomMiningStats.phase[partId].valid);
                         respond.status = RespondCustomMiningSolutionVerification::valid;
                     }
                 }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3116,12 +3116,12 @@ static void processTick(unsigned long long processorNumber)
         }
     }
 
-    // In the begining of mining phase.
-    // Also skip the begining of the epoch, because the no thing to do
-    if (getTickInMiningPhaseCycle() == 0 && (system.tick - system.initialTick) > INTERNAL_COMPUTATIONS_INTERVAL)
+    // Broadcast custom mining shares 
+    if (isMainMode())
     {
-        // Broadcast custom mining shares 
-        if (isMainMode())
+        // In the begining of mining phase.
+        // Also skip the begining of the epoch, because the no thing to do
+        if (getTickInMiningPhaseCycle() == 0 && (system.tick - system.initialTick) > INTERNAL_COMPUTATIONS_INTERVAL)
         {
             long long customMiningCountOverflow = 0;
             for (unsigned int i = 0; i < numberOfOwnComputorIndices; i++)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3392,16 +3392,25 @@ static void endEpoch()
         for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
         {
             unsigned long long vote_count = voteCounter.getVoteCount(i);
-            if (vote_count != 0)
+            unsigned long long custom_mining_share_count = gCustomMiningSharesCounter.getSharesCount(i);
+            if (vote_count != 0 && custom_mining_share_count != 0)
             {
-                unsigned long long final_score = vote_count * revenueScore[i];
-                if ((final_score / vote_count) != revenueScore[i]) // detect overflow
+                unsigned long long score_with_vote = vote_count * revenueScore[i];
+                if ((score_with_vote / vote_count) != revenueScore[i]) // detect overflow
                 {
                     revenueScore[i] = 0xFFFFFFFFFFFFFFFFULL; // maximum score
                 }
                 else
                 {
-                    revenueScore[i] = final_score;
+                    unsigned long long final_score = score_with_vote * custom_mining_share_count;
+                    if ((final_score / custom_mining_share_count) != score_with_vote) // detect overflow
+                    {
+                        revenueScore[i] = 0xFFFFFFFFFFFFFFFFULL; // maximum score
+                    }
+                    else
+                    {
+                        revenueScore[i] = final_score;
+                    }
                 }
             }
             else

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1410,7 +1410,7 @@ static void processRequestedCustomMiningSolutionVerificationRequest(Peer* peer, 
                         RELEASE(gCustomMiningSharesCountLock);
 
                         // Save the number of invalid share count
-                        ATOMIC_INC64(gCustomMiningStats.phase[partId].inValid);
+                        ATOMIC_INC64(gCustomMiningStats.phase[partId].invalid);
 
                         respond.status = RespondCustomMiningSolutionVerification::invalid;
                     }
@@ -5797,10 +5797,9 @@ static void logInfo()
     logToConsole(message);
 
     // Log infomation about custom mining
-    // TODO: move those stats into F3 pressed key and using atomic operations.
     setText(message, L"CustomMining: ");
 
-    // System: Active | solutions count at current phase | Total duplicated solutions | Total skipped solutions
+    // System: Active status | Overflow | Collision
     char isCustomMiningStateActive = 0;
     ACQUIRE(gIsInCustomMiningStateLock);
     isCustomMiningStateActive = gIsInCustomMiningState;

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1494,6 +1494,10 @@ static void processCustomMiningDataRequest(Peer* peer, const unsigned long long 
                     respond = gCustomMiningStorage._solutionStorage[partId].getSerializedData(request->fromTaskIndex, processorNumber);
                     RELEASE(gCustomMiningSolutionStorageLock);
                 }
+                else
+                {
+                    respond = NULL;
+                }
 
                 // Has the solutions
                 if (NULL != respond)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -528,13 +528,15 @@ static void processBroadcastMessage(const unsigned long long processorNumber, Re
 
             if (isZero(request->destinationPublicKey))
             {
+                const unsigned int messagePayloadSize = messageSize - sizeof(BroadcastMessage) - SIGNATURE_SIZE;
+
                 // Only record task and solution message in idle phase
                 char recordCustomMining = 0;
                 ACQUIRE(gIsInCustomMiningStateLock);
                 recordCustomMining = gIsInCustomMiningState;
                 RELEASE(gIsInCustomMiningStateLock);
 
-                if (request->sourcePublicKey == dispatcherPublicKey)
+                if (messagePayloadSize == sizeof(CustomMiningTask) && request->sourcePublicKey == dispatcherPublicKey)
                 {
                     // See CustomMiningTaskMessage structure
                     // MESSAGE_TYPE_CUSTOM_MINING_TASK
@@ -567,7 +569,7 @@ static void processBroadcastMessage(const unsigned long long processorNumber, Re
                         }
                     }
                 }
-                else
+                else if (messagePayloadSize == sizeof(CustomMiningSolution))
                 {
                     for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
                     {

--- a/src/score_cache.h
+++ b/src/score_cache.h
@@ -118,7 +118,7 @@ public:
 
         const unsigned long long beginningTick = __rdtsc();
         ACQUIRE(lock);
-        long long savedSize = ::save(filename, sizeof(cache), (unsigned char*)&cache, directory);
+        long long savedSize = ::save(filename, sizeof(cache), (unsigned char*)cache, directory);
         RELEASE(lock);
         if (savedSize == sizeof(cache))
         {

--- a/test/custom_mining.cpp
+++ b/test/custom_mining.cpp
@@ -19,7 +19,7 @@
 TEST(CustomMining, TaskStorageGeneral)
 {
     constexpr unsigned long long NUMBER_OF_TASKS = 100;
-    CustomMiningSortedStorage<CustomMiningTask, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, false> storage;
+    CustomMiningTaskStorage storage;
 
     storage.init();
 
@@ -47,7 +47,7 @@ TEST(CustomMining, TaskStorageDuplicatedItems)
 {
     constexpr unsigned long long NUMBER_OF_TASKS = 100;
     constexpr unsigned long long DUPCATED_TASKS = 10;
-    CustomMiningSortedStorage<CustomMiningTask, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, false> storage;
+    CustomMiningTaskStorage storage;
 
     storage.init();
 
@@ -78,7 +78,7 @@ TEST(CustomMining, TaskStorageExistedItem)
 {
     constexpr unsigned long long NUMBER_OF_TASKS = 100;
     constexpr unsigned long long DUPCATED_TASKS = 10;
-    CustomMiningSortedStorage<CustomMiningTask, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, false> storage;
+    CustomMiningTaskStorage storage;
 
     storage.init();
 
@@ -119,7 +119,7 @@ TEST(CustomMining, TaskStorageExistedItem)
 TEST(CustomMining, TaskStorageOverflow)
 {
     constexpr unsigned long long NUMBER_OF_TASKS = CUSTOM_MINING_TASK_STORAGE_COUNT;
-    CustomMiningSortedStorage<CustomMiningTask, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, false> storage;
+    CustomMiningTaskStorage storage;
 
     storage.init();
 
@@ -141,7 +141,7 @@ TEST(CustomMining, TaskStorageOverflow)
 TEST(CustomMining, SolutionStorageGeneral)
 {
     constexpr unsigned long long NUMBER_OF_TASKS = 100;
-    CustomMiningSortedStorage<CustomMiningSolutionStorageEntry, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, true> storage;
+    CustomMiningSolutionStorage storage;
 
     storage.init();
 
@@ -169,7 +169,7 @@ TEST(CustomMining, SolutionStorageDuplicatedItems)
 {
     constexpr unsigned long long NUMBER_OF_SOLS = 100;
     constexpr unsigned long long DUPLICATED_SOLS = 10;
-    CustomMiningSortedStorage<CustomMiningSolutionStorageEntry, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, true> storage;
+    CustomMiningSolutionStorage storage;
 
     storage.init();
 
@@ -215,7 +215,7 @@ TEST(CustomMining, SolutionStorageExistedItem)
 {
     constexpr unsigned long long NUMBER_OF_SOLS = 100;
     constexpr unsigned long long DUPCATED_SOLS = 10;
-    CustomMiningSortedStorage<CustomMiningSolutionStorageEntry, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, true> storage;
+    CustomMiningSolutionStorage storage;
 
     storage.init();
 
@@ -257,8 +257,8 @@ TEST(CustomMining, SolutionStorageExistedItem)
 
 TEST(CustomMining, SolutionsStorageOverflow)
 {
-    constexpr unsigned long long NUMBER_OF_SOLS = CUSTOM_MINING_TASK_STORAGE_COUNT;
-    CustomMiningSortedStorage<CustomMiningSolutionStorageEntry, CUSTOM_MINING_TASK_STORAGE_COUNT, 0, true> storage;
+    constexpr unsigned long long NUMBER_OF_SOLS = CUSTOM_MINING_SOLUTION_STORAGE_COUNT;
+    CustomMiningSolutionStorage storage;
 
     storage.init();
 
@@ -273,7 +273,7 @@ TEST(CustomMining, SolutionsStorageOverflow)
     // Overflow. Add one more and get error status
     CustomMiningSolutionStorageEntry entry;
     entry.taskIndex = NUMBER_OF_SOLS + 1;
-    EXPECT_NE(storage.addData(&entry), 0);
+    EXPECT_NE(storage.addData(&entry), CustomMiningSolutionStorage::OK);
 
     storage.deinit();
 }


### PR DESCRIPTION
This PR,
- Re-able the custom mining revenue calculation.
- Clean up and replace some locks of custom mining with atomic function.
- Only display the detail custom mining stats when pressing F3. Otherwise just show the state and abnormal info.
- Fix some minor bug relate to submitting incorrect RequestCustomMiningData 