### PR TITLE
Fix preprocessor guard for loading execution fee files on non-scratch…

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -6119,7 +6119,7 @@ static bool initialize()
             }
             if (!loadContractStateFiles())
                 return false;
-#ifndef START_NETWORK_FROM_SCRATCH
+#if !START_NETWORK_FROM_SCRATCH
             if (!loadContractExecFeeFiles())
                 return false;
 #endif


### PR DESCRIPTION
Changed `#ifndef` to `#if !`  so that `loadContractExecFeeFiles()` is called when `START_NETWORK_FROM_SCRATCH` is `0` (node joining existing network). The `#ifndef` check always skipped loading because the macro is always defined, causing misalignment after epoch transition.

When a node is starting with `START_NETWORK_FROM_SCRATCH = 0` the file `contract_exec_fees_rec.xxx` is required.