### PR TITLE
fix: fixed gtest bug in qearn

### DIFF
--- a/src/contracts/Qearn.h
+++ b/src/contracts/Qearn.h
@@ -899,9 +899,9 @@ protected:
         uint32 t;
         bit status;
         uint64 pre_epoch_balance;
-        uint64 current_balance, totalLockedAmountInEpoch172;
+        uint64 current_balance;
         Entity entity;
-        uint32 locked_epoch, start_index, end_index;
+        uint32 locked_epoch;
     };
 
     BEGIN_EPOCH_WITH_LOCALS()


### PR DESCRIPTION
we added the code for initialization in the epoch 175 to fix the Qearn data. the gtest fails due to this hardcorded value. we can remove it now.