### PR TITLE
Enable qpi mining function.

### DIFF
--- a/src/contract_core/qpi_mining_impl.h
+++ b/src/contract_core/qpi_mining_impl.h
@@ -19,3 +19,8 @@ m256i QPI::QpiContextFunctionCall::computeMiningFunction(const m256i miningSeed,
     (*score_qpi)(0, publicKey, miningSeed, nonce);
     return score_qpi->getLastOutput(0);
 }
+
+void QPI::QpiContextFunctionCall::initMiningSeed(const m256i miningSeed) const
+{
+    score_qpi->initMiningData(miningSeed);
+}

--- a/src/contracts/QUtil.h
+++ b/src/contracts/QUtil.h
@@ -1169,6 +1169,7 @@ public:
     BEGIN_EPOCH()
     {
         state.dfMiningSeed = qpi.getPrevSpectrumDigest();
+        qpi.initMiningSeed(state.dfMiningSeed);
     }
 
     struct BEGIN_TICK_locals

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -1782,6 +1782,9 @@ namespace QPI
 		// run the score function (in qubic mining) and return first 256 bit of output
 		inline m256i computeMiningFunction(const m256i miningSeed, const m256i publicKey, const m256i nonce) const;
 
+		// init mining seed for the score function (in qubic mining)
+		inline void initMiningSeed(const m256i miningSeed) const;
+
 		inline bit signatureValidity(
 			const id& entity,
 			const id& digest,


### PR DESCRIPTION
This PR fix a bug in which qpi mining doesn't run due to invalid mining seed.