### PR TITLE
Schedule revenue donations

### DIFF
--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -385,7 +385,7 @@ static void addDebugMessageAboutContractStateLockChange(const CHAR16* functionNa
 // Used to acquire a contract state lock when one contract calls a function of a different contract
 void* QPI::QpiContextFunctionCall::__qpiAcquireStateForReading(unsigned int contractIndex) const
 {
-#if !defined(NDEBUG)
+#if !defined(NDEBUG) && defined(PRINT_CONTRACT_LOCK_DETAILS)
     addDebugMessageAboutContractStateLockChange(L"__qpiAcquireStateForReading", _currentContractIndex, contractIndex, _entryPoint);
 #endif
 
@@ -470,7 +470,7 @@ void* QPI::QpiContextFunctionCall::__qpiAcquireStateForReading(unsigned int cont
 // Used to release a contract state lock when one contract calls a function of a different contract
 void QPI::QpiContextFunctionCall::__qpiReleaseStateForReading(unsigned int contractIndex) const
 {
-#if !defined(NDEBUG)
+#if !defined(NDEBUG) && defined(PRINT_CONTRACT_LOCK_DETAILS)
     addDebugMessageAboutContractStateLockChange(L"__qpiReleaseStateForReading", _currentContractIndex, contractIndex, _entryPoint);
 #endif
 
@@ -508,7 +508,7 @@ void QPI::QpiContextFunctionCall::__qpiReleaseStateForReading(unsigned int contr
 // Used to acquire a contract state lock when one contract calls a procedure of a different contract
 void* QPI::QpiContextProcedureCall::__qpiAcquireStateForWriting(unsigned int contractIndex) const
 {
-#if !defined(NDEBUG)
+#if !defined(NDEBUG) && defined(PRINT_CONTRACT_LOCK_DETAILS)
     addDebugMessageAboutContractStateLockChange(L"__qpiAcquireStateForWriting", _currentContractIndex, contractIndex, _entryPoint);
 #endif
 
@@ -570,7 +570,7 @@ void* QPI::QpiContextProcedureCall::__qpiAcquireStateForWriting(unsigned int con
 // Used to release a contract state lock when one contract calls a procedure of a different contract
 void QPI::QpiContextProcedureCall::__qpiReleaseStateForWriting(unsigned int contractIndex) const
 {
-#if !defined(NDEBUG)
+#if !defined(NDEBUG) && defined(PRINT_CONTRACT_LOCK_DETAILS)
     addDebugMessageAboutContractStateLockChange(L"__qpiReleaseStateForWriting", _currentContractIndex, contractIndex, _entryPoint);
 #endif
 

--- a/src/contract_core/qpi_proposal_voting.h
+++ b/src/contract_core/qpi_proposal_voting.h
@@ -135,6 +135,9 @@ namespace QPI
 		case ProposalTypes::Class::Transfer:
 			valid = (options >= 2 && options <= 5);
 			break;
+		case ProposalTypes::Class::TransferInEpoch:
+			valid = options == 2;
+			break;
 		case ProposalTypes::Class::Variable:
 			valid =
 				(options >= 2 && options <= 5) // option voting

--- a/src/contract_core/qpi_proposal_voting.h
+++ b/src/contract_core/qpi_proposal_voting.h
@@ -326,7 +326,7 @@ namespace QPI
 	};
 
 	template <typename ProposerAndVoterHandlingType, typename ProposalDataType>
-	bool QpiContextProposalProcedureCall<ProposerAndVoterHandlingType, ProposalDataType>::setProposal(
+	uint16 QpiContextProposalProcedureCall<ProposerAndVoterHandlingType, ProposalDataType>::setProposal(
 		const id& proposer,
 		const ProposalDataType& proposal
 	)
@@ -336,15 +336,18 @@ namespace QPI
 
 		// epoch 0 means to clear proposal
 		if (proposal.epoch == 0)
-			return clearProposal(pv.proposersAndVoters.getExistingProposalIndex(qpi, proposer));
+		{
+			unsigned int proposalIndex = pv.proposersAndVoters.getExistingProposalIndex(qpi, proposer);
+			return clearProposal(proposalIndex) ? proposalIndex : INVALID_PROPOSAL_INDEX;
+		}
 
 		// check if proposal is valid
 		if (!proposal.checkValidity())
-			return false;
+			return INVALID_PROPOSAL_INDEX;
 
 		// check if proposer ID has right to propose
 		if (!pv.proposersAndVoters.isValidProposer(qpi, proposer))
-			return false;
+			return INVALID_PROPOSAL_INDEX;
 
 		// get proposal index
 		unsigned int proposalIndex = pv.proposersAndVoters.getNewProposalIndex(qpi, proposer);
@@ -363,7 +366,7 @@ namespace QPI
 
 			// all occupied slots are used in current epoch? -> error
 			if (proposalIndex >= pv.maxProposals)
-				return false;
+				return INVALID_PROPOSAL_INDEX;
 			
 			// remove oldest proposal
 			clearProposal(proposalIndex);
@@ -373,11 +376,19 @@ namespace QPI
 		}
 
 		// set proposal (and reset previous votes if any)
-		bool okay = pv.proposals[proposalIndex].set(proposal);
-		pv.proposals[proposalIndex].tick = qpi.tick();
-		pv.proposals[proposalIndex].epoch = qpi.epoch();
-
-		return okay;
+		ASSERT(proposalIndex < pv.maxProposals);
+		if (pv.proposals[proposalIndex].set(proposal))
+		{
+			pv.proposals[proposalIndex].tick = qpi.tick();
+			pv.proposals[proposalIndex].epoch = qpi.epoch();
+			return proposalIndex;
+		}
+		else
+		{
+			// cleanup in case of this error, which indicates a bug
+			pv.proposersAndVoters.freeProposalByIndex(qpi, proposalIndex);
+			return INVALID_PROPOSAL_INDEX;
+		}
 	}
 
 	template <typename ProposerAndVoterHandlingType, typename ProposalDataType>

--- a/src/contracts/GeneralQuorumProposal.h
+++ b/src/contracts/GeneralQuorumProposal.h
@@ -33,10 +33,21 @@ struct GQMPROP : public ContractBase
 
 	typedef Array<RevenueDonationEntry, 128> RevenueDonationT;
 
-private:
+protected:
 	//----------------------------------------------------------------------------
 	// Define state
+
+	// Storage of proposals and votes
 	ProposalVotingT proposals;
+
+	// Revenue donation table:
+	// - order of IDs (destinationPublicKey) defines the order of donations
+	// - order of IDs does not change except for IDs being added at the end, no ID is removed or inserted in the middle
+	// - there may be multiple entries of one ID, exactly one with a firstEpoch in the past and multiple with
+	//   firstEpoch in the future
+	// - each pair of ID and firstEpoch exists at most once (it identifies the entry that may be overwritten)
+	// - entries of the same ID are grouped in a continuous block and sorted by firstEpoch in ascending order
+	// - the first entry with NULL_ID marks the end of the current table
 	RevenueDonationT revenueDonation;
 
 	//----------------------------------------------------------------------------
@@ -46,32 +57,111 @@ private:
 	typedef Success_output _SetRevenueDonationEntry_output;
 	struct _SetRevenueDonationEntry_locals
 	{
-		uint64 idx;
+		sint64 idx;
+		sint64 firstEmptyIdx;
+		sint64 beforeInsertIdx;
+		RevenueDonationEntry entry;
 	};
 
 	PRIVATE_PROCEDURE_WITH_LOCALS(_SetRevenueDonationEntry)
 	{
-		// Try to find public key for updating entry
-		for (locals.idx = 0; locals.idx < state.revenueDonation.capacity(); ++locals.idx)
+		// Based on publicKey and firstEpoch, find entry to update or indices required to add entry later
+		locals.firstEmptyIdx = -1;
+		locals.beforeInsertIdx = -1;
+		for (locals.idx = 0; locals.idx < (sint64)state.revenueDonation.capacity(); ++locals.idx)
 		{
-			if (input.destinationPublicKey == state.revenueDonation.get(locals.idx).destinationPublicKey)
+			locals.entry = state.revenueDonation.get(locals.idx);
+			if (input.destinationPublicKey == locals.entry.destinationPublicKey)
 			{
-				// update entry
-				state.revenueDonation.set(locals.idx, input);
-				output.okay = true;
-				return;
+				// Found entry with matching publicKey
+				if (input.firstEpoch == locals.entry.firstEpoch)
+				{
+					// Found entry with same publicKey and "first epoch" -> update entry and we are done
+					state.revenueDonation.set(locals.idx, input);
+					output.okay = true;
+					return;
+				}
+				else if (input.firstEpoch > locals.entry.firstEpoch)
+				{
+					// Update insertion index for sorting by firstEpoch
+					locals.beforeInsertIdx = locals.idx;
+				}
+				else // input.firstEpoch < locals.entry.firstEpoch
+				{
+					if (locals.beforeInsertIdx == -1)
+					{
+						// Insert before first entry with this publicKey
+						locals.beforeInsertIdx = locals.idx - 1;
+					}
+				}
+			}
+			else if (isZero(locals.entry.destinationPublicKey))
+			{
+				// We reached the end of the used list
+				locals.firstEmptyIdx = locals.idx;
+				break;
 			}
 		}
 
-		// Public key not in table -> add entry to empty slot (with zero public key)
-		for (locals.idx = 0; locals.idx < state.revenueDonation.capacity(); ++locals.idx)
+		// Found no entry for updating -> entry needs to be added
+		if (locals.firstEmptyIdx >= 0)
 		{
-			if (isZero(state.revenueDonation.get(locals.idx).destinationPublicKey))
+			// We have at least one free slot for adding the entry
+			if (locals.beforeInsertIdx >= 0)
 			{
-				// add entry
-				state.revenueDonation.set(locals.idx, input);
+				// Insert entry at correct position to keep order after moving items to free the slot
+				ASSERT(locals.beforeInsertIdx < locals.firstEmptyIdx);
+				ASSERT(locals.beforeInsertIdx + 1 < (sint64)state.revenueDonation.capacity());
+				for (locals.idx = locals.firstEmptyIdx - 1; locals.idx > locals.beforeInsertIdx; --locals.idx)
+				{
+					state.revenueDonation.set(locals.idx + 1, state.revenueDonation.get(locals.idx));
+				}
+				state.revenueDonation.set(locals.beforeInsertIdx + 1, input);
+			}
+			else
+			{
+				// PublicKey not found so far -> add entry at the end
+				state.revenueDonation.set(locals.firstEmptyIdx, input);
 				output.okay = true;
-				return;
+			}
+		}
+	}
+
+	typedef NoData _CleanupRevenueDonation_input;
+	typedef NoData _CleanupRevenueDonation_output;
+	struct _CleanupRevenueDonation_locals
+	{
+		uint64 idx, idxMove;
+		RevenueDonationEntry entry1;
+		RevenueDonationEntry entry2;
+	};
+
+	PRIVATE_PROCEDURE_WITH_LOCALS(_CleanupRevenueDonation)
+	{
+		// Make sure we have at most one entry with non-future firstEpoch per destinationPublicKey.
+		// Use that entries are grouped by ID and sorted by firstEpoch.
+		for (locals.idx = 1; locals.idx < state.revenueDonation.capacity(); ++locals.idx)
+		{
+			locals.entry1 = state.revenueDonation.get(locals.idx - 1);
+			if (isZero(locals.entry1.destinationPublicKey))
+				break;
+			locals.entry2 = state.revenueDonation.get(locals.idx);
+			if (locals.entry1.destinationPublicKey == locals.entry2.destinationPublicKey)
+			{
+				ASSERT(locals.entry1.firstEpoch < locals.entry2.firstEpoch);
+				if (locals.entry1.firstEpoch < qpi.epoch() && locals.entry2.firstEpoch <= qpi.epoch())
+				{
+					// We have found two non-future entries of the same ID, so remove older one and fill gap
+					//for (locals.idxMove = locals.idx; locals.idxMove < state.revenueDonation.capacity() && !isZero(state.revenueDonation.get(locals.idxMove).destinationPublicKey); ++locals.idxMove)
+					locals.idxMove = locals.idx;
+					while (locals.idxMove < state.revenueDonation.capacity() && !isZero(state.revenueDonation.get(locals.idxMove).destinationPublicKey))
+					{
+						state.revenueDonation.set(locals.idxMove - 1, state.revenueDonation.get(locals.idxMove));
+						++locals.idxMove;
+					}
+					setMemory(locals.entry2, 0);
+					state.revenueDonation.set(locals.idxMove - 1, locals.entry2);
+				}
 			}
 		}
 	}
@@ -81,7 +171,11 @@ public:
 	// Define public procedures and functions with input and output
 
 	typedef ProposalDataT SetProposal_input;
-	typedef Success_output SetProposal_output;
+	struct SetProposal_output
+	{
+		uint16 proposalIndex;
+		bool okay;
+	};
 	struct SetProposal_locals
 	{
 		uint32 i;
@@ -92,9 +186,17 @@ public:
 	{
 		// TODO: Fee? Burn fee?
 
+		// Set default return values to error
+		output.okay = false;
+		output.proposalIndex = INVALID_PROPOSAL_INDEX;
+
 		// Check requirements for proposals in this contract
 		switch (ProposalTypes::cls(input.type))
 		{
+		case ProposalTypes::Class::GeneralOptions:
+			// No extra checks required
+			break;
+
 		case ProposalTypes::Class::Transfer:
 			// Check that amounts, which are in millionth, are in range of 0 (= 0%) to 1000000 (= 100%)
 			for (locals.i = 0; locals.i < 4; ++locals.i)
@@ -102,20 +204,28 @@ public:
 				locals.millionthAmount = input.transfer.amounts.get(locals.i);
 				if (locals.millionthAmount < 0 || locals.millionthAmount > 1000000)
 				{
-					output.okay = false;
 					return;
 				}
 			}
 			break;
 
-		case ProposalTypes::Class::Variable:
-			// Proposals for setting a variable are not allowed at the moment (lack of meaning)
-			output.okay = false;
+		case ProposalTypes::Class::TransferInEpoch:
+			// Check amount and epoch
+			locals.millionthAmount = input.transferInEpoch.amount;
+			if (locals.millionthAmount < 0 || locals.millionthAmount > 1000000 || input.transferInEpoch.targetEpoch <= qpi.epoch())
+			{
+				return;
+			}
+			break;
+
+		default:
+			// Default: not allowed (only allow classes listed expliticly, because new classes may be added)
 			return;
 		}
 
 		// Try to set proposal (checks originators rights and general validity of input proposal)
-		output.okay = qpi(state.proposals).setProposal(qpi.originator(), input);
+		output.proposalIndex = qpi(state.proposals).setProposal(qpi.originator(), input);
+		output.okay = (output.proposalIndex != INVALID_PROPOSAL_INDEX);
 	}
 
 
@@ -253,6 +363,7 @@ public:
 	{
 		sint32 proposalIndex;
 		ProposalDataT proposal;
+		uint16 propClass;
 		ProposalSummarizedVotingDataV1 results;
 		sint32 optionIndex;
 		uint32 optionVotes;
@@ -260,6 +371,8 @@ public:
 		uint32 mostVotedOptionVotes;
 		RevenueDonationEntry revenueDonationEntry;
 		Success_output success;
+		_CleanupRevenueDonation_input cleanupInput;
+		_CleanupRevenueDonation_output cleanupOutput;
 	};
 
 	BEGIN_EPOCH_WITH_LOCALS()
@@ -273,7 +386,8 @@ public:
 			if (qpi(state.proposals).getProposal(locals.proposalIndex, locals.proposal))
 			{
 				// ... and have transfer proposal type
-				if (ProposalTypes::cls(locals.proposal.type) == ProposalTypes::Class::Transfer)
+				locals.propClass = ProposalTypes::cls(locals.proposal.type);
+				if (locals.propClass == ProposalTypes::Class::Transfer || locals.propClass == ProposalTypes::Class::TransferInEpoch)
 				{
 					// Get voting results and check if conditions for proposal acceptance are met
 					if (qpi(state.proposals).getVotingSummary(locals.proposalIndex, locals.results))
@@ -299,9 +413,20 @@ public:
 							{
 								// Set in revenueDonation table (cannot be done in END_EPOCH, because this may overwrite entries that
 								// are still needed unchanged for this epoch for the revenue donation which is run after END_EPOCH)
-								locals.revenueDonationEntry.destinationPublicKey = locals.proposal.transfer.destination;
-								locals.revenueDonationEntry.millionthAmount = locals.proposal.transfer.amounts.get(locals.mostVotedOptionIndex - 1);
-								locals.revenueDonationEntry.firstEpoch = qpi.epoch();
+								if (locals.propClass == ProposalTypes::Class::TransferInEpoch)
+								{
+									ASSERT(locals.mostVotedOptionIndex == 1);
+									ASSERT(locals.proposal.transferInEpoch.targetEpoch >= qpi.epoch());
+									locals.revenueDonationEntry.destinationPublicKey = locals.proposal.transferInEpoch.destination;
+									locals.revenueDonationEntry.millionthAmount = locals.proposal.transferInEpoch.amount;
+									locals.revenueDonationEntry.firstEpoch = locals.proposal.transferInEpoch.targetEpoch;
+								}
+								else
+								{
+									locals.revenueDonationEntry.destinationPublicKey = locals.proposal.transfer.destination;
+									locals.revenueDonationEntry.millionthAmount = locals.proposal.transfer.amounts.get(locals.mostVotedOptionIndex - 1);
+									locals.revenueDonationEntry.firstEpoch = qpi.epoch();
+								}
 								CALL(_SetRevenueDonationEntry, locals.revenueDonationEntry, locals.success);
 							}
 						}
@@ -309,6 +434,9 @@ public:
 				}
 			}
 		}
+
+		// Cleanup revenue donation table (remove outdated entires)
+		CALL(_CleanupRevenueDonation, locals.cleanupInput, locals.cleanupOutput);
 	}
 
 

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -1173,6 +1173,12 @@ namespace QPI
 
 		// Whether to support scalar votes next to option votes.
 		static constexpr bool supportScalarVotes = SupportScalarVotes;
+
+		ProposalDataV1() = default;
+		ProposalDataV1(const ProposalDataV1<SupportScalarVotes>& src)
+		{
+			copyMemory(*this, src);
+		}
 	};
 	static_assert(sizeof(ProposalDataV1<true>) == 256 + 8 + 64, "Unexpected struct size.");
 

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -1357,8 +1357,8 @@ namespace QPI
 		// are discarded).
 		// If there is no free slot, one of the oldest proposals from prior epochs is deleted to free a slot.
 		// This may be also used to clear a proposal by setting proposal.epoch = 0.
-		// Return whether proposal has been set.
-		bool setProposal(
+		// Return proposalIndex if proposal has been set, or INVALID_PROPOSAL_INDEX on error.
+		uint16 setProposal(
 			const id& proposer,
 			const ProposalDataType& proposal
 		);

--- a/test/contract_gqmprop.cpp
+++ b/test/contract_gqmprop.cpp
@@ -1,0 +1,509 @@
+#define NO_UEFI
+
+#include "contract_testing.h"
+
+#define PRINT_DETAILS 0
+
+class GQmPropChecker : public GQMPROP
+{
+public:
+    void checkRevenueDonations(
+        std::vector<id>* expectedOrder = nullptr,
+        std::vector<GQMPROP::RevenueDonationEntry>* expectedEntries = nullptr,
+        bool printTable = PRINT_DETAILS)
+    {
+        const GQMPROP::RevenueDonationT& revDon = this->revenueDonation;
+        const GQMPROP::RevenueDonationEntry* cur = nullptr;
+        const GQMPROP::RevenueDonationEntry* prev = nullptr;
+        uint64 idxRD = 0;
+
+        if (printTable)
+        {
+            std::cout << "Revenue donations table (epoch " << system.epoch << "):" << std::endl;
+            for (idxRD = 0; idxRD < revDon.capacity(); ++idxRD)
+            {
+                cur = &revDon.get(idxRD);
+                if (isZero(cur->destinationPublicKey))
+                    break;
+                std::cout << "- " << idxRD << ": ID " << cur->destinationPublicKey << ", epoch " << cur->firstEpoch << ", amount " << float(cur->millionthAmount) / 1000000.f << std::endl;
+            }
+        }
+
+        // check the used part of the table
+        std::set<id> prevIds;
+        uint64 idxO = 0;
+        for (idxRD = 0; idxRD < revDon.capacity(); ++idxRD)
+        {
+            cur = &revDon.get(idxRD);
+            if (isZero(cur->destinationPublicKey))
+            {
+                // done with checking used part of the table
+                break;
+            }
+            if (idxRD > 0)
+            {
+                if (cur->destinationPublicKey == prev->destinationPublicKey)
+                {
+                    // entries of same ID
+                    // -> check order
+                    EXPECT_LT((int)prev->firstEpoch, (int)cur->firstEpoch);
+                    // -> check that we don't have two non-future entries
+                    if (prev->firstEpoch < system.epoch)
+                    {
+                        EXPECT_GE((int)cur->firstEpoch, (int)system.epoch);
+                    }
+                }
+                else
+                {
+                    // next ID
+                    // -> check that we haven't seen it before
+                    EXPECT_EQ(prevIds.find(cur->destinationPublicKey), prevIds.end());
+                    ++idxO;
+                }
+            }
+
+            EXPECT_GE(cur->millionthAmount, 0);
+            EXPECT_LE(cur->millionthAmount, 1000000);
+
+            if (expectedOrder)
+            {
+                EXPECT_LT(idxO, expectedOrder->size());
+                EXPECT_EQ(cur->destinationPublicKey, expectedOrder->at(idxO));
+            }
+            if (expectedEntries)
+            {
+                EXPECT_LT(idxRD, expectedEntries->size());
+                EXPECT_EQ(cur->destinationPublicKey, expectedEntries->at(idxRD).destinationPublicKey);
+                EXPECT_EQ((int)cur->firstEpoch, (int)expectedEntries->at(idxRD).firstEpoch);
+                EXPECT_EQ(cur->millionthAmount, expectedEntries->at(idxRD).millionthAmount);
+            }
+
+            // update prev data for later checks
+            prev = cur;
+            prevIds.insert(cur->destinationPublicKey);
+        }
+
+        // check that all remaining entries are 0
+        for (; idxRD < revDon.capacity(); ++idxRD)
+        {
+            EXPECT_TRUE(isZero(revDon.get(idxRD).destinationPublicKey));
+            EXPECT_EQ((int)revDon.get(idxRD).firstEpoch, 0);
+            EXPECT_EQ(revDon.get(idxRD).millionthAmount, 0);
+        }
+    }
+};
+
+
+class ContractTestingGQmProp : protected ContractTesting
+{
+public:
+    ContractTestingGQmProp()
+    {
+        initEmptySpectrum();
+        INIT_CONTRACT(GQMPROP);
+        callSystemProcedure(GQMPROP_CONTRACT_INDEX, INITIALIZE);
+
+        // Setup computors
+        for (unsigned long long i = 0; i < NUMBER_OF_COMPUTORS; ++i)
+        {
+            broadcastedComputors.computors.publicKeys[i] = id(i, 1, 2, 3);
+            increaseEnergy(id(i, 1, 2, 3), 1000000);
+        }
+    }
+
+    GQmPropChecker* getState()
+    {
+        return (GQmPropChecker*)contractStates[GQMPROP_CONTRACT_INDEX];
+    }
+
+    GQMPROP::GetProposal_output getProposal(uint16 proposalIndex)
+    {
+        GQMPROP::GetProposal_input input{ proposalIndex };
+        GQMPROP::GetProposal_output output;
+        callFunction(GQMPROP_CONTRACT_INDEX, 2, input, output);
+        return output;
+    }
+
+    GQMPROP::GetVotingResults_output getResults(uint16 proposalIndex)
+    {
+        GQMPROP::GetVotingResults_input input{ proposalIndex };
+        GQMPROP::GetVotingResults_output output;
+        callFunction(GQMPROP_CONTRACT_INDEX, 4, input, output);
+        return output;
+    }
+
+    uint16 setProposal(const id& originator, const GQMPROP::ProposalDataT& proposalData)
+    {
+        GQMPROP::SetProposal_input input = proposalData;
+        GQMPROP::SetProposal_output output;
+        invokeUserProcedure(GQMPROP_CONTRACT_INDEX, 1, input, output, originator, 0);
+        return output.proposalIndex;
+    }
+
+    bool vote(const id& originator, uint16 proposalIndex, const GQMPROP::ProposalDataT& proposalData, sint64 voteValue)
+    {
+        GQMPROP::Vote_input input{proposalIndex, proposalData.type, proposalData.tick, voteValue};
+        GQMPROP::Vote_output output;
+        invokeUserProcedure(GQMPROP_CONTRACT_INDEX, 2, input, output, originator, 0);
+        return output.okay;
+    }
+
+    // TODO: add other procedures
+
+    void beginEpoch(bool expectSuccess = true)
+    {
+        callSystemProcedure(GQMPROP_CONTRACT_INDEX, BEGIN_EPOCH, expectSuccess);
+    }
+
+    void voteMultipleComputors(uint16 proposalIndex, uint16 votesNo, uint16 votesYes1, uint16 votesYes2 = 0)
+    {
+        EXPECT_LE(int(votesNo + votesYes1 + votesYes2), NUMBER_OF_COMPUTORS);
+        const auto proposal = getProposal(proposalIndex);
+        EXPECT_TRUE(proposal.okay);
+        uint16 compIdx = 0;
+        for (uint16 i = 0; i < votesNo; ++i, ++compIdx)
+            EXPECT_TRUE(vote(id(compIdx, 1, 2, 3), proposalIndex, proposal.proposal, 0));
+        for (uint16 i = 0; i < votesYes1; ++i, ++compIdx)
+            EXPECT_TRUE(vote(id(compIdx, 1, 2, 3), proposalIndex, proposal.proposal, 1));
+        for (uint16 i = 0; i < votesYes2; ++i, ++compIdx)
+            EXPECT_TRUE(vote(id(compIdx, 1, 2, 3), proposalIndex, proposal.proposal, 2));
+        auto results = getResults(proposalIndex);
+        EXPECT_TRUE(results.okay);
+        EXPECT_EQ(results.results.optionVoteCount.get(0), uint32(votesNo));
+        EXPECT_EQ(results.results.optionVoteCount.get(1), uint32(votesYes1));
+        EXPECT_EQ(results.results.optionVoteCount.get(2), uint32(votesYes2));
+    }
+
+    uint16 setupProposal(uint16 proposer, uint16 type, const id& dest, sint64 amount = 0, uint16 targetEpoch = 0, bool expectSuccess = true)
+    {
+        GQMPROP::ProposalDataT proposal;
+        setMemory(proposal, 0);
+        proposal.epoch = system.epoch;
+        proposal.type = type;
+        switch (ProposalTypes::cls(type))
+        {
+        case ProposalTypes::Class::Transfer:
+        {
+            const auto amountCount = ProposalTypes::optionCount(type) - 1;
+            for (int i = 0; i < amountCount; ++i)
+                proposal.transfer.amounts.set(i, amount + i);
+            proposal.transfer.destination = dest;
+            break;
+        }
+        case ProposalTypes::Class::TransferInEpoch:
+            proposal.transferInEpoch.amount = amount;
+            proposal.transferInEpoch.destination = dest;
+            proposal.transferInEpoch.targetEpoch = targetEpoch;
+            break;
+        }
+        uint16 proposalIdx = setProposal(id(proposer, 1, 2, 3), proposal);
+        if (expectSuccess)
+            EXPECT_NE((int)proposalIdx, (int)INVALID_PROPOSAL_INDEX);
+        else
+            EXPECT_EQ((int)proposalIdx, (int)INVALID_PROPOSAL_INDEX);
+        return proposalIdx;
+    }
+};
+
+static id ENTITY0(7, 0, 0, 0);
+static id ENTITY1(100, 0, 0, 0);
+static id ENTITY2(123, 456, 789, 0);
+static id ENTITY3(42, 69, 0, 13);
+static id ENTITY4(3, 14, 2, 7);
+
+TEST(ContractGQmProp, RevDonation)
+{
+    ContractTestingGQmProp test;
+    uint16 proposalIndex;
+    std::vector<id> revDonationOrder;
+    std::vector<GQMPROP::RevenueDonationEntry> revDonationEntries;
+
+    // rev donation from INITALIZE
+    revDonationOrder.push_back(ENTITY0);
+    revDonationEntries = { {ENTITY0, 150000, 123} };
+
+    //-------------------------------------------------------------
+    // epoch 200
+    system.epoch = 200;
+    test.beginEpoch();
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+    
+    // one successful and one unsuccessful proposal (testing insert at end)
+    proposalIndex = test.setupProposal(0, ProposalTypes::TransferYesNo, ENTITY1, 1000);
+    test.voteMultipleComputors(proposalIndex, 200, 350);
+    revDonationOrder.push_back(ENTITY1);
+
+    proposalIndex = test.setupProposal(1, ProposalTypes::TransferYesNo, ENTITY2, 10000);
+    test.voteMultipleComputors(proposalIndex, 100, 200);
+
+    //-------------------------------------------------------------
+    // epoch 201
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = { {ENTITY0, 150000, 123}, {ENTITY1, 1000, 201} };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    // add future revenue donations (testing insert at end and in the middle)
+    proposalIndex = test.setupProposal(0, ProposalTypes::TransferInEpochYesNo, ENTITY2, 2000, 205);
+    test.voteMultipleComputors(proposalIndex, 0, 600);
+    revDonationOrder.push_back(ENTITY2);
+
+    proposalIndex = test.setupProposal(1, ProposalTypes::TransferInEpochYesNo, ENTITY1, 3000, 204);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(2, ProposalTypes::TransferInEpochYesNo, ENTITY1, 4000, 203);
+    test.voteMultipleComputors(proposalIndex, 300, 350);
+
+    proposalIndex = test.setupProposal(3, ProposalTypes::TransferInEpochYesNo, ENTITY1, 5000, 205);
+    test.voteMultipleComputors(proposalIndex, 300, 350);
+
+    //-------------------------------------------------------------
+    // epoch 202
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = { {ENTITY0, 150000, 123}, {ENTITY1, 1000, 201}, {ENTITY1, 4000, 203}, {ENTITY1, 3000, 204}, {ENTITY1, 5000, 205}, {ENTITY2, 2000, 205} };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    //-------------------------------------------------------------
+    // epoch 203 -> {ENTITY1, 1000, 201} is cleaned up, because {ENTITY1, 4000, 203} is in action now
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = {
+        {ENTITY0, 150000, 123},
+        {ENTITY1, 4000, 203}, {ENTITY1, 3000, 204}, {ENTITY1, 5000, 205},
+        {ENTITY2, 2000, 205}
+    };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    // add more dontaions
+    proposalIndex = test.setupProposal(1, ProposalTypes::TransferThreeAmounts, ENTITY4, 6000);
+    test.voteMultipleComputors(proposalIndex, 100, 100, 400); // vote for second amount (6001)
+    revDonationOrder.push_back(ENTITY3);
+
+    proposalIndex = test.setupProposal(0, ProposalTypes::TransferInEpochYesNo, ENTITY3, 7000, 205);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+    revDonationOrder.push_back(ENTITY4);
+
+    // add at front of ENTITY3
+    proposalIndex = test.setupProposal(2, ProposalTypes::TransferInEpochYesNo, ENTITY3, 8000, 204);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(3, ProposalTypes::TransferInEpochYesNo, ENTITY3, 9000, 210);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(4, ProposalTypes::TransferInEpochYesNo, ENTITY3, 10000, 207);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(5, ProposalTypes::TransferInEpochYesNo, ENTITY4, 11000, 220);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(6, ProposalTypes::TransferInEpochYesNo, ENTITY4, 12000, 210);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(7, ProposalTypes::TransferInEpochYesNo, ENTITY4, 13000, 208);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    // rejected due to non-future epoch
+    test.setupProposal(1, ProposalTypes::TransferInEpochYesNo, ENTITY4, 7500, 203, false);
+
+    //-------------------------------------------------------------
+    // epoch 204 -> {ENTITY1, 4000, 203} is cleaned up, because {ENTITY1, 3000, 204} is in action now
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = {
+        {ENTITY0, 150000, 123},
+        {ENTITY1, 3000, 204}, {ENTITY1, 5000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 8000, 204}, {ENTITY3, 7000, 205}, {ENTITY3, 10000, 207}, {ENTITY3, 9000, 210},
+        {ENTITY4, 6001, 204}, {ENTITY4, 13000, 208}, {ENTITY4, 12000, 210}, {ENTITY4, 11000, 220},
+    };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    // update amounts (feature to overwrite/cancel scheduled changes)
+    proposalIndex = test.setupProposal(0, ProposalTypes::TransferYesNo, ENTITY3, 14000); // epoch 205
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(1, ProposalTypes::TransferInEpochYesNo, ENTITY1, 15000, 205);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(2, ProposalTypes::TransferInEpochYesNo, ENTITY4, 16000, 220);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(3, ProposalTypes::TransferInEpochYesNo, ENTITY3, 17000, 207);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    // update with higher proposal index overwrites the one with lower index (both ENTITY3 epoch 205)
+    proposalIndex = test.setupProposal(4, ProposalTypes::TransferInEpochYesNo, ENTITY3, 18000, 205);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    //-------------------------------------------------------------
+    // epoch 205 -> {ENTITY1, 3000, 204} and {ENTITY3, 8000, 204} are cleaned up
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = {
+        {ENTITY0, 150000, 123},
+        {ENTITY1, 15000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 18000, 205}, {ENTITY3, 17000, 207}, {ENTITY3, 9000, 210},
+        {ENTITY4, 6001, 204}, {ENTITY4, 13000, 208}, {ENTITY4, 12000, 210}, {ENTITY4, 16000, 220},
+    };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    // update amount (feature to overwrite/cancel scheduled changes)
+    proposalIndex = test.setupProposal(0, ProposalTypes::TransferInEpochYesNo, ENTITY3, 19000, 210);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    // schedule new rev. donation for ENTITY0
+    proposalIndex = test.setupProposal(1, ProposalTypes::TransferInEpochYesNo, ENTITY0, 20000, 210);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(2, ProposalTypes::TransferInEpochYesNo, ENTITY0, 21000, 207);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(3, ProposalTypes::TransferInEpochYesNo, ENTITY0, 22000, 215);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(4, ProposalTypes::TransferInEpochYesNo, ENTITY0, 23000, 208);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    //-------------------------------------------------------------
+    // epoch 206 -> nothing cleaned up (not epoch 206 donation entry gets in action)
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = {
+        {ENTITY0, 150000, 123}, {ENTITY0, 21000, 207}, {ENTITY0, 23000, 208}, {ENTITY0, 20000, 210}, {ENTITY0, 22000, 215},
+        {ENTITY1, 15000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 18000, 205}, {ENTITY3, 17000, 207}, {ENTITY3, 19000, 210},
+        {ENTITY4, 6001, 204}, {ENTITY4, 13000, 208}, {ENTITY4, 12000, 210}, {ENTITY4, 16000, 220},
+    };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    //-------------------------------------------------------------
+    // epoch 207 -> entries from ENTITY0 and ENTITY3 cleaned up
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = {
+        {ENTITY0, 21000, 207}, {ENTITY0, 23000, 208}, {ENTITY0, 20000, 210}, {ENTITY0, 22000, 215},
+        {ENTITY1, 15000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 17000, 207}, {ENTITY3, 19000, 210},
+        {ENTITY4, 6001, 204}, {ENTITY4, 13000, 208}, {ENTITY4, 12000, 210}, {ENTITY4, 16000, 220},
+    };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    //-------------------------------------------------------------
+    // epoch 208 -> entries from ENTITY0 and ENTITY4 cleaned up
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries = {
+        {ENTITY0, 23000, 208}, {ENTITY0, 20000, 210}, {ENTITY0, 22000, 215},
+        {ENTITY1, 15000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 17000, 207}, {ENTITY3, 19000, 210},
+        {ENTITY4, 13000, 208}, {ENTITY4, 12000, 210}, {ENTITY4, 16000, 220},
+    };
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    // fill up the revenue donation table storage completely (2 of 10 are updated, 118 are added, 10 cannot be added
+    // due to lack of storage)
+    revDonationEntries = { {ENTITY0, 23000, 208} };
+    for (unsigned int i = 0; i < 130; ++i)
+    {
+        proposalIndex = test.setupProposal(i, ProposalTypes::TransferInEpochYesNo, ENTITY0, 30000 + i, 210 + i);
+        test.voteMultipleComputors(proposalIndex, 100, 500);
+        if (i < 120)
+            revDonationEntries.push_back({ ENTITY0, 30000 + i, uint16(210 + i) });
+    }
+    revDonationEntries.insert(revDonationEntries.end(), {
+        {ENTITY1, 15000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 17000, 207}, {ENTITY3, 19000, 210},
+        {ENTITY4, 13000, 208}, {ENTITY4, 12000, 210}, {ENTITY4, 16000, 220} });
+    EXPECT_EQ(revDonationEntries.size(), 128);
+
+    //-------------------------------------------------------------
+    // epoch 209 -> no entries cleaned up
+    ++system.epoch;
+    test.beginEpoch();
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    //-------------------------------------------------------------
+    // epoch 210 -> 3 entries cleaned up (ENTITY0, ENTITY3, ENTITY4) 
+    ++system.epoch;
+    test.beginEpoch();
+
+    revDonationEntries.clear();
+    for (unsigned int i = 0; i < 120; ++i)
+    {
+        revDonationEntries.push_back({ ENTITY0, 30000 + i, uint16(210 + i) });
+    }
+    revDonationEntries.insert(revDonationEntries.end(), {
+        {ENTITY1, 15000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 19000, 210},
+        {ENTITY4, 12000, 210}, {ENTITY4, 16000, 220} });
+
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+
+    //-------------------------------------------------------------
+    // epoch 211 -> entry removed from ENTITY0 (first entry)
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries.erase(revDonationEntries.begin());
+    EXPECT_EQ(revDonationEntries.size(), 124);
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    // fill up storage at the end
+    proposalIndex = test.setupProposal(0, ProposalTypes::TransferInEpochYesNo, ENTITY4, 40000, 213);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(1, ProposalTypes::TransferInEpochYesNo, ENTITY4, 41000, 225);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(2, ProposalTypes::TransferInEpochYesNo, ENTITY4, 42000, 215);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(3, ProposalTypes::TransferInEpochYesNo, ENTITY4, 43000, 214);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    // will fail due to storage limitation
+    proposalIndex = test.setupProposal(4, ProposalTypes::TransferInEpochYesNo, ENTITY4, 44000, 230);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    proposalIndex = test.setupProposal(5, ProposalTypes::TransferInEpochYesNo, ENTITY4, 44000, 212);
+    test.voteMultipleComputors(proposalIndex, 100, 500);
+
+    revDonationEntries.erase(revDonationEntries.end() - 1);
+    revDonationEntries.insert(revDonationEntries.end(), {
+        {ENTITY4, 40000, 213}, {ENTITY4, 43000, 214}, {ENTITY4, 42000, 215}, {ENTITY4, 16000, 220}, {ENTITY4, 41000, 225},
+        });
+
+    //-------------------------------------------------------------
+    // epoch 212 -> entry removed from ENTITY0 (first entry)
+    ++system.epoch;
+    test.beginEpoch();
+    revDonationEntries.erase(revDonationEntries.begin());
+    EXPECT_EQ(revDonationEntries.size(), 127);
+    test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries);
+
+    //-------------------------------------------------------------
+    // run 120 epochs reducing table back to one entry per entity
+    revDonationEntries = {
+        {ENTITY0, 30119, 329},
+        {ENTITY1, 15000, 205},
+        {ENTITY2, 2000, 205},
+        {ENTITY3, 19000, 210},
+        {ENTITY4, 41000, 225},
+    };
+    for (unsigned int i = 0; i < 120; ++i)
+    {
+        ++system.epoch;
+        test.beginEpoch();
+        if (i == 119)
+            test.getState()->checkRevenueDonations(&revDonationOrder, &revDonationEntries, true);
+        else
+            test.getState()->checkRevenueDonations(&revDonationOrder, nullptr, false);
+    }
+}

--- a/test/qpi.cpp
+++ b/test/qpi.cpp
@@ -604,13 +604,19 @@ template <typename ProposalVotingType, typename ProposalDataType>
 void setProposalWithSuccessCheck(const QPI::QpiContextProcedureCall& qpi, const ProposalVotingType& pv, const QPI::id& proposerId, const ProposalDataType& proposal)
 {
     ProposalDataType proposalReturned;
-    EXPECT_TRUE(qpi(*pv).setProposal(proposerId, proposal));
+    EXPECT_NE((int)qpi(*pv).setProposal(proposerId, proposal), (int)QPI::INVALID_PROPOSAL_INDEX);
     QPI::uint16 proposalIdx = qpi(*pv).proposalIndex(proposerId);
     EXPECT_NE((int)proposalIdx, (int)QPI::INVALID_PROPOSAL_INDEX);
     EXPECT_EQ(qpi(*pv).proposerId(proposalIdx), proposerId);
     EXPECT_TRUE(qpi(*pv).getProposal(proposalIdx, proposalReturned));
     EXPECT_TRUE(isReturnedProposalAsExpected(qpi, proposalReturned, proposal));
     expectNoVotes(qpi, pv, proposalIdx);
+}
+
+template <typename ProposalVotingType, typename ProposalDataType>
+void setProposalExpectFailure(const QPI::QpiContextProcedureCall& qpi, const ProposalVotingType& pv, const QPI::id& proposerId, const ProposalDataType& proposal)
+{
+    EXPECT_EQ((int)qpi(*pv).setProposal(proposerId, proposal), (int)QPI::INVALID_PROPOSAL_INDEX);
 }
 
 template <bool successExpected, typename ProposalVotingType>
@@ -820,7 +826,7 @@ void testProposalVotingV1()
     if (proposalByComputorsOnly)
     {
         // fail: originator id(1,2,3,4) is no computor (see custom qpi.computor() above)
-        EXPECT_FALSE(qpi(*pv).setProposal(qpi.originator(), proposal));
+        setProposalExpectFailure(qpi, pv, qpi.originator(), proposal);
     }
     else
     {
@@ -842,15 +848,15 @@ void testProposalVotingV1()
     // fail: invalid type (more options than supported)
     proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::GeneralOptions, 9);
     EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
 
     // fail: invalid type (less options than supported)
     proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::GeneralOptions, 0);
     EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
     proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::GeneralOptions, 1);
     EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
 
     // okay: set proposal for computor 2 / other ID (proposal index 1, first use)
     QPI::id secondNonComputorId(12345, 6789, 987, 654);
@@ -893,7 +899,7 @@ void testProposalVotingV1()
     proposal.type = QPI::ProposalTypes::TransferYesNo;
     proposal.transfer.destination = QPI::NULL_ID;
     proposal.transfer.amounts.setAll(0);
-    EXPECT_FALSE(qpi(*pv).setProposal(secondProposer, proposal));
+    setProposalExpectFailure(qpi, pv, secondProposer, proposal);
     // check that overwrite did not work
     EXPECT_TRUE(qpi(*pv).getProposal(qpi(*pv).proposalIndex(secondProposer), proposalReturned));
     EXPECT_FALSE(isReturnedProposalAsExpected(qpi, proposalReturned, proposal));
@@ -901,19 +907,19 @@ void testProposalVotingV1()
     // fail: proposal of transfer with too many or too few options
     proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::Transfer, 0);
     EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
-    EXPECT_FALSE(qpi(*pv).setProposal(secondProposer, proposal));
+    setProposalExpectFailure(qpi, pv, secondProposer, proposal);
     proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::Transfer, 1);
     EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
-    EXPECT_FALSE(qpi(*pv).setProposal(secondProposer, proposal));
+    setProposalExpectFailure(qpi, pv, secondProposer, proposal);
     proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::Transfer, 6);
     EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
-    EXPECT_FALSE(qpi(*pv).setProposal(secondProposer, proposal));
+    setProposalExpectFailure(qpi, pv, secondProposer, proposal);
 
     // fail: proposal of revenue distribution with invalid amount
     proposal.type = QPI::ProposalTypes::TransferYesNo;
     proposal.transfer.destination = qpi.originator();
     proposal.transfer.amounts.set(0, -123456);
-    EXPECT_FALSE(qpi(*pv).setProposal(secondProposer, proposal));
+    setProposalExpectFailure(qpi, pv, secondProposer, proposal);
 
     // okay: revenue distribution, overwrite existing proposal of comp 2 (proposal index 1, reused)
     proposal.transfer.destination = qpi.originator();
@@ -948,7 +954,7 @@ void testProposalVotingV1()
     {
         // fail: scalar proposal not supported
         proposal.type = QPI::ProposalTypes::VariableScalarMean;
-        EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+        setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
     }
     else
     {
@@ -958,15 +964,15 @@ void testProposalVotingV1()
         proposal.variableScalar.minValue = 11;
         proposal.variableScalar.maxValue = 20;
         proposal.variableScalar.variable = 123; // not checked, full range usable
-        EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+        setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
         proposal.variableScalar.minValue = 0;
         proposal.variableScalar.maxValue = 9;
-        EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+        setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
 
         // fail: scalar proposal with full range is invalid, because NO_VOTE_VALUE is reserved for no vote
         proposal.variableScalar.minValue = proposal.variableScalar.minSupportedValue - 1;
         proposal.variableScalar.maxValue = proposal.variableScalar.maxSupportedValue;
-        EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+        setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
 
         // okay: scalar proposal with nearly full range
         proposal.variableScalar.minValue = proposal.variableScalar.minSupportedValue;
@@ -1044,22 +1050,22 @@ void testProposalVotingV1()
     {
         proposal.transfer.amounts.setAll(0);
         proposal.transfer.amounts.set(i, -100 * i - 1);
-        EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+        setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
     }
     proposal.transfer.amounts.set(0, 0);
     proposal.transfer.amounts.set(1, 10);
     proposal.transfer.amounts.set(2, 20);
     proposal.transfer.amounts.set(3, 100); // for ProposalTypes::TransferThreeAmounts, fourth must be 0
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
 
     // fail: duplicate options
     proposal.transfer.amounts.setAll(0);
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
 
     // fail: options not sorted
     for (int i = 0; i < 3; ++i)
         proposal.transfer.amounts.set(i, 100 - i);
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(1), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.computor(1), proposal);
 
     // okay: fill proposal storage
     proposal.transfer.amounts.setAll(0);
@@ -1075,7 +1081,7 @@ void testProposalVotingV1()
     EXPECT_EQ(qpi(*pv).nextFinishedProposalIndex(-1), -1);
 
     // fail: no space left
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.computor(pv->maxProposals), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.computor(pv->maxProposals), proposal);
 
     // cast some votes before epoch change to test querying voting summary afterwards
     for (int i = 0; i < 20; ++i)
@@ -1119,8 +1125,8 @@ void testProposalVotingV1()
     EXPECT_EQ(countActiveProposals(qpi, pv), 1);
     EXPECT_EQ(countFinishedProposals(qpi, pv), (int)pv->maxProposals - 2);
     proposal.epoch = 0;
-    EXPECT_FALSE(qpi(*pv).setProposal(qpi.originator(), proposal));
-    EXPECT_TRUE(qpi(*pv).setProposal(qpi.computor(7), proposal));
+    setProposalExpectFailure(qpi, pv, qpi.originator(), proposal);
+    EXPECT_NE((int)qpi(*pv).setProposal(qpi.computor(7), proposal), (int)QPI::INVALID_PROPOSAL_INDEX); // success
     EXPECT_EQ((int)qpi(*pv).proposalIndex(qpi.computor(7)), (int)QPI::INVALID_PROPOSAL_INDEX);
     EXPECT_EQ(countActiveProposals(qpi, pv), 1);
     EXPECT_EQ(countFinishedProposals(qpi, pv), (int)pv->maxProposals - 3);

--- a/test/qpi.cpp
+++ b/test/qpi.cpp
@@ -416,6 +416,21 @@ void testProposalWithAllVoteData()
     proposal.transfer.amounts.set(3, 1234567);
     testProposalWithAllVoteDataOptionVotes(pwav, proposal, 5);
 
+    // TransferInEpochYesNo proposal
+    proposal.type = QPI::ProposalTypes::TransferInEpochYesNo;
+    proposal.transferInEpoch.destination = QPI::id(1, 2, 3, 4);
+    proposal.transferInEpoch.amount = 10;
+    proposal.transferInEpoch.targetEpoch = 123;
+    testProposalWithAllVoteDataOptionVotes(pwav, proposal, 2);
+
+    // fail: test TransferInEpoch proposal with too many or too few options
+    proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::TransferInEpoch, 1);
+    EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
+    EXPECT_FALSE(proposal.checkValidity());
+    proposal.type = QPI::ProposalTypes::type(QPI::ProposalTypes::Class::TransferInEpoch, 3);
+    EXPECT_FALSE(QPI::ProposalTypes::isValid(proposal.type));
+    EXPECT_FALSE(proposal.checkValidity());
+
     // VariableYesNo proposal
     proposal.type = QPI::ProposalTypes::VariableYesNo;
     proposal.variableOptions.variable = 42;
@@ -509,6 +524,10 @@ TEST(TestCoreQPI, ProposalWithAllVoteDataYesNoProposals)
 
     // TransferThreeAmounts
     proposal.type = QPI::ProposalTypes::TransferThreeAmounts;
+    EXPECT_FALSE(proposal.checkValidity());
+
+    // fail: TransferInEpochYesNo proposal not supported due to lack of storage
+    proposal.type = QPI::ProposalTypes::TransferInEpochYesNo;
     EXPECT_FALSE(proposal.checkValidity());
 
     // VariableYesNo proposal

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="contract_qvault.cpp" />
     <ClCompile Include="contract_testex.cpp" />
     <ClCompile Include="contract_qbay.cpp" />
+    <ClCompile Include="contract_gqmprop.cpp" />
     <ClCompile Include="custom_mining.cpp" />
     <ClCompile Include="file_io.cpp" />
     <ClCompile Include="qpi_collection.cpp" />

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -29,6 +29,7 @@
     <ClCompile Include="virtual_memory.cpp" />
     <ClCompile Include="custom_mining.cpp" />
     <ClCompile Include="revenue.cpp" />
+    <ClCompile Include="contract_gqmprop.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="score_reference.h" />


### PR DESCRIPTION
- add new proposal type "transfer with target epoch" (`TransferInEpoch`)
- adapt GQMPROP to support scheduling future revenue donation changes
  - enable multiple entries of same target ID in revenue donation table (distinguished by epoch)
  - enable to overwrite entry for specific first epoch (to cancel / modify donation change that was scheduled before)
- change "SetProposal" in QPI and GQMPROP to return proposal index
- disable debug logging of contact locking by default