### PR TITLE
Fix error in refresh peers logic

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -6781,7 +6781,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                     unsigned short numberOfSuitablePeers = 0;
                     for (unsigned int i = 0; i < NUMBER_OF_OUTGOING_CONNECTIONS + NUMBER_OF_INCOMING_CONNECTIONS; i++)
                     {
-                        if (peers[i].tcp4Protocol && peers[i].isConnectedAccepted && peers[i].exchangedPublicPeers && !peers[i].isClosing)
+                        if (peers[i].tcp4Protocol && peers[i].isConnectedAccepted && !peers[i].isClosing)
                         {
                             if (!peers[i].isFullNode())
                             {


### PR DESCRIPTION
Nodes regularly close random connected peers. However the logic required publicPeers to be exchanged before it potentially is selected for closing. It is to expect that a lot of incoming request do ignore the exchangePublicPeer process and, therefore, are never valid for selection. This is in particularly critical if the peer is not closing the connection properly from his side, leading to slowly filling up all connection slots on the node.