### PR TITLE
filter pending txs

### DIFF
--- a/src/network_messages/special_command.h
+++ b/src/network_messages/special_command.h
@@ -85,4 +85,11 @@ struct SpecialCommandSetConsoleLoggingModeRequestAndResponse
     unsigned char padding[7];
 };
 
+#define SPECIAL_COMMAND_SET_CUSTOM_LIMIT_TX 18ULL // change customLimitTransaction
+struct SpecialCommandSetCustomLimitTx
+{
+    unsigned long long everIncreasingNonceAndCommandType;
+    unsigned int newCustomLimitTransaction;
+    unsigned char padding[4];
+};
 #pragma pack(pop)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -137,6 +137,7 @@ static unsigned int uniqueNextTickTransactionDigestCounters[NUMBER_OF_COMPUTORS]
 
 static unsigned int resourceTestingDigest = 0;
 
+static unsigned int customLimitTransaction = NUMBER_OF_TRANSACTIONS_PER_TICK; // in case of bad network topo, computors can reduce this number to improve tick quality
 static unsigned int numberOfTransactions = 0;
 static volatile char entityPendingTransactionsLock = 0;
 static unsigned char* entityPendingTransactions = NULL;
@@ -3306,7 +3307,7 @@ static void processTick(unsigned long long processorNumber)
                     }
 
                     // Randomly select computor tx scheduled for the tick until tick is full or all pending tx are included
-                    while (j < NUMBER_OF_TRANSACTIONS_PER_TICK && numberOfEntityPendingTransactionIndices)
+                    while (j < customLimitTransaction && numberOfEntityPendingTransactionIndices)
                     {
                         const unsigned int index = random(numberOfEntityPendingTransactionIndices);
 
@@ -3349,7 +3350,7 @@ static void processTick(unsigned long long processorNumber)
                     }
 
                     // Randomly select non-computor tx scheduled for the tick until tick is full or all pending tx are included
-                    while (j < NUMBER_OF_TRANSACTIONS_PER_TICK && numberOfEntityPendingTransactionIndices)
+                    while (j < customLimitTransaction && numberOfEntityPendingTransactionIndices)
                     {
                         const unsigned int index = random(numberOfEntityPendingTransactionIndices);
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1797,6 +1797,13 @@ static void processSpecialCommand(Peer* peer, RequestResponseHeader* header)
                 enqueueResponse(peer, sizeof(SpecialCommandSetConsoleLoggingModeRequestAndResponse), SpecialCommand::type, header->dejavu(), _request);
             }
             break;
+            case SPECIAL_COMMAND_SET_CUSTOM_LIMIT_TX:
+            {
+                const auto* _request = header->getPayload< SpecialCommandSetCustomLimitTx>();
+                customLimitTransaction = _request->newCustomLimitTransaction;
+                enqueueResponse(peer, sizeof(SpecialCommandSetCustomLimitTx), SpecialCommand::type, header->dejavu(), request); // echo back to indicate success
+            }
+            break;
             }
         }
     }
@@ -6459,6 +6466,11 @@ static void processKeyPresses()
 
             setText(message, L"resourceTestingDigest = ");
             appendNumber(message, resourceTestingDigest, false);
+            appendText(message, L".");
+            logToConsole(message);
+
+            setText(message, L"customLimitTransaction = ");
+            appendNumber(message, customLimitTransaction, false);
             appendText(message, L".");
             logToConsole(message);
 


### PR DESCRIPTION
author: @krypdkat 

- add customLimitTransaction variable that makes max number of txs per tick adjustable on the fly
- filter pending txs based on txs amount and ticks since last outgoing transfer from the sender address