### PR TITLE
networking: support private IPs

### DIFF
--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -464,11 +464,6 @@ static void forgetPublicPeer(const IPv4Address& address)
         return;
     }
 
-    if (isPrivateIp(address.u8))
-    {
-        return;
-    }
-
     ACQUIRE(publicPeersLock);
 
     for (unsigned int i = 0; numberOfPublicPeers > NUMBER_OF_PUBLIC_PEERS_TO_KEEP && i < numberOfPublicPeers; i++)

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -185,7 +185,7 @@ static bool isWhiteListPeer(unsigned char address[4])
 static bool isPrivateIp(const unsigned char address[4])
 {
     int total = min(int(sizeof(knownPublicPeers)/sizeof(knownPublicPeers[0])), NUMBER_OF_PRIVATE_IP);
-    for (unsigned int i = 0; i < total; i++)
+    for (int i = 0; i < total; i++)
     {
         const auto& privateIp = knownPublicPeers[i];
         if (address[0] == privateIp[0]

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -182,6 +182,23 @@ static bool isWhiteListPeer(unsigned char address[4])
 }
 */
 
+static bool isPrivateIp(const unsigned char address[4])
+{
+    int total = min(int(sizeof(knownPublicPeers)/sizeof(knownPublicPeers[0])), NUMBER_OF_PRIVATE_IP);
+    for (unsigned int i = 0; i < total; i++)
+    {
+        const auto& privateIp = knownPublicPeers[i];
+        if (address[0] == privateIp[0]
+            && address[1] == privateIp[1]
+            && address[2] == privateIp[2]
+            && address[3] == privateIp[3])
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 static void closePeer(Peer* peer)
 {
     PROFILE_SCOPE();
@@ -443,6 +460,11 @@ static void forgetPublicPeer(const IPv4Address& address)
     }
 
     if (listOfPeersIsStatic)
+    {
+        return;
+    }
+
+    if (isPrivateIp(address.u8))
     {
         return;
     }

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -10,6 +10,9 @@ static unsigned char computorSeeds[][55 + 1] = {
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 };
 
+// number of private ips for computor's internal services
+// these are the first N ip in knownPublicPeers, these IPs will never be shared or deleted
+#define NUMBER_OF_PRIVATE_IP 2
 // Enter static IPs of peers (ideally at least 4 including your own IP) to disseminate them to other peers.
 // You can find current peer IPs at https://app.qubic.li/network/live
 static const unsigned char knownPublicPeers[][4] = {

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -6962,17 +6962,24 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             }
                             else
                             {
-                                // randomly select verified public peers and discard private IPs
-                                // first NUMBER_OF_PRIVATE_IP ips are same on both array publicPeers and knownPublicPeers
-                                const unsigned int publicPeerIndex = NUMBER_OF_PRIVATE_IP + random(numberOfPublicPeers - NUMBER_OF_PRIVATE_IP);
-                                // share the peer if it's not our private IPs and is handshaked
-                                if (publicPeers[publicPeerIndex].isHandshaked)
+                                if (NUMBER_OF_PRIVATE_IP < numberOfPublicPeers)
                                 {
-                                    request->peers[j] = publicPeers[publicPeerIndex].address;
+                                    // randomly select verified public peers and discard private IPs
+                                    // first NUMBER_OF_PRIVATE_IP ips are same on both array publicPeers and knownPublicPeers
+                                    const unsigned int publicPeerIndex = NUMBER_OF_PRIVATE_IP + random(numberOfPublicPeers - NUMBER_OF_PRIVATE_IP);
+                                    // share the peer if it's not our private IPs and is handshaked
+                                    if (publicPeers[publicPeerIndex].isHandshaked)
+                                    {
+                                        request->peers[j] = publicPeers[publicPeerIndex].address;
+                                    }
+                                    else
+                                    {
+                                        j--;
+                                    }
                                 }
                                 else
                                 {
-                                    j--;
+                                    request->peers[j].u32 = 0;
                                 }
                             }
                         }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -6964,7 +6964,8 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             {
                                 // randomly select verified public peers
                                 const unsigned int publicPeerIndex = random(numberOfPublicPeers);
-                                if (publicPeers[publicPeerIndex].isHandshaked /*&& publicPeers[publicPeerIndex].isFullnode*/)
+                                // share the peer if it's not our private IPs and is handshaked
+                                if (publicPeers[publicPeerIndex].isHandshaked && !(isPrivateIp(publicPeers[publicPeerIndex].address.u8)))
                                 {
                                     request->peers[j] = publicPeers[publicPeerIndex].address;
                                 }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -6962,10 +6962,11 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             }
                             else
                             {
-                                // randomly select verified public peers
-                                const unsigned int publicPeerIndex = random(numberOfPublicPeers);
+                                // randomly select verified public peers and discard private IPs
+                                // first NUMBER_OF_PRIVATE_IP ips are same on both array publicPeers and knownPublicPeers
+                                const unsigned int publicPeerIndex = NUMBER_OF_PRIVATE_IP + random(numberOfPublicPeers - NUMBER_OF_PRIVATE_IP);
                                 // share the peer if it's not our private IPs and is handshaked
-                                if (publicPeers[publicPeerIndex].isHandshaked && !(isPrivateIp(publicPeers[publicPeerIndex].address.u8)))
+                                if (publicPeers[publicPeerIndex].isHandshaked)
                                 {
                                     request->peers[j] = publicPeers[publicPeerIndex].address;
                                 }


### PR DESCRIPTION
https://github.com/qubic/core/issues/508
add `#define NUMBER_OF_PRIVATE_IP X` such that the node won't share first X IP addresses in the bootstrap list in exchangePeerAddress (handshake) packet, these IPs won't be deleted from public peer.
Reason: allowing operators to have private connections to the node, easier to control nodes if it getting DDoS