### PR TITLE
Fix data types in m256 tests

### DIFF
--- a/test/m256.cpp
+++ b/test/m256.cpp
@@ -158,8 +158,7 @@ TEST(TestCore256BitFunctionsIntrinsicType, isZero) {
     EXPECT_FALSE(isZero(m256i(0, 1, 0, 0).m256i_intr()));
     EXPECT_FALSE(isZero(m256i(0, 0, 1, 0).m256i_intr()));
     EXPECT_FALSE(isZero(m256i(0, 0, 0, 1).m256i_intr()));
-    // Invalid test case, due to type conversion from signed long long to unsigned long long 
-    // EXPECT_FALSE(isZero(m256i(-1, -1, -1, -1).m256i_intr()));
+    EXPECT_FALSE(isZero(m256i(0xffffffffffffffff,0xffffffffffffffff,0xffffffffffffffff,0xffffffffffffffff).m256i_intr()));
 }
 
 TEST(TestCore256BitFunctionsIntrinsicType, isZeroPerformance)

--- a/test/m256.cpp
+++ b/test/m256.cpp
@@ -9,34 +9,34 @@
 TEST(TestCore256BitClass, ConstructAssignCompare) {
     // Basic construction, comparison, and assignment
     unsigned char buffer_u8[32];
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
         buffer_u8[i] = 3 + 2 * i;
 
     m256i v1(buffer_u8);
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
         EXPECT_EQ(v1.m256i_u8[i], 3 + 2 * i);
     EXPECT_TRUE(v1 == buffer_u8);
     EXPECT_FALSE(v1 != buffer_u8);
     EXPECT_FALSE(isZero(v1));
 
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
         buffer_u8[i] = 250 - 3 * i;
 
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
         EXPECT_EQ(v1.m256i_u8[i], 3 + 2 * i);
     EXPECT_TRUE(v1 != buffer_u8);
     EXPECT_FALSE(v1 == buffer_u8);
     EXPECT_FALSE(isZero(v1));
 
     m256i v2(buffer_u8);
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
         EXPECT_EQ(v2.m256i_u8[i], 250 - 3 * i);
     EXPECT_TRUE(v1 != v2);
     EXPECT_FALSE(v1 == v2);
     EXPECT_FALSE(isZero(v2));
 
     m256i v3(v1);
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
         EXPECT_EQ(v3.m256i_u8[i], 3 + 2 * i);
     EXPECT_TRUE(v1 == v3);
     EXPECT_FALSE(v1 != v3);
@@ -47,7 +47,7 @@ TEST(TestCore256BitClass, ConstructAssignCompare) {
         buffer_intr.m256i_u8[i] = 90 + i;
 
     m256i v4(buffer_intr);
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
         EXPECT_EQ(v4.m256i_u8[i], 90 + i);
     EXPECT_TRUE(v4 == buffer_intr);
     EXPECT_FALSE(v4 != buffer_intr);
@@ -119,9 +119,9 @@ TEST(TestCore256BitClass, ConstructAssignCompare) {
 
     // Non-aligned assignment and comparison
     unsigned char buffer_u8_64[64];
-    for (int i = 0; i < 64; ++i)
+    for (int8_t i = 0; i < 64; ++i)
         buffer_u8_64[i] = 7 + i;
-    for (int i = 0; i < 32; ++i)
+    for (int8_t i = 0; i < 32; ++i)
     {
         v1 = buffer_u8_64 + i;
         EXPECT_TRUE(v1 == buffer_u8_64 + i);
@@ -158,7 +158,8 @@ TEST(TestCore256BitFunctionsIntrinsicType, isZero) {
     EXPECT_FALSE(isZero(m256i(0, 1, 0, 0).m256i_intr()));
     EXPECT_FALSE(isZero(m256i(0, 0, 1, 0).m256i_intr()));
     EXPECT_FALSE(isZero(m256i(0, 0, 0, 1).m256i_intr()));
-    EXPECT_FALSE(isZero(m256i(-1, -1, -1, -1).m256i_intr()));
+    // Invalid test case, due to type conversion from signed long long to unsigned long long 
+    // EXPECT_FALSE(isZero(m256i(-1, -1, -1, -1).m256i_intr()));
 }
 
 TEST(TestCore256BitFunctionsIntrinsicType, isZeroPerformance)


### PR DESCRIPTION
While compiling with `msvc` with higher warning levels a problem because of the conversion between `int` and `unsigned char` and `potential loss of data` arises.

No actual loss happens due to the used values but with a `int8_t` the correct type is used. Static analyser of `clang` figures that no actual loss happens and does not yield the warning at all.

Additionally one of the tests initialises a m256 with 4 negative values but functions expects `unsigned long long`

Relates to #246 and #257.