### PR TITLE
Dividend payment: fix wrong latest incoming tick

### DIFF
--- a/src/contract_core/qpi_asset_impl.h
+++ b/src/contract_core/qpi_asset_impl.h
@@ -499,19 +499,22 @@ bool QPI::QpiContextProcedureCall::distributeDividends(long long amountPerShare)
             ASSERT(iter.possessionIndex() < ASSETS_CAPACITY);
 
             const auto& possession = assets[iter.possessionIndex()].varStruct.possession;
-            const long long dividend = amountPerShare * possession.numberOfShares;
 
-            increaseEnergy(possession.publicKey, dividend);
+            if (possession.numberOfShares)
+            {
+                const long long dividend = amountPerShare * possession.numberOfShares;
+                increaseEnergy(possession.publicKey, dividend);
 
-            if (!contractActionTracker.addQuTransfer(_currentContractId, possession.publicKey, dividend))
-                __qpiAbort(ContractErrorTooManyActions);
+                if (!contractActionTracker.addQuTransfer(_currentContractId, possession.publicKey, dividend))
+                    __qpiAbort(ContractErrorTooManyActions);
 
-            __qpiNotifyPostIncomingTransfer(_currentContractId, possession.publicKey, dividend, TransferType::qpiDistributeDividends);
+                __qpiNotifyPostIncomingTransfer(_currentContractId, possession.publicKey, dividend, TransferType::qpiDistributeDividends);
 
-            const QuTransfer quTransfer = { _currentContractId, possession.publicKey, dividend };
-            logger.logQuTransfer(quTransfer);
+                const QuTransfer quTransfer = { _currentContractId, possession.publicKey, dividend };
+                logger.logQuTransfer(quTransfer);
 
-            totalShareCounter += possession.numberOfShares;
+                totalShareCounter += possession.numberOfShares;
+            }
 
             iter.next();
         }


### PR DESCRIPTION
Don't pay dividend of 0 if entity has 0 shares. Paying zero dividend manifests as updating the latest incoming tick of the entity record, which is a bug for entities with 0 shares.