### PR TITLE
Exclude memory allocation from runtime of SC

### DIFF
--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -1303,8 +1303,6 @@ struct QpiContextUserProcedureNotificationCall : public QPI::QpiContextProcedure
         // acquire state for writing (may block)
         contractStateLock[_currentContractIndex].acquireWrite();
 
-        const unsigned long long startTick = __rdtsc();
-
         QPI::NoData output;
         char* input = contractLocalsStack[_stackIndex].allocate(notif.inputSize + notif.localsSize);
         if (!input)
@@ -1332,15 +1330,15 @@ struct QpiContextUserProcedureNotificationCall : public QPI::QpiContextProcedure
         setMem(locals, notif.localsSize, 0);
 
         // call user procedure
+        const unsigned long long startTick = __rdtsc();
         notif.procedure(*this, contractStates[_currentContractIndex], input, &output, locals);
+        const unsigned long long executionTime = __rdtsc() - startTick;
+        _interlockedadd64(&contractTotalExecutionTime[_currentContractIndex], executionTime);
+        executionTimeAccumulator.addTime(_currentContractIndex, executionTime);
 
         // free data on stack
         contractLocalsStack[_stackIndex].free();
         ASSERT(contractLocalsStack[_stackIndex].size() == 0);
-
-        const unsigned long long executionTime = __rdtsc() - startTick;
-        _interlockedadd64(&contractTotalExecutionTime[_currentContractIndex], executionTime);
-        executionTimeAccumulator.addTime(_currentContractIndex, executionTime);
 
         // release lock of contract state and set state to changed
         contractStateLock[_currentContractIndex].releaseWrite();


### PR DESCRIPTION
There was a discrepancy between `QpiContextUserProcedureNotificationCall` and `QpiContextUserProcedureCall` regarding how memory allocation was handled during contract runtime.

This commit unifies the approach by excluding memory allocation in both cases, ensuring consistent behavior across these procedure types.