### PR TITLE
Set contractError as NoContractError when IPO finish successfully.

### DIFF
--- a/src/contract_core/ipo.h
+++ b/src/contract_core/ipo.h
@@ -183,6 +183,8 @@ static void finishIPOs()
             if (finalPrice > 0)
             {
                 setContractFeeReserve(contractIndex, finalPrice * NUMBER_OF_COMPUTORS);
+                // IPO finished successfully, mark this contract error as NoContractError
+                contractError[contractIndex] = NoContractError;
             }
             else
             {


### PR DESCRIPTION
After a contract's IPO succeeds at the end of epoch N, nodes that restart from epoch-start files become misaligned with nodes that ran continuously through the IPO.

Reason: initializeContractErrors() (called at startup) sets contractError[A] = ContractErrorIPOFailed for any contract A that has no shares yet (i.e. during its IPO phase). 
When finishIPOs() successfully completes the IPO, it never clears this error.