### PR TITLE
improve peer logic

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -877,7 +877,7 @@ static void processBroadcastTick(Peer* peer, RequestResponseHeader* header)
             {
                 // Copy the sent tick to the tick storage
                 copyMem(tsTick, &request->tick, sizeof(Tick));
-                peer->lastActiveTick = request->tick.tick;
+                peer->lastActiveTick = max(peer->lastActiveTick, peer->getDejavuTick(header->dejavu()));
             }
 
             ts.ticks.releaseLock(request->tick.computorIndex);
@@ -943,7 +943,7 @@ static void processBroadcastFutureTickData(Peer* peer, RequestResponseHeader* he
                             if (digest == targetNextTickDataDigest)
                             {
                                 copyMem(&td, &request->tickData, sizeof(TickData));
-                                peer->lastActiveTick = request->tickData.tick;
+                                peer->lastActiveTick = max(peer->lastActiveTick, peer->getDejavuTick(header->dejavu()));
                             }
                         }
                     }
@@ -972,7 +972,7 @@ static void processBroadcastFutureTickData(Peer* peer, RequestResponseHeader* he
                         else
                         {
                             copyMem(&td, &request->tickData, sizeof(TickData));
-                            peer->lastActiveTick = request->tickData.tick;
+                            peer->lastActiveTick = max(peer->lastActiveTick, peer->getDejavuTick(header->dejavu()));
                         }
                     }
                 }


### PR DESCRIPTION
This change aim to distinguish between node and repeater.
Previously, any peer that sends valid data to this node would be categorized as a "fullnode". Thus, custom repeater is usually categorized as fullnode, although it doesn't reply anything to other requests.
With this change, it only counts fullnode as a peer that replying valid data to requests that are initiated by this node (via `dejavu`)