### PR TITLE
Fix bug in initialization of system struct

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5274,6 +5274,9 @@ static bool initialize()
         load(SYSTEM_FILE_NAME, sizeof(system), (unsigned char*)&system);
         system.version = VERSION_B;
         system.epoch = EPOCH;
+        system.initialMillisecond = 0;
+        system.initialSecond = 0;
+        system.initialMinute = 0;
         system.initialHour = 12;
         system.initialDay = 13;
         system.initialMonth = 4;


### PR DESCRIPTION
This commit adds additional  initialisation of `system.initialSecond`, `system.initialMinute` and `system.initialMilisecond` and set them to 0. This avoids a misalignment if some computors delete the `system` file and some don't, resulting in different initaltick timestamps.