### PR TITLE
Bugfix Revenue Computation

### DIFF
--- a/src/revenue.h
+++ b/src/revenue.h
@@ -146,7 +146,7 @@ static void computeRevenue(
             unsigned long long combinedScoreFactor = txFactor * voteFactor * customFactor;
 
             gRevenueComponents.revenue[i] =
-                (long long)(combinedScoreFactor * issuancePerComputor / gTxScoreScalingThreshold / gVoteScoreScalingThreshold / gVoteScoreScalingThreshold);
+                (long long)(combinedScoreFactor * issuancePerComputor / gTxScoreScalingThreshold / gVoteScoreScalingThreshold / gCustomMiningScoreScalingThreshold);
         }
     }
 


### PR DESCRIPTION
`computeRevenue()` function divided by `gVoteScoreScalingThreshold` twice the second one should probably be `gCustomMiningScoreScalingThreshold`. The bug has no influence so far since both ScalingThresholds are the same for the moment. But in the future might be different.