### PR TITLE
Issues RLT token

### DIFF
--- a/src/contracts/RandomLottery.h
+++ b/src/contracts/RandomLottery.h
@@ -679,22 +679,22 @@ public:
 			}
 		}
 
-		// Reward Participants With LOTTO
-		{
-			if (state.playerCounter != 0 && state.tokenRewardDivisor > 0)
-			{
-				if (state.lottoTokenPrice > 0)
-				{
-					locals.rewardPerTicket = max<sint64>(1, div<uint64>(state.lottoTokenPrice, state.tokenRewardDivisor));
-
-					for (locals.index = 0; locals.index < state.playerCounter; ++locals.index)
-					{
-						qpi.transferShareOwnershipAndPossession(RL_LOTTO_TOKEN_NAME, SELF, SELF, SELF, locals.rewardPerTicket,
-						                                        state.players.get(locals.index));
-					}
-				}
-			}
-		}
+		// Reward Participants With LOTTO (disabled)
+		// {
+		// 	if (state.playerCounter != 0 && state.tokenRewardDivisor > 0)
+		// 	{
+		// 		if (state.lottoTokenPrice > 0)
+		// 		{
+		// 			locals.rewardPerTicket = max<sint64>(1, div<uint64>(state.lottoTokenPrice, state.tokenRewardDivisor));
+		//
+		// 			for (locals.index = 0; locals.index < state.playerCounter; ++locals.index)
+		// 			{
+		// 				qpi.transferShareOwnershipAndPossession(RL_LOTTO_TOKEN_NAME, SELF, SELF, SELF, locals.rewardPerTicket,
+		// 				                                        state.players.get(locals.index));
+		// 			}
+		// 		}
+		// 	}
+		// }
 
 		clearStateOnEndDraw(state);
 

--- a/test/contract_rl.cpp
+++ b/test/contract_rl.cpp
@@ -1005,7 +1005,7 @@ TEST(ContractRandomLottery, DrawAndPayout_BeginTick)
 	}
 }
 
-TEST(ContractRandomLottery, ParticipantsReceiveLOTTOPerTicketOnDraw)
+/*TEST(ContractRandomLottery, ParticipantsReceiveLOTTOPerTicketOnDraw)
 {
 	ContractTestingRL ctl;
 	ctl.forceSchedule(RL_ANY_DAY_DRAW_SCHEDULE);
@@ -1043,7 +1043,7 @@ TEST(ContractRandomLottery, ParticipantsReceiveLOTTOPerTicketOnDraw)
 	EXPECT_EQ(ctl.tokenBalance(RL_LOTTO_TOKEN_NAME, playerA, ctl.rlSelf()), rewardPerTicket * 2);
 	EXPECT_EQ(ctl.tokenBalance(RL_LOTTO_TOKEN_NAME, playerB, ctl.rlSelf()), rewardPerTicket);
 	EXPECT_EQ(ctl.tokenBalance(RL_LOTTO_TOKEN_NAME, ctl.rlSelf(), ctl.rlSelf()), contractTokensBefore - (rewardPerTicket * 3));
-}
+}*/
 
 TEST(ContractRandomLottery, GetBalance)
 {


### PR DESCRIPTION
Added `LOTTO` token issuance
Enabled purchasing lottery tickets using tokens
Implemented peer-to-peer `LOTTO` token exchange
Adds random sorting of players before choosing a winner.

With the new update, we only need to run this command prior to network launch:

`dd if=/dev/zero bs=16 count=1 >> contract0016.xxx`
Command breakdown:

The original size of the contract: `82,040 bytes`
The new size of the contract: `82,056 bytes`
The size difference is `82,056 - 82,040 = 16 bytes`
Hence, the command will expand the contract to `16 bytes`.