### PR TITLE
Deactivate delay function

### DIFF
--- a/src/contracts/QUtil.h
+++ b/src/contracts/QUtil.h
@@ -66,6 +66,9 @@ struct QUTILLogger
     // Other data go here
     sint8 _terminator; // Only data before "_terminator" are logged
 };
+
+// Deactivate logger for delay function
+#if 0
 struct QUTILDFLogger
 {
     uint32 contractId; // to distinguish bw SCs
@@ -76,6 +79,7 @@ struct QUTILDFLogger
     id result;
     sint8 _terminator; // Only data before "_terminator" are logged
 };
+#endif
 
 // poll and voter structs
 struct QUTILPoll {

--- a/src/contracts/QUtil.h
+++ b/src/contracts/QUtil.h
@@ -1181,6 +1181,8 @@ public:
         state.dfMiningSeed = qpi.getPrevSpectrumDigest();
     }
 
+    // Deactivate delay function
+    #if 0
     struct BEGIN_TICK_locals
     {
         m256i dfPubkey, dfNonce;
@@ -1194,10 +1196,11 @@ public:
         locals.dfPubkey = qpi.getPrevSpectrumDigest();
         locals.dfNonce = qpi.getPrevComputerDigest();
         state.dfCurrentState = qpi.computeMiningFunction(state.dfMiningSeed, locals.dfPubkey, locals.dfNonce);
-        
+
         locals.logger = QUTILDFLogger{ 0, 0, locals.dfNonce, locals.dfPubkey, state.dfMiningSeed, state.dfCurrentState};
         LOG_INFO(locals.logger);
     }
+    #endif
 
     /*
     * @return Return total number of shares that currently exist of the asset given as input


### PR DESCRIPTION
PR deactivates the delay function.

Deactivation is done with `#if 0` macros to avoid clutter in the commits. In a later stage this code should be removed. 

`QPI::QpiContextFunctionCall::computeMiningFunction(...)` in [qpi_mining_impl.h](https://github.com/qubic/core/blob/main/src/contract_core/qpi_mining_impl.h) remains available for the moment.
