### PR TITLE
Fix duplicate type "Entity"

### DIFF
--- a/src/common_buffers.h
+++ b/src/common_buffers.h
@@ -7,7 +7,7 @@
 #include "network_messages/assets.h"
 
 
-constexpr unsigned long long spectrumSizeInBytes = SPECTRUM_CAPACITY * sizeof(::Entity);
+constexpr unsigned long long spectrumSizeInBytes = SPECTRUM_CAPACITY * sizeof(EntityRecord);
 constexpr unsigned long long universeSizeInBytes = ASSETS_CAPACITY * sizeof(AssetRecord);
 // TODO: check that max contract state size does not exceed size of spectrum or universe
 constexpr unsigned long long reorgBufferSize = (spectrumSizeInBytes >= universeSizeInBytes) ? spectrumSizeInBytes : universeSizeInBytes;

--- a/src/contracts/QVAULT.h
+++ b/src/contracts/QVAULT.h
@@ -604,7 +604,7 @@ protected:
 
     struct END_EPOCH_locals 
     {
-        ::Entity entity;
+        Entity entity;
         AssetPossessionIterator iter;
         Asset QCAPId;
         uint64 revenue;

--- a/src/contracts/Qearn.h
+++ b/src/contracts/Qearn.h
@@ -318,7 +318,7 @@ protected:
 
     struct getStatsPerEpoch_locals 
     {
-        ::Entity entity;
+        Entity entity;
         uint32 cnt, _t;
     };
 
@@ -900,7 +900,7 @@ protected:
         bit status;
         uint64 pre_epoch_balance;
         uint64 current_balance;
-        ::Entity entity;
+        Entity entity;
         uint32 locked_epoch;
     };
 

--- a/src/network_messages/entity.h
+++ b/src/network_messages/entity.h
@@ -2,7 +2,7 @@
 
 #include "common_def.h"
 
-struct Entity
+struct EntityRecord
 {
     m256i publicKey;
     long long incomingAmount, outgoingAmount;
@@ -13,7 +13,7 @@ struct Entity
     unsigned int latestIncomingTransferTick, latestOutgoingTransferTick;
 };
 
-static_assert(sizeof(::Entity) == 32 + 2 * 8 + 2 * 4 + 2 * 4, "Something is wrong with the struct size.");
+static_assert(sizeof(EntityRecord) == 32 + 2 * 8 + 2 * 4 + 2 * 4, "Something is wrong with the struct size.");
 
 
 #define REQUEST_ENTITY 31
@@ -30,10 +30,10 @@ static_assert(sizeof(RequestedEntity) == 32, "Something is wrong with the struct
 
 struct RespondedEntity
 {
-    ::Entity entity;
+    EntityRecord entity;
     unsigned int tick;
     int spectrumIndex;
     m256i siblings[SPECTRUM_DEPTH];
 };
 
-static_assert(sizeof(RespondedEntity) == sizeof(::Entity) + 4 + 4 + 32 * SPECTRUM_DEPTH, "Something is wrong with the struct size.");
+static_assert(sizeof(RespondedEntity) == sizeof(EntityRecord) + 4 + 4 + 32 * SPECTRUM_DEPTH, "Something is wrong with the struct size.");

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1265,7 +1265,7 @@ static void processRequestEntity(Peer* peer, RequestResponseHeader* header)
     }
     else
     {
-        copyMem(&respondedEntity.entity, &spectrum[respondedEntity.spectrumIndex], sizeof(::Entity));
+        copyMem(&respondedEntity.entity, &spectrum[respondedEntity.spectrumIndex], sizeof(EntityRecord));
         ACQUIRE(spectrumLock);
         getSiblings<SPECTRUM_DEPTH>(respondedEntity.spectrumIndex, spectrumDigests, respondedEntity.siblings);
         RELEASE(spectrumLock);
@@ -5524,7 +5524,7 @@ static bool initialize()
                     numberOfLeafs >>= 1;
                 }
 
-                setNumber(message, SPECTRUM_CAPACITY * sizeof(::Entity), TRUE);
+                setNumber(message, SPECTRUM_CAPACITY * sizeof(EntityRecord), TRUE);
                 appendText(message, L" bytes of the spectrum data are hashed (");
                 appendNumber(message, (__rdtsc() - beginningTick) * 1000000 / frequency, TRUE);
                 appendText(message, L" microseconds).");

--- a/src/spectrum/spectrum.h
+++ b/src/spectrum/spectrum.h
@@ -18,7 +18,7 @@
 #include "common_buffers.h"
 
 GLOBAL_VAR_DECL volatile char spectrumLock GLOBAL_VAR_INIT(0);
-GLOBAL_VAR_DECL ::Entity* spectrum GLOBAL_VAR_INIT(nullptr);
+GLOBAL_VAR_DECL EntityRecord* spectrum GLOBAL_VAR_INIT(nullptr);
 GLOBAL_VAR_DECL struct SpectrumInfo {
     unsigned int numberOfEntities = 0;  // Number of entities in the spectrum hash map, may include entries with balance == 0
     unsigned long long totalAmount = 0; // Total amount of qubics in the spectrum
@@ -149,8 +149,8 @@ static void reorganizeSpectrum()
 
     unsigned long long spectrumReorgStartTick = __rdtsc();
 
-    ::Entity* reorgSpectrum = (::Entity*)reorgBuffer;
-    setMem(reorgSpectrum, SPECTRUM_CAPACITY * sizeof(::Entity), 0);
+    EntityRecord* reorgSpectrum = (EntityRecord*)reorgBuffer;
+    setMem(reorgSpectrum, SPECTRUM_CAPACITY * sizeof(EntityRecord), 0);
     for (unsigned int i = 0; i < SPECTRUM_CAPACITY; i++)
     {
         if (spectrum[i].incomingAmount - spectrum[i].outgoingAmount)
@@ -160,7 +160,7 @@ static void reorganizeSpectrum()
         iteration:
             if (isZero(reorgSpectrum[index].publicKey))
             {
-                copyMem(&reorgSpectrum[index], &spectrum[i], sizeof(::Entity));
+                copyMem(&reorgSpectrum[index], &spectrum[i], sizeof(EntityRecord));
             }
             else
             {
@@ -170,7 +170,7 @@ static void reorganizeSpectrum()
             }
         }
     }
-    copyMem(spectrum, reorgSpectrum, SPECTRUM_CAPACITY * sizeof(::Entity));
+    copyMem(spectrum, reorgSpectrum, SPECTRUM_CAPACITY * sizeof(EntityRecord));
 
     unsigned int digestIndex;
     for (digestIndex = 0; digestIndex < SPECTRUM_CAPACITY; digestIndex++)
@@ -380,8 +380,8 @@ static bool decreaseEnergy(const int index, long long amount)
 static bool loadSpectrum(const CHAR16* fileName = SPECTRUM_FILE_NAME, const CHAR16* directory = nullptr)
 {
     logToConsole(L"Loading spectrum file ...");
-    long long loadedSize = load(fileName, SPECTRUM_CAPACITY * sizeof(::Entity), (unsigned char*)spectrum, directory);
-    if (loadedSize != SPECTRUM_CAPACITY * sizeof(::Entity))
+    long long loadedSize = load(fileName, SPECTRUM_CAPACITY * sizeof(EntityRecord), (unsigned char*)spectrum, directory);
+    if (loadedSize != SPECTRUM_CAPACITY * sizeof(EntityRecord))
     {
         logStatusToConsole(L"EFI_FILE_PROTOCOL.Read() reads invalid number of bytes", loadedSize, __LINE__);
 
@@ -398,10 +398,10 @@ static bool saveSpectrum(const CHAR16* fileName = SPECTRUM_FILE_NAME, const CHAR
     const unsigned long long beginningTick = __rdtsc();
 
     ACQUIRE(spectrumLock);
-    long long savedSize = save(fileName, SPECTRUM_CAPACITY * sizeof(::Entity), (unsigned char*)spectrum, directory);
+    long long savedSize = save(fileName, SPECTRUM_CAPACITY * sizeof(EntityRecord), (unsigned char*)spectrum, directory);
     RELEASE(spectrumLock);
 
-    if (savedSize == SPECTRUM_CAPACITY * sizeof(::Entity))
+    if (savedSize == SPECTRUM_CAPACITY * sizeof(EntityRecord))
     {
         setNumber(message, savedSize, TRUE);
         appendText(message, L" bytes of the spectrum data are saved (");


### PR DESCRIPTION
So far, there were two definitions of the type `Entity`, one in the global namespace and one in the QPI namespace. Although both definitions are identical, this sometimes caused ambiguity trouble due to `using namespace QPI`.

In order to keep `qpi.h`'s external dependencies minimal, we keep both definitions, but rename the global scope version from `Entity` to `EntityRecord` in order to fix the ambiguity.