### PR TITLE
ExecutionTimeAccumulator class

### DIFF
--- a/src/Qubic.vcxproj
+++ b/src/Qubic.vcxproj
@@ -50,6 +50,7 @@
     <ClInclude Include="contract_core\contract_action_tracker.h" />
     <ClInclude Include="contract_core\contract_def.h" />
     <ClInclude Include="contract_core\contract_exec.h" />
+    <ClInclude Include="contract_core\execution_time_accumulator.h" />
     <ClInclude Include="contract_core\ipo.h" />
     <ClInclude Include="contract_core\pre_qpi_def.h" />
     <ClInclude Include="contract_core\qpi_asset_impl.h" />

--- a/src/Qubic.vcxproj.filters
+++ b/src/Qubic.vcxproj.filters
@@ -300,6 +300,9 @@
     <ClInclude Include="contract_core\pre_qpi_def.h">
       <Filter>contract_core</Filter>
     </ClInclude>
+    <ClInclude Include="contract_core\execution_time_accumulator.h">
+      <Filter>contract_core</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="platform">

--- a/src/network_messages/execution_fees.h
+++ b/src/network_messages/execution_fees.h
@@ -113,7 +113,7 @@ static_assert( sizeof(ExecutionFeeReportPayload) <= sizeof(Transaction) + MAX_IN
 // Returns the number of entries added (0 if no contracts were executed)
 static inline unsigned int buildExecutionFeeReportPayload(
     ExecutionFeeReportPayload& payload,
-    const volatile long long* contractExecutionTimes,
+    const long long* contractExecutionTimes,
     const unsigned int phaseNumber,
     const long long multiplierNumerator,
     const long long multiplierDenominator

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>--gtest_break_on_failure</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>--gtest_break_on_failure --gtest_filter=*ExecutionTimeAccumulatorTest*</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">


### PR DESCRIPTION
created ExecutionTimeAccumulator class to encapsulate variables from contract_exec

- this makes access to previous phase times less confusing because the index handling does not need to be done by the user
- this makes save/load easier to implement because the repective functions can also be encapsulated in the class

(Note: this is part of the execution fee branch, do not merge into develop)