### PR TITLE
Remove mining seed set function in qpi.

### DIFF
--- a/src/contract_core/qpi_mining_impl.h
+++ b/src/contract_core/qpi_mining_impl.h
@@ -16,11 +16,12 @@ static ScoreFunction<
 
 m256i QPI::QpiContextFunctionCall::computeMiningFunction(const m256i miningSeed, const m256i publicKey, const m256i nonce) const
 {
+    // Score's currentRandomSeed is initialized to zero by setMem(score_qpi, sizeof(*score_qpi), 0)
+    // If the mining seed changes, we must reinitialize it
+    if (miningSeed != score_qpi->currentRandomSeed)
+    {
+        score_qpi->initMiningData(miningSeed);
+    }
     (*score_qpi)(0, publicKey, miningSeed, nonce);
     return score_qpi->getLastOutput(0);
-}
-
-void QPI::QpiContextFunctionCall::initMiningSeed(const m256i miningSeed) const
-{
-    score_qpi->initMiningData(miningSeed);
 }

--- a/src/contracts/QUtil.h
+++ b/src/contracts/QUtil.h
@@ -1169,7 +1169,6 @@ public:
     BEGIN_EPOCH()
     {
         state.dfMiningSeed = qpi.getPrevSpectrumDigest();
-        qpi.initMiningSeed(state.dfMiningSeed);
     }
 
     struct BEGIN_TICK_locals

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -1782,9 +1782,6 @@ namespace QPI
 		// run the score function (in qubic mining) and return first 256 bit of output
 		inline m256i computeMiningFunction(const m256i miningSeed, const m256i publicKey, const m256i nonce) const;
 
-		// init mining seed for the score function (in qubic mining)
-		inline void initMiningSeed(const m256i miningSeed) const;
-
 		inline bit signatureValidity(
 			const id& entity,
 			const id& digest,


### PR DESCRIPTION
This will prevent future SC ability to disable qpi mining.
It also fix the unittest of qpi that call the score function at the begining of the epoch.
This PR can be merged for the epoch 177.