### PR TITLE
Add revenue formula v2.

### DIFF
--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -87,6 +87,7 @@ static unsigned short CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME[] = L"custom_
 static unsigned short CUSTOM_MINING_CACHE_FILE_NAME[] = L"custom_mining_cache.???";
 static unsigned short CONTRACT_EXEC_FEES_ACC_FILE_NAME[] = L"contract_exec_fees_acc.???";
 static unsigned short CONTRACT_EXEC_FEES_REC_FILE_NAME[] = L"contract_exec_fees_rec.???";
+static unsigned short REVENUE_DATA_END_OF_EPOCH_FILE_NAME[] = L"revenue_data.eoe";
 
 static constexpr unsigned long long HYPERIDENTITY_NUMBER_OF_INPUT_NEURONS = 512;     // K
 static constexpr unsigned long long HYPERIDENTITY_NUMBER_OF_OUTPUT_NEURONS = 512;    // L

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4000,6 +4000,88 @@ static void endEpoch()
                 gRevenueComponents.revenue);
         }
 
+        // Revenue V2: filter transactions. Run here but have not applied yet
+        // Make sure run after gRevenueComponents is calculated because it use some of data
+        gEpochRevenueData.initialTick = system.initialTick;
+        gEpochRevenueData.totalTicks = system.tick - system.initialTick;
+        for (unsigned int tick = system.initialTick; tick < system.tick; tick++)
+        {
+            const m256i& tickLeaderPublicKey = broadcastedComputors.computors.publicKeys[tick % NUMBER_OF_COMPUTORS];
+
+            // Defensive lock, actually at the end of epoch, no more tick data written. 
+            ts.tickData.acquireLock();
+            unsigned int tickOffset = tick - system.initialTick;
+            TickData& td = ts.tickData.getByTickInCurrentEpoch(tick);
+            if ((td.epoch == system.epoch) && (tickOffset < MAX_NUMBER_OF_TICKS_PER_EPOCH))
+            {
+                unsigned int nTickLeader = 0;
+                unsigned int nProtocol = 0;
+                unsigned int nContract = 0;
+                unsigned int nOther = 0;
+                auto* offsets = ts.tickTransactionOffsets.getByTickInCurrentEpoch(tick);
+                for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
+                {
+                    if (isZero(td.transactionDigests[i]))
+                    {
+                        continue;
+                    }
+
+                    // Make sure tx body existed
+                    if (!offsets[i])
+                    {
+                        continue;
+                    }
+
+                    const Transaction* tx = ts.tickTransactions(offsets[i]);
+
+                    // skip leader's own txs
+                    if (tx->sourcePublicKey == tickLeaderPublicKey)
+                    {
+                        nTickLeader++;
+                        continue;
+                    }
+
+                    if (isZero(tx->destinationPublicKey))
+                    {
+                        nProtocol++;
+                    }
+                    else
+                    {
+                        m256i masked = tx->destinationPublicKey;
+                        masked.m256i_u64[0] &= ~(unsigned long long)(MAX_NUMBER_OF_CONTRACTS - 1);
+                        unsigned int cIdx = (unsigned int)tx->destinationPublicKey.m256i_u64[0];
+                        if (isZero(masked) && cIdx < contractCount)
+                        {
+                            nContract++;
+                        }
+                        else
+                        {
+                            nOther++;
+                        }
+                    }
+
+                }
+                gEpochRevenueData.perTickTxTickLeaderCount[tickOffset] = (unsigned short)nTickLeader;
+
+                gEpochRevenueData.perTickTxCount[tickOffset] = (unsigned short)(nProtocol + nContract + nOther);
+                gEpochRevenueData.perTickProtocolTxCount[tickOffset] = (unsigned short)nProtocol;
+                gEpochRevenueData.perTickContractTxCount[tickOffset] = (unsigned short)nContract;
+                gEpochRevenueData.perTickOtherTxCount[tickOffset] = (unsigned short)nOther;
+            }
+            ts.tickData.releaseLock();
+        }
+        // Fetch oracle revenue points (accumulated during epoch, reset at beginEpoch)
+        {
+            OracleRevenuePoints oracleRevPoints;
+            oracleEngine.getRevenuePoints(oracleRevPoints);
+            for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+            {
+                gEpochRevenueData.oracleScore[i] = oracleRevPoints.computorRevPoints[i];
+            }
+        }
+        computeRevenueV2(gEpochRevenueData);
+
+
         // Get revenue donation data by calling contract GQMPROP::GetRevenueDonation()
         QpiContextUserFunctionCall qpiContext(GQMPROP::__contract_index);
         qpiContext.call(5, "", 0);
@@ -5547,6 +5629,8 @@ static void tickProcessor(void*)
 
                                     // Save the file of revenue. This blocking save can be called from any thread
                                     saveRevenueComponents(NULL);
+                                    // Revenue v2 data
+                                    asyncSave(REVENUE_DATA_END_OF_EPOCH_FILE_NAME, sizeof(gEpochRevenueData), (unsigned char*)&gEpochRevenueData);
 
                                     // Reorder futureComputors so requalifying computors keep their index
                                     // This is needed for correct execution fee reporting across epoch boundaries

--- a/src/revenue.h
+++ b/src/revenue.h
@@ -157,4 +157,150 @@ static void computeRevenue(
     }
 }
 
+// New reveneue formula
+
+static constexpr unsigned int MAX_TX_LUT_INDEX = (unsigned int)(sizeof(gTxRevenuePoints) / sizeof(gTxRevenuePoints[0]) - 1);
+static constexpr unsigned int REVENUE_HALF_WINDOW = NUMBER_OF_COMPUTORS - 1;  // 675
+static constexpr unsigned int REVENUE_WINDOW_SIZE = 2 * REVENUE_HALF_WINDOW + 1;      // 1351
+static constexpr unsigned long long REVENUE_SCALE = 1024;
+static constexpr unsigned long long REVENUE_BONUS_CAP = 256; // capacity for non-mandatory factor
+static constexpr unsigned int REVENUE_W_TX = 17;             // mandatory weight: TX (85%)
+static constexpr unsigned int REVENUE_W_ORACLE = 3;          // mandatory weight: Oracle (15%)
+static constexpr unsigned int REVENUE_W_SUM = REVENUE_W_TX + REVENUE_W_ORACLE;  // 20
+// M_combined is computed as (W_TX*scoreTx + W_ORACLE*scoreOracle) / W_SUM first → [0, S]
+// Then formula: revenue = ipc × M × (S² + B×E) / (S × (S+B) × S)
+static constexpr unsigned long long REVENUE_DIVISOR = REVENUE_SCALE * (REVENUE_SCALE + REVENUE_BONUS_CAP) * REVENUE_SCALE; // 1024 × 1280 × 1024 = 1,342,177,280
+static constexpr long long REVENUE_IPC = ISSUANCE_RATE / NUMBER_OF_COMPUTORS;
+// Overflow check: IPC * S * (S^2 + B*S) = 1,479,289,940 * 1,342,177,280 ≈ 1.99e18 < u64 max (1.84e19)
+static_assert((unsigned long long)REVENUE_IPC * REVENUE_SCALE
+    * (REVENUE_SCALE * REVENUE_SCALE + REVENUE_BONUS_CAP * REVENUE_SCALE) <= 0xFFFFFFFFFFFFFFFFULL,
+    "V2 revenue formula intermediate can overflow u64");
+
+// Struct record all data so that we can do the offline analysis
+struct EpochRevenueData
+{
+    // Header
+    unsigned int initialTick;
+    unsigned int totalTicks;                                        // system.tick - system.initialTick
+
+    // Per-computor arrays (NUMBER_OF_COMPUTORS entries each)
+    unsigned long long slidingWindowTxScore[NUMBER_OF_COMPUTORS];   // new sliding window accumulated score
+    unsigned long long oracleScore[NUMBER_OF_COMPUTORS];            // oracle commit/reveal revenue points
+    long long v2Revenue[NUMBER_OF_COMPUTORS];                       // V2 shadow output
+
+    // Per-tick TX counts — existing total + 3 categories
+    unsigned short perTickTxCount[MAX_NUMBER_OF_TICKS_PER_EPOCH];           // total of txs exclude the tx of tick leader
+    unsigned short perTickProtocolTxCount[MAX_NUMBER_OF_TICKS_PER_EPOCH];   // protocol txs (votes, mining, oracle, etc.)
+    unsigned short perTickContractTxCount[MAX_NUMBER_OF_TICKS_PER_EPOCH];   // contract txs
+    unsigned short perTickOtherTxCount[MAX_NUMBER_OF_TICKS_PER_EPOCH];   // mainly: user transfers
+    unsigned short perTickTxTickLeaderCount[MAX_NUMBER_OF_TICKS_PER_EPOCH];           // total of txs
+};
+
+static EpochRevenueData gEpochRevenueData;
+
+// Intermediate buffers for V2 revenue computation
+struct RevenueV2Buffers
+{
+    unsigned int slidingWindowLogScore[MAX_NUMBER_OF_TICKS_PER_EPOCH];
+    unsigned long long txFactor[NUMBER_OF_COMPUTORS];
+    unsigned long long oracleFactor[NUMBER_OF_COMPUTORS];
+    unsigned long long miningFactor[NUMBER_OF_COMPUTORS];
+};
+static RevenueV2Buffers gRevenueV2Buffers;
+
+static void computeRevenueV2(EpochRevenueData& rEpochReveneuData)
+{
+    // Defensive: need at least WINDOW_SIZE ticks for circular sliding window to be valid.
+    if (rEpochReveneuData.totalTicks < REVENUE_WINDOW_SIZE)
+    {
+        setMem(rEpochReveneuData.slidingWindowTxScore, sizeof(rEpochReveneuData.slidingWindowTxScore), 0);
+        setMem(rEpochReveneuData.v2Revenue, sizeof(rEpochReveneuData.v2Revenue), 0);
+        return;
+    }
+
+    setMem(rEpochReveneuData.slidingWindowTxScore, sizeof(rEpochReveneuData.slidingWindowTxScore), 0);
+
+    // Transaction score computation
+    for (unsigned int t = 0; t < rEpochReveneuData.totalTicks; t++)
+    {
+        unsigned int txCount = rEpochReveneuData.perTickTxCount[t];
+        txCount = txCount > MAX_TX_LUT_INDEX ? MAX_TX_LUT_INDEX : txCount;
+
+        // Get the log of total transaction
+        gRevenueV2Buffers.slidingWindowLogScore[t] = gTxRevenuePoints[txCount];
+    }
+
+    // Pre-calculate window sum for t = 0: indices [-675, +675] with circular wrap
+    unsigned long long windowSum = 0;
+    for (int i = -(int)REVENUE_HALF_WINDOW; i <= (int)REVENUE_HALF_WINDOW; ++i)
+    {
+        unsigned int idx = ((i % (int)rEpochReveneuData.totalTicks) + (int)rEpochReveneuData.totalTicks) % (int)rEpochReveneuData.totalTicks;
+        windowSum += gRevenueV2Buffers.slidingWindowLogScore[idx];
+    }
+
+    for (unsigned int t = 0; t < rEpochReveneuData.totalTicks; t++)
+    {
+        // Compute score using current window sum
+        unsigned long long windowVal = windowSum;
+        if (windowVal == 0)
+        {
+            windowVal = 1;
+        }
+
+        // Score of center compare to windows
+        unsigned long long txScore = (unsigned long long)gRevenueV2Buffers.slidingWindowLogScore[t];
+        txScore = txScore * REVENUE_SCALE * REVENUE_WINDOW_SIZE / windowVal;
+
+        // Absolute tick number for computor tick leader
+        unsigned int computorIndex = (rEpochReveneuData.initialTick + t) % NUMBER_OF_COMPUTORS;
+        rEpochReveneuData.slidingWindowTxScore[computorIndex] += txScore;
+
+        // Slide the window: subtract leaving element, add entering element
+        unsigned int leavingIdx = (t + rEpochReveneuData.totalTicks - REVENUE_HALF_WINDOW) % rEpochReveneuData.totalTicks;
+        unsigned int enteringIdx = (t + REVENUE_HALF_WINDOW + 1) % rEpochReveneuData.totalTicks;
+        windowSum = windowSum - gRevenueV2Buffers.slidingWindowLogScore[leavingIdx] + gRevenueV2Buffers.slidingWindowLogScore[enteringIdx];
+    }
+
+    // Compute each independent factor
+    computeRevFactor(rEpochReveneuData.slidingWindowTxScore, REVENUE_SCALE, gRevenueV2Buffers.txFactor);
+
+    // Oracle: if no oracle activity this epoch, give everyone max score so the
+    // mandatory weight doesn't penalize computors for something outside their control
+    bool hasOracleActivity = false;
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        if (rEpochReveneuData.oracleScore[i] != 0)
+        {
+            hasOracleActivity = true;
+            break;
+        }
+    }
+    if (hasOracleActivity)
+    {
+        computeRevFactor(rEpochReveneuData.oracleScore, REVENUE_SCALE, gRevenueV2Buffers.oracleFactor);
+    }
+    else
+    {
+        // No oracle queries this epoch — all computors get full oracle factor
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            gRevenueV2Buffers.oracleFactor[i] = REVENUE_SCALE;
+        }
+    }
+
+    computeRevFactor(gRevenueComponents.customMiningScore, REVENUE_SCALE, gRevenueV2Buffers.miningFactor);
+
+    // Combine: M = weighted average of mandatory factors (TX + Oracle), E = bonus (mining)
+    // M = (W_TX*scoreTx + W_ORACLE*scoreOracle) / W_SUM  in  [0, S]
+    // revenue = ipc × M × (S² + B×E) / (S × (S+B) × S)
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        unsigned long long scoreTx = gRevenueV2Buffers.txFactor[i];          // [0, S]
+        unsigned long long scoreOracle = gRevenueV2Buffers.oracleFactor[i];  // [0, S]
+        unsigned long long E = gRevenueV2Buffers.miningFactor[i];         // [0, S]
+        unsigned long long M = (REVENUE_W_TX * scoreTx + REVENUE_W_ORACLE * scoreOracle) / REVENUE_W_SUM;  // [0, S]
+        unsigned long long numerator = M * (REVENUE_SCALE * REVENUE_SCALE + REVENUE_BONUS_CAP * E);
+        rEpochReveneuData.v2Revenue[i] = (long long)(REVENUE_IPC * numerator / REVENUE_DIVISOR);
+    }
+}
 


### PR DESCRIPTION
## Summary

- Add a new revenue formula V2 ("Base × (1 + Bonus)") that runs in **shadow mode** at epoch end — computes V2 revenue alongside V1 without distributing it
- V2 uses sliding-window TX scoring (±675 tick circular window), oracle participation as a weighted mandatory factor (85% TX / 15% Oracle), and mining as an additive bonus (capped at 25%)
- Classifies per-tick transactions into protocol/contract/other categories, filtering out tick leader's own TXs
- Dumps all raw data + V2 results to `revenue_data.eoe` for offline validation and parameter tuning