### PR TITLE
Multiple event time points for full custom mining.

### DIFF
--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -1483,6 +1483,11 @@ void saveCustomMiningCache(int epoch, CHAR16* directory = NULL)
         CUSTOM_MINING_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_CACHE_FILE_NAME[0]) - 6] = i % 10 + L'0';
         gSystemCustomMiningSolutionCache[i].save(CUSTOM_MINING_CACHE_FILE_NAME, directory);
     }
+
+    CUSTOM_MINING_V2_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME[0]) - 4] = epoch / 100 + L'0';
+    CUSTOM_MINING_V2_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME[0]) - 3] = (epoch % 100) / 10 + L'0';
+    CUSTOM_MINING_V2_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME[0]) - 2] = epoch % 10 + L'0';
+    gSystemCustomMiningSolutionV2Cache.save(CUSTOM_MINING_V2_CACHE_FILE_NAME, directory);
 }
 
 // Update score cache filename with epoch and try to load file
@@ -1501,6 +1506,12 @@ bool loadCustomMiningCache(int epoch)
         CUSTOM_MINING_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_CACHE_FILE_NAME[0]) - 6] = i % 10 + L'0';
         success &= gSystemCustomMiningSolutionCache[i].load(CUSTOM_MINING_CACHE_FILE_NAME);
     }
+
+    CUSTOM_MINING_V2_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME[0]) - 4] = epoch / 100 + L'0';
+    CUSTOM_MINING_V2_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME[0]) - 3] = (epoch % 100) / 10 + L'0';
+    CUSTOM_MINING_V2_CACHE_FILE_NAME[sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME) / sizeof(CUSTOM_MINING_V2_CACHE_FILE_NAME[0]) - 2] = epoch % 10 + L'0';
+    success &= gSystemCustomMiningSolutionV2Cache.load(CUSTOM_MINING_V2_CACHE_FILE_NAME);
+
     return success;
 }
 #endif

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -74,6 +74,7 @@ static unsigned short SCORE_CACHE_FILE_NAME[] = L"score.???";
 static unsigned short CONTRACT_FILE_NAME[] = L"contract????.???";
 static unsigned short CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME[] = L"custom_revenue.eoe";
 static unsigned short CUSTOM_MINING_CACHE_FILE_NAME[] = L"custom_mining_cache???.???";
+static unsigned short CUSTOM_MINING_V2_CACHE_FILE_NAME[] = L"custom_mining_v2_cache.???";
 
 static constexpr unsigned long long NUMBER_OF_INPUT_NEURONS = 512;     // K
 static constexpr unsigned long long NUMBER_OF_OUTPUT_NEURONS = 512;    // L

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -100,10 +100,15 @@ static constexpr unsigned int SOLUTION_THRESHOLD_DEFAULT = 321;
 #define EXTERNAL_COMPUTATIONS_INTERVAL (676 + 1)
 static_assert(INTERNAL_COMPUTATIONS_INTERVAL >= NUMBER_OF_COMPUTORS, "Internal computation phase needs to be at least equal NUMBER_OF_COMPUTORS");
 
-// Format is DoW-hh-mm-ss in hex format, total 4bytes, each use 1 bytes
+// List of start-end for full external computation times. The event must not be overlap.
+// Format is DoW-hh-mm-ss in hex format, total 4 bytes, each use 1 bytes
 // DoW: Day of the week 0: Sunday, 1 = Monday ...
-#define FULL_EXTERNAL_COMPUTATIONS_TIME_START_TIME 0x060C0000 // Sat 12:00:00
-#define FULL_EXTERNAL_COMPUTATIONS_TIME_STOP_TIME 0x000C0000 // Sun 12:00:00
+static unsigned long long gFullExternalComputationTimes[][2] =
+{
+    {0x040C0000ULL, 0x050C0000ULL}, // Thu 12:00:00 - Fri 12:00:00
+    {0x060C0000ULL, 0x000C0000ULL}, // Sat 12:00:00 - Sun 12:00:00
+    {0x010C0000ULL, 0x020C0000ULL}, // Mon 12:00:00 - Tue 12:00:00
+};
 
 #define STACK_SIZE 4194304
 #define TRACK_MAX_STACK_BUFFER_SIZE

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1886,14 +1886,6 @@ static void checkAndSwitchMiningPhase(short tickEpoch, TimeDate tickDate)
         }
         else // Not in the full external time, just behavior like normal.
         {
-            // Switch back to qubic mining phase if neccessary
-            if (fullExternalTimeBegin)
-            {
-                if (getTickInMiningPhaseCycle() <= INTERNAL_COMPUTATIONS_INTERVAL)
-                {
-                    setNewMiningSeed();
-                }
-            }
             fullExternalTimeBegin = false;
         }
     }


### PR DESCRIPTION
This PR 
- Allow us to set multiple full custom mining event in weekday.
- Unify all mining phase transition logic into the checkAndSwitchMiningPhase function.
- Add support for resetting the mining state within checkAndSwitchMiningPhase.
