### PR TITLE
Fix broken gtest (scratchpad)

### DIFF
--- a/test/qpi_collection.cpp
+++ b/test/qpi_collection.cpp
@@ -2,11 +2,6 @@
 
 #include "gtest/gtest.h"
 
-static void* __scratchpadBuffer = nullptr;
-static void* __scratchpad()
-{
-    return __scratchpadBuffer;
-}
 namespace QPI
 {
     struct QpiContextProcedureCall;
@@ -16,6 +11,7 @@ typedef void (*USER_FUNCTION)(const QPI::QpiContextFunctionCall&, void* state, v
 typedef void (*USER_PROCEDURE)(const QPI::QpiContextProcedureCall&, void* state, void* input, void* output, void* locals);
 
 #include "../src/contracts/qpi.h"
+#include "../src/common_buffers.h"
 #include "../src/contract_core/qpi_collection_impl.h"
 #include "../src/contract_core/qpi_trivial_impl.h"
 
@@ -1522,7 +1518,7 @@ void testCollectionPseudoRandom(int povs, int seed, bool povCollisions, int clea
 
 TEST(TestCoreQPI, CollectionInsertRemoveCleanupRandom)
 {
-    __scratchpadBuffer = new char[10 * 1024 * 1024];
+    reorgBuffer = new char[10 * 1024 * 1024];
     constexpr unsigned int numCleanups = 30;
     for (int i = 0; i < 10; ++i)
     {
@@ -1540,21 +1536,21 @@ TEST(TestCoreQPI, CollectionInsertRemoveCleanupRandom)
         testCollectionPseudoRandom<16>(10, 12 + i, povCollisions, numCleanups, 55, 45);
         testCollectionPseudoRandom<4>(4, 42 + i, povCollisions, numCleanups, 52, 48);
     }
-    delete[] __scratchpadBuffer;
-    __scratchpadBuffer = nullptr;
+    delete[] reorgBuffer;
+    reorgBuffer = nullptr;
 }
 
 TEST(TestCoreQPI, CollectionCleanupWithPovCollisions)
 {
     // Shows bugs in cleanup() that occur in case of massive pov hash map collisions and in case of capacity < 32
-    __scratchpadBuffer = new char[10 * 1024 * 1024];
+    reorgBuffer = new char[10 * 1024 * 1024];
     bool cleanupAfterEachRemove = true;
     testCollectionMultiPovOneElement<16>(cleanupAfterEachRemove);
     testCollectionMultiPovOneElement<32>(cleanupAfterEachRemove);
     testCollectionMultiPovOneElement<64>(cleanupAfterEachRemove);
     testCollectionMultiPovOneElement<128>(cleanupAfterEachRemove);
-    delete[] __scratchpadBuffer;
-    __scratchpadBuffer = nullptr;
+    delete[] reorgBuffer;
+    reorgBuffer = nullptr;
 }
 
 
@@ -1673,7 +1669,7 @@ QPI::uint64 testCollectionPerformance(
 TEST(TestCoreQPI, CollectionPerformance)
 {
 
-    __scratchpadBuffer = new char[16 * 1024 * 1024];
+    reorgBuffer = new char[16 * 1024 * 1024];
 
     std::vector<QPI::uint64> durations;
     std::vector<std::string> descriptions;
@@ -1702,8 +1698,8 @@ TEST(TestCoreQPI, CollectionPerformance)
     durations.push_back(testCollectionPerformance<512>(16, 333));
     descriptions.push_back("[CollectionPerformance] Collection<512>(16, 333)");
 
-    delete[] __scratchpadBuffer;
-    __scratchpadBuffer = nullptr;
+    delete[] reorgBuffer;
+    reorgBuffer = nullptr;
 
     bool verbose = true;
     if (verbose)

--- a/test/qpi_hash_map.cpp
+++ b/test/qpi_hash_map.cpp
@@ -2,11 +2,6 @@
 
 #include "gtest/gtest.h"
 
-static void* __scratchpadBuffer = nullptr;
-static void* __scratchpad()
-{
-	return __scratchpadBuffer;
-}
 namespace QPI
 {
 	struct QpiContextProcedureCall;
@@ -16,6 +11,7 @@ typedef void (*USER_FUNCTION)(const QPI::QpiContextFunctionCall&, void* state, v
 typedef void (*USER_PROCEDURE)(const QPI::QpiContextProcedureCall&, void* state, void* input, void* output, void* locals);
 
 #include "../src/contracts/qpi.h"
+#include "../src/common_buffers.h"
 #include "../src/contract_core/qpi_hash_map_impl.h"
 #include <unordered_set>
 #include <array>
@@ -374,7 +370,7 @@ TYPED_TEST_P(QPIHashMapTest, TestCleanup)
 	constexpr QPI::uint64 capacity = 4;
 	QPI::HashMap<TypeParam::first_type, TypeParam::second_type, capacity> hashMap;
 
-	__scratchpadBuffer = new char[2 * sizeof(hashMap)];
+	reorgBuffer = new char[2 * sizeof(hashMap)];
 
 	std::array<TypeParam, 4> keyValuePairs = HashMapTestData<TypeParam::first_type, TypeParam::second_type>::CreateKeyValueTestPairs();
 	auto ids = std::views::keys(keyValuePairs);
@@ -413,8 +409,8 @@ TYPED_TEST_P(QPIHashMapTest, TestCleanup)
 	EXPECT_NE(returnedIndex, QPI::NULL_INDEX);
 	EXPECT_EQ(hashMap.population(), 4);
 
-	delete[] __scratchpadBuffer;
-	__scratchpadBuffer = nullptr;
+	delete[] reorgBuffer;
+	reorgBuffer = nullptr;
 }
 
 TYPED_TEST_P(QPIHashMapTest, TestCleanupPerformanceShortcuts)
@@ -450,7 +446,7 @@ TEST(NonTypedQPIHashMapTest, TestCleanupLargeMapSameHashes)
 	constexpr QPI::uint64 capacity = 64;
 	QPI::HashMap<QPI::id, int, capacity> hashMap;
 
-	__scratchpadBuffer = new char[2 * sizeof(hashMap)];
+	reorgBuffer = new char[2 * sizeof(hashMap)];
 
 	for (QPI::uint64 i = 0; i < 64; ++i)
 	{
@@ -463,8 +459,8 @@ TEST(NonTypedQPIHashMapTest, TestCleanupLargeMapSameHashes)
 	// Cleanup will have to iterate through the whole map to find an empty slot for the last element.
 	hashMap.cleanup();
 
-	delete[] __scratchpadBuffer;
-	__scratchpadBuffer = nullptr;
+	delete[] reorgBuffer;
+	reorgBuffer = nullptr;
 }
 
 TYPED_TEST_P(QPIHashMapTest, TestReplace)
@@ -623,7 +619,7 @@ void testHashMapPseudoRandom(int seed, int cleanups, int percentAdd, int percent
 	std::map<KeyT, ValueT> referenceMap;
 	QPI::HashMap<KeyT, ValueT, capacity> map;
 
-	__scratchpadBuffer = new char[2 * sizeof(map)];
+	reorgBuffer = new char[2 * sizeof(map)];
 
 	map.reset();
 
@@ -685,8 +681,8 @@ void testHashMapPseudoRandom(int seed, int cleanups, int percentAdd, int percent
 		// std::cout << "capacity: " << set.capacity() << ", pupulation:" << set.population() << std::endl;
 	}
 
-	delete[] __scratchpadBuffer;
-	__scratchpadBuffer = nullptr;
+	delete[] reorgBuffer;
+	reorgBuffer = nullptr;
 }
 
 TEST(QPIHashMapTest, HashMapPseudoRandom)
@@ -718,7 +714,7 @@ TEST(QPIHashMapTest, HashSet)
 {
 	constexpr QPI::uint64 capacity = 128;
 	QPI::HashSet<QPI::id, capacity> hashSet;
-	__scratchpadBuffer = new char[2 * sizeof(hashSet)];
+	reorgBuffer = new char[2 * sizeof(hashSet)];
 	EXPECT_EQ(hashSet.capacity(), capacity);
 
 	// Test add() and contains()
@@ -816,8 +812,8 @@ TEST(QPIHashMapTest, HashSet)
 	hashSet.reset();
 	EXPECT_EQ(hashSet.population(), 0);
 
-	delete[] __scratchpadBuffer;
-	__scratchpadBuffer = nullptr;
+	delete[] reorgBuffer;
+	reorgBuffer = nullptr;
 }
 
 template <class T, unsigned int capacity>
@@ -886,7 +882,7 @@ void testHashSetPseudoRandom(int seed, int cleanups, int percentAdd, int percent
 	std::set<T> referenceSet;
 	QPI::HashSet<T, capacity> set;
 
-	__scratchpadBuffer = new char[2 * sizeof(set)];
+	reorgBuffer = new char[2 * sizeof(set)];
 
 	set.reset();
 
@@ -946,8 +942,8 @@ void testHashSetPseudoRandom(int seed, int cleanups, int percentAdd, int percent
 		// std::cout << "capacity: " << set.capacity() << ", pupulation:" << set.population() << std::endl;
 	}
 
-	delete[] __scratchpadBuffer;
-	__scratchpadBuffer = nullptr;
+	delete[] reorgBuffer;
+	reorgBuffer = nullptr;
 }
 
 TEST(QPIHashMapTest, HashSetPseudoRandom)
@@ -983,7 +979,7 @@ static void perfTestCleanup(int seed)
 	std::mt19937_64 gen64(seed);
 
 	auto* set = new QPI::HashSet<QPI::id, capacity>();
-	__scratchpadBuffer = new char[sizeof(*set)];
+	reorgBuffer = new char[sizeof(*set)];
 
 	for (QPI::uint64 i = 1; i <= 100; ++i)
 	{
@@ -1007,8 +1003,8 @@ static void perfTestCleanup(int seed)
 	}
 
 	delete set;
-	delete[] __scratchpadBuffer;
-	__scratchpadBuffer = nullptr;
+	delete[] reorgBuffer;
+	reorgBuffer = nullptr;
 }
 
 TEST(QPIHashMapTest, HashSetPerfTest)


### PR DESCRIPTION
The wrong version of `__scratchpad()` was called with `HashSet<id, 1024>` in gtest leading to a failed test (it tried to use the unallocated `reorgBuffer`).

Fixed by removing alternative implementations of `__scratchpad()` from tests and always using `reorgBuffer`.