### PR TITLE
Update test project to use Windows SDK version available on GitHub.

### DIFF
--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -17,7 +17,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{30e8e249-6b00-4575-bcdf-be2445d5e099}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>


### PR DESCRIPTION
The test project currently fails to build because GitHub no longer provides the targeted Windows SDK. This PR updates the project to use a Windows SDK version available on GitHub Actions.