### PR TITLE
Hotfix/Custom mining save load

### DIFF
--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -143,7 +143,7 @@ public:
     // get and compress number of shares of 676 computors to 676x10 bit numbers
     void compressNewSharesPacket(unsigned int ownComputorIdx, unsigned char customMiningShareCountPacket[CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES])
     {
-        setMem(customMiningShareCountPacket, sizeof(customMiningShareCountPacket), 0);
+        setMem(customMiningShareCountPacket, CUSTOM_MINING_SHARES_COUNT_SIZE_IN_BYTES, 0);
         setMem(_buffer, sizeof(_buffer), 0);
         for (int j = 0; j < NUMBER_OF_COMPUTORS; j++)
         {

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5291,6 +5291,10 @@ static bool initialize()
         // needs to be called after ts.beginEpoch() because it looks up tickIndex, which requires to setup begin of epoch in ts
         updateNumberOfTickTransactions();
 
+        // Reset the custom mining data here so that Save/Load state for custom mining is correct.
+        customMiningInitialize();
+        resetCustomMining();
+
 #if TICK_STORAGE_AUTOSAVE_MODE
         bool canLoadFromFile = loadAllNodeStates();
 #else
@@ -5400,9 +5404,6 @@ static bool initialize()
         setNewMiningSeed();
     }    
     score->loadScoreCache(system.epoch);
-
-    customMiningInitialize();
-    resetCustomMining();
 
     loadCustomMiningCache(system.epoch);
 


### PR DESCRIPTION
This PR will,
- Make sure we reset before loading data from state that potentially cause the issue of mismatch file in last epoch.
- Correct the setMem of `customMiningShareCountPacket` 