### PR TITLE
Improve QPI (HashMap, HashSet, ...)

### DIFF
--- a/src/contract_core/contract_def.h
+++ b/src/contract_core/contract_def.h
@@ -362,6 +362,7 @@ contractSystemProcedureLocalsSizes[contractIndex][POST_INCOMING_TRANSFER] = cont
 if (!contractName::__expandEmpty) contractExpandProcedures[contractIndex] = (EXPAND_PROCEDURE)contractName::__expand;\
 QpiContextForInit qpi(contractIndex); \
 contractName::__registerUserFunctionsAndProcedures(qpi); \
+static_assert(sizeof(contractName) <= MAX_CONTRACT_STATE_SIZE, "Size of contract state " #contractName " is too large!"); \
 }
 
 

--- a/src/contract_core/qpi_hash_map_impl.h
+++ b/src/contract_core/qpi_hash_map_impl.h
@@ -161,6 +161,45 @@ namespace QPI
 	}
 
 	template <typename KeyT, typename ValueT, uint64 L, typename HashFunc>
+	sint64 HashMap<KeyT, ValueT, L, HashFunc>::nextElementIndex(sint64 elementIndex) const
+	{
+		if (!_population)
+			return NULL_INDEX;
+
+		if (elementIndex < 0)
+			elementIndex = 0;
+		else
+			++elementIndex;
+
+		// search for next occupied element until end of hash map array
+		constexpr uint64 flagsLength = math_lib::max(L >> 5, 1ull);
+		sint64 flagsIdx = elementIndex >> 5;
+		sint64 offset = elementIndex & 31ll;
+		uint64 flags = _occupationFlags[flagsIdx] >> (2 * offset);
+		while (flagsIdx < flagsLength)
+		{
+			for (sint64 i = offset; i < _nEncodedFlags; ++i, flags >>= 2)
+			{
+				if (!flags)
+				{
+					// no occupied entries in current flags
+					break;
+				}
+				if ((flags & 3ULL) == 1)
+				{
+					// found occupied entry
+					return (flagsIdx << 5) + i;
+				}
+			}
+
+			flags = _occupationFlags[++flagsIdx];
+			offset = 0;
+		}
+
+		return NULL_INDEX;
+	}
+
+	template <typename KeyT, typename ValueT, uint64 L, typename HashFunc>
 	void HashMap<KeyT, ValueT, L, HashFunc>::removeByIndex(sint64 elementIdx)
 	{
 		elementIdx &= (L - 1);

--- a/src/contract_core/qpi_hash_map_impl.h
+++ b/src/contract_core/qpi_hash_map_impl.h
@@ -43,6 +43,12 @@ namespace QPI
 	}
 
 	template <typename KeyT, typename ValueT, uint64 L, typename HashFunc>
+	bool HashMap<KeyT, ValueT, L, HashFunc>::contains(const KeyT& key) const
+	{
+		return getElementIndex(key) != NULL_INDEX;
+	}
+
+	template <typename KeyT, typename ValueT, uint64 L, typename HashFunc>
 	bool HashMap<KeyT, ValueT, L, HashFunc>::get(const KeyT& key, ValueT& value) const 
 	{
 		sint64 elementIndex = getElementIndex(key);

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -476,6 +476,10 @@ namespace QPI
 		// Return if slot at elementIndex is empty (not occupied by an element). If false, key() is valid.
 		inline bool isEmptySlot(sint64 elementIndex) const;
 
+		// Return index of the next occupied element following the index passed as an argument. Pass NULL_INDEX to get
+		// the first occupied element. Returns NULL_INDEX if there are no more occupied elements.
+		inline sint64 nextElementIndex(sint64 elementIndex) const;
+
 		// Return key at elementIndex. Invalid if isEmptySlot(elementIndex).
 		inline KeyT key(sint64 elementIndex) const;
 

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -396,6 +396,10 @@ namespace QPI
 		// Return if slot at elementIndex is empty (not occupied by an element). If false, key() is valid.
 		inline bool isEmptySlot(sint64 elementIndex) const;
 
+		// Return index of the next occupied element following the index passed as an argument. Pass NULL_INDEX to get
+		// the first occupied element. Returns NULL_INDEX if there are no more occupied elements.
+		inline sint64 nextElementIndex(sint64 elementIndex) const;
+
 		// Return key at elementIndex. Invalid if isEmptySlot(elementIndex).
 		inline KeyT key(sint64 elementIndex) const;
 

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -384,6 +384,9 @@ namespace QPI
 		inline uint64 population() const;
 
 		// Return boolean indicating whether key is contained in the hash map.
+		bool contains(const KeyT& key) const;
+
+		// Return boolean indicating whether key is contained in the hash map.
 		// If key is contained, write the associated value into the provided ValueT&. 
 		bool get(const KeyT& key, ValueT& value) const;
 

--- a/test/qpi_hash_map.cpp
+++ b/test/qpi_hash_map.cpp
@@ -474,6 +474,181 @@ REGISTER_TYPED_TEST_CASE_P(QPIHashMapTest,
 typedef Types<std::pair<QPI::id, int>, std::pair<QPI::sint64, char>, std::pair<QPI::bit_1024, QPI::uint64>> KeyValueTypesToTest;
 INSTANTIATE_TYPED_TEST_CASE_P(TypedQPIHashMapTests, QPIHashMapTest, KeyValueTypesToTest);
 
+template <class KeyT, class ValueT, unsigned int capacity>
+void hasSameContent(QPI::HashMap<KeyT, ValueT, capacity>& map, const std::map<KeyT, ValueT>& referenceMap)
+{
+	EXPECT_EQ(map.population(), referenceMap.size());
+	for (const auto& item : referenceMap)
+	{
+		EXPECT_TRUE(map.contains(item.first));
+		ValueT value;
+		EXPECT_TRUE(map.get(item.first, value));
+		EXPECT_EQ(value, item.second);
+	}
+	for (unsigned int i = 0; i < capacity; ++i)
+	{
+		KeyT key = map.key(i);	// returns key value at slot i (like 0), even if the value is not contained
+		if (!map.isEmptySlot(i))
+		{
+			// key is valid, part of map, and exactly at this position
+			EXPECT_NE(referenceMap.find(key), referenceMap.end());
+			EXPECT_EQ(map.getElementIndex(key), i);
+		}
+		else
+		{
+			// key is invalid and not at this slot
+			QPI::uint64 elementIndex = map.getElementIndex(key);
+			EXPECT_NE(elementIndex, i);
+			if (elementIndex == QPI::NULL_INDEX)
+			{
+				// not in map
+				EXPECT_EQ(referenceMap.find(key), referenceMap.end());
+			}
+			else
+			{
+				// in map, but at different position
+				EXPECT_NE(referenceMap.find(key), referenceMap.end());
+			}
+		}
+	}
+
+	// test iterator
+	QPI::sint64 i = map.nextElementIndex(QPI::NULL_INDEX);
+	unsigned int cnt = 0;
+	while (i != QPI::NULL_INDEX)
+	{
+		cnt++;
+		EXPECT_FALSE(map.isEmptySlot(i));
+		auto it = referenceMap.find(map.key(i));
+		EXPECT_NE(it, referenceMap.end());
+		EXPECT_EQ(it->second, map.value(i));
+		i = map.nextElementIndex(i);
+	}
+	EXPECT_EQ(cnt, referenceMap.size());
+}
+
+template <class KeyT, class ValueT, unsigned int capacity>
+void cleanupHashMap(QPI::HashMap<KeyT, ValueT, capacity>& map, const std::map<KeyT, ValueT>& referenceMap)
+{
+	hasSameContent(map, referenceMap);
+	map.cleanup();
+	//map.cleanupIfNeeded();
+	hasSameContent(map, referenceMap);
+}
+
+void getValue(std::mt19937_64& gen64, QPI::id& value)
+{
+	value.u64._0 = gen64();
+	value.u64._1 = gen64();
+	value.u64._2 = gen64();
+	value.u64._3 = gen64();
+}
+
+void getValue(std::mt19937_64& gen64, QPI::uint8& value)
+{
+	value = gen64() & 0xff;
+}
+
+template <class KeyT, class ValueT, unsigned int capacity>
+void testHashMapPseudoRandom(int seed, int cleanups, int percentAdd, int percentAddSecondHalf = -1)
+{
+	// add and remove entries with pseudo-random sequence
+	std::mt19937_64 gen64(seed);
+
+	std::map<KeyT, ValueT> referenceMap;
+	QPI::HashMap<KeyT, ValueT, capacity> map;
+
+	__scratchpadBuffer = new char[2 * sizeof(map)];
+
+	map.reset();
+
+	// test cleanup of empty collection
+	cleanupHashMap(map, referenceMap);
+
+	if (seed & 1)
+	{
+		// add default value of empty slot to set
+		referenceMap[map.key(0)] = map.value(0);
+		EXPECT_NE(map.set(map.key(0), map.value(0)), QPI::NULL_INDEX);
+		hasSameContent(map, referenceMap);
+	}
+
+	// Randomly add, remove, and cleanup until 50 cleanups are reached
+	int cleanupCounter = 0;
+	while (cleanupCounter < cleanups)
+	{
+		int p = gen64() % 100;
+
+		if (p == 0)
+		{
+			// cleanup (with 1% probability)
+			cleanupHashMap(map, referenceMap);
+			++cleanupCounter;
+
+			if (cleanupCounter == cleanups / 2 && percentAddSecondHalf >= 0)
+				percentAdd = percentAddSecondHalf;
+		}
+
+		if (p < percentAdd)
+		{
+			// add to map (more probable than remove)
+			KeyT key;
+			ValueT value;
+			getValue(gen64, key);
+			getValue(gen64, value);
+			if (map.set(key, value) != QPI::NULL_INDEX)
+				referenceMap[key] = value;
+			hasSameContent(map, referenceMap);
+		}
+		else
+		{
+			// remove from map
+			QPI::sint64 removeIdx = gen64() % map.capacity();
+			KeyT key = map.key(removeIdx);
+			if (!map.isEmptySlot(removeIdx))
+			{
+				referenceMap.erase(key);
+				EXPECT_EQ(map.removeByKey(key), removeIdx);
+			}
+			else if (referenceMap.find(key) == referenceMap.end())
+			{
+				EXPECT_EQ(map.removeByKey(key), QPI::NULL_INDEX);
+			}
+			hasSameContent(map, referenceMap);
+		}
+
+		// std::cout << "capacity: " << set.capacity() << ", pupulation:" << set.population() << std::endl;
+	}
+
+	delete[] __scratchpadBuffer;
+	__scratchpadBuffer = nullptr;
+}
+
+TEST(QPIHashMapTest, HashMapPseudoRandom)
+{
+	constexpr unsigned int numCleanups = 5;
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 1>(42, numCleanups, 20);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 1>(1337, numCleanups, 80);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 8>(42, 4 * numCleanups, 30);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 8>(1337, 4 * numCleanups, 50);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 8>(123456789, 4 * numCleanups, 70);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 8>(42, 10 * numCleanups, 30, 70);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 8>(1337, 10 * numCleanups, 50, 10);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 8>(123456789, 10 * numCleanups, 70, 10);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 128>(42 + 1, 6 * numCleanups, 30);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 128>(1337 + 1, 6 * numCleanups, 50);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 128>(123456789 + 1, 6 * numCleanups, 70);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 1024>(42 + 2, 10 * numCleanups, 30);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 1024>(1337 + 2, 10 * numCleanups, 50);
+	testHashMapPseudoRandom<QPI::id, QPI::uint8, 1024>(123456789 + 2, 10 * numCleanups, 70);
+	testHashMapPseudoRandom<QPI::uint8, QPI::id, 1>(42, numCleanups, 20);
+	testHashMapPseudoRandom<QPI::uint8, QPI::id, 8>(42 + 1, 10 * numCleanups, 30, 70);
+	testHashMapPseudoRandom<QPI::uint8, QPI::id, 8>(1337, 10 * numCleanups, 50, 10);
+	testHashMapPseudoRandom<QPI::uint8, QPI::id, 8>(123456789, 10 * numCleanups, 70, 10);
+	testHashMapPseudoRandom<QPI::uint8, QPI::id, 128>(1337 + 1, 6 * numCleanups, 50);
+	testHashMapPseudoRandom<QPI::uint8, QPI::id, 1024>(123456789 + 2, 10 * numCleanups, 70);
+}
+
 TEST(QPIHashMapTest, HashSet)
 {
 	constexpr QPI::uint64 capacity = 128;
@@ -635,19 +810,6 @@ void cleanupHashSet(QPI::HashSet<T, capacity>& set, const std::set<T>& reference
 	set.cleanup();
 	//set.cleanupIfNeeded();
 	hasSameContent(set, referenceSet);
-}
-
-void getValue(std::mt19937_64& gen64, QPI::id& value)
-{
-	value.u64._0 = gen64();
-	value.u64._1 = gen64();
-	value.u64._2 = gen64();
-	value.u64._3 = gen64();
-}
-
-void getValue(std::mt19937_64& gen64, QPI::uint8& value)
-{
-	value = gen64() & 0xff;
 }
 
 template <class T, unsigned int capacity>

--- a/test/qpi_hash_map.cpp
+++ b/test/qpi_hash_map.cpp
@@ -199,6 +199,8 @@ TYPED_TEST_P(QPIHashMapTest, TestGetters)
 	auto values = std::views::values(keyValuePairs);
 	QPI::sint64 returnedIndex;
 
+	EXPECT_EQ(hashMap.getElementIndex(ids[3]), QPI::NULL_INDEX);
+	EXPECT_FALSE(hashMap.contains(ids[3]));
 	EXPECT_TRUE(hashMap.isEmptySlot(0));
 
 	for (int i = 0; i < 4; ++i)
@@ -207,6 +209,7 @@ TYPED_TEST_P(QPIHashMapTest, TestGetters)
 	}
 
 	EXPECT_EQ(hashMap.getElementIndex(ids[3]), returnedIndex);
+	EXPECT_TRUE(hashMap.contains(ids[3]));
 	EXPECT_EQ(hashMap.key(returnedIndex), ids[3]);
 	EXPECT_EQ(hashMap.value(returnedIndex), values[3]);
 	EXPECT_FALSE(hashMap.isEmptySlot(returnedIndex));
@@ -286,6 +289,9 @@ TYPED_TEST_P(QPIHashMapTest, TestRemove)
 	EXPECT_NE(hashMap.getElementIndex(ids[0]), QPI::NULL_INDEX);
 	EXPECT_NE(hashMap.getElementIndex(ids[1]), QPI::NULL_INDEX);
 	EXPECT_EQ(hashMap.getElementIndex(ids[2]), QPI::NULL_INDEX);
+	EXPECT_TRUE(hashMap.contains(ids[0]));
+	EXPECT_TRUE(hashMap.contains(ids[1]));
+	EXPECT_FALSE(hashMap.contains(ids[2]));
 
 	// Try to remove key not contained in the hash map. 
 	returnedIndex = hashMap.removeByKey(TestData::GetKeyNotInTestPairs());
@@ -299,6 +305,9 @@ TYPED_TEST_P(QPIHashMapTest, TestRemove)
 	EXPECT_EQ(hashMap.getElementIndex(ids[0]), QPI::NULL_INDEX);
 	EXPECT_NE(hashMap.getElementIndex(ids[1]), QPI::NULL_INDEX);
 	EXPECT_EQ(hashMap.getElementIndex(ids[2]), QPI::NULL_INDEX);
+	EXPECT_FALSE(hashMap.contains(ids[0]));
+	EXPECT_TRUE(hashMap.contains(ids[1]));
+	EXPECT_FALSE(hashMap.contains(ids[2]));
 }
 
 TYPED_TEST_P(QPIHashMapTest, TestCleanup)

--- a/test/qpi_hash_map.cpp
+++ b/test/qpi_hash_map.cpp
@@ -605,6 +605,18 @@ void hasSameContent(QPI::HashSet<T, capacity>& set, const std::set<T>& reference
 			}
 		}
 	}
+
+	// test iterator
+	QPI::sint64 i = set.nextElementIndex(QPI::NULL_INDEX);
+	unsigned int cnt = 0;
+	while (i != QPI::NULL_INDEX)
+	{
+		cnt++;
+		EXPECT_FALSE(set.isEmptySlot(i));
+		EXPECT_NE(referenceSet.find(set.key(i)), referenceSet.end());
+		i = set.nextElementIndex(i);
+	}
+	EXPECT_EQ(cnt, referenceSet.size());
 }
 
 template <class T, unsigned int capacity>
@@ -645,10 +657,13 @@ void testHashSetPseudoRandom(int seed, int cleanups, int percentAdd, int percent
 	// test cleanup of empty collection
 	cleanupHashSet(set, referenceSet);
 
-	// add default value of empty slot to set
-	referenceSet.insert(set.key(0));
-	EXPECT_NE(set.add(set.key(0)), QPI::NULL_INDEX);
-	hasSameContent(set, referenceSet);
+	if (seed & 1)
+	{
+		// add default value of empty slot to set
+		referenceSet.insert(set.key(0));
+		EXPECT_NE(set.add(set.key(0)), QPI::NULL_INDEX);
+		hasSameContent(set, referenceSet);
+	}
 
 	// Randomly add, remove, and cleanup until 50 cleanups are reached
 	int cleanupCounter = 0;


### PR DESCRIPTION
- HashMap:
  - add iterator function `nextElementIndex()`
  - add pseudo-random tests
  - add convenience function `contains()`
- HashSet:
  - add iterator function `nextElementIndex()`
- add compile-time check of contract state size