### PR TITLE
contract-verify: check input/output types

### DIFF
--- a/.github/workflows/contract-verify.yml
+++ b/.github/workflows/contract-verify.yml
@@ -32,6 +32,6 @@ jobs:
           echo "contract-filepaths=$files" >> "$GITHUB_OUTPUT"
       - name: Contract verify action step
         id: verify
-        uses: Franziska-Mueller/qubic-contract-verify@v0.3.3-beta
+        uses: Franziska-Mueller/qubic-contract-verify@v1.0.0
         with:
           filepaths: '${{ steps.filepaths.outputs.contract-filepaths }}'


### PR DESCRIPTION
updates the contract verification tool to the new release that includes the checks for input/output structs as detailed in https://github.com/qubic/core/issues/434