### PR TITLE
Implement special handling of DogeShareValidation user queries

### DIFF
--- a/src/oracle_core/oracle_engine.h
+++ b/src/oracle_core/oracle_engine.h
@@ -594,9 +594,10 @@ public:
     * Check and start user query based on transaction (should be called from tick processor).
     * @param tx Transaction, whose validity and signature has been checked before.
     * @param txIndex Index of tx in tick data, for referencing in tick storage.
+    * @param forceZeroFee Whether to overwrite the oracle fee by zero. Default: false.
     * @return Query ID or -1 on error.
     */
-    int64_t startUserQuery(const OracleUserQueryTransactionPrefix* tx, uint32_t txIndex)
+    int64_t startUserQuery(const OracleUserQueryTransactionPrefix* tx, uint32_t txIndex, bool forceZeroFee = false)
     {
         // check preconditions (that function is used correctly)
         ASSERT(tx);
@@ -626,7 +627,7 @@ public:
 
         // check fee
         const void* queryData = (tx + 1);
-        const int64_t fee = OI::getOracleQueryFeeFunc[tx->oracleInterfaceIndex](queryData);
+        const int64_t fee = (forceZeroFee) ? 0 : OI::getOracleQueryFeeFunc[tx->oracleInterfaceIndex](queryData);
         if (tx->amount < fee)
         {
             // tx amount insufficient for fee -> return error (caller should refund in all error cases)

--- a/src/oracle_core/oracle_engine.h
+++ b/src/oracle_core/oracle_engine.h
@@ -335,6 +335,9 @@ protected:
     /// fast lookup of query indices for which the contract should be notified (in order of generation / queryIndex)
     MinHeap<uint32_t, MAX_SIMULTANEOUS_ORACLE_QUERIES> notificationQueryIndexQueue;
 
+    /// fast lookup of query indices of finished user queries (in order of generation / queryIndex)
+    MinHeap<uint32_t, MAX_SIMULTANEOUS_ORACLE_QUERIES> finishedUserQueryIndexQueue;
+
     // revenue points collected by each computor for fast and correct commit
     uint64_t revenuePoints[NUMBER_OF_COMPUTORS];
 
@@ -551,6 +554,7 @@ public:
         pendingCommitReplyStateIndices.numValues = 0;
         pendingRevealReplyStateIndices.numValues = 0;
         notificationQueryIndexQueue.init();
+        finishedUserQueryIndexQueue.init();
         usedSubscriptionSlots = 0;
         usedSubscriberSlots = 0;
         notificationCurrentSubscriberIdx = 0;
@@ -1035,7 +1039,7 @@ public:
         logger.logOracleSubscriber({ subscriptionId, subscription.interfaceIndex, contractIndex, 0, 0 });
 
         // debug logging
-#if !defined(NDEBUG)// && !defined(NO_UEFI)
+#if !defined(NDEBUG) && !defined(NO_UEFI)
         CHAR16 dbgMsg[300];
         setText(dbgMsg, L"oracleEngine.stopContractSubscription(), tick ");
         appendNumber(dbgMsg, system.tick, FALSE);
@@ -1719,6 +1723,8 @@ public:
                 // schedule contract notification(s) if needed
                 if (oqm.type != ORACLE_QUERY_TYPE_USER_QUERY)
                     notificationQueryIndexQueue.insert(queryIndex);
+                else
+                    finishedUserQueryIndexQueue.insert(queryIndex);
 
                 // log status change
                 logQueryStatusChange(oqm);
@@ -2069,6 +2075,8 @@ public:
                 // schedule contract notification(s) if needed
                 if (oqm.type != ORACLE_QUERY_TYPE_USER_QUERY)
                     notificationQueryIndexQueue.insert(queryIndex);
+                else
+                    finishedUserQueryIndexQueue.insert(queryIndex);
 
                 // log status change
                 logQueryStatusChange(oqm);
@@ -2113,6 +2121,8 @@ public:
         // schedule contract notification(s) if needed
         if (oqm.type != ORACLE_QUERY_TYPE_USER_QUERY)
             notificationQueryIndexQueue.insert(queryIndex);
+        else
+            finishedUserQueryIndexQueue.insert(queryIndex);
 
         // log status change
         logQueryStatusChange(oqm);
@@ -2184,6 +2194,8 @@ public:
                 // schedule contract notification(s) if needed
                 if (oqm.type != ORACLE_QUERY_TYPE_USER_QUERY)
                     notificationQueryIndexQueue.insert(queryIndex);
+                else
+                    finishedUserQueryIndexQueue.insert(queryIndex);
 
                 // log status change
                 logQueryStatusChange(oqm);
@@ -2285,6 +2297,33 @@ public:
         }
 
         return &notificationOutputBuffer;
+    }
+
+    /**
+     * @brief Get finished user queries one after another. Call until nullptr is returned.
+     * @return Pointer to oracle query metadata or nullptr if there isn't another finished user query.
+     *
+     * Only to be used in tick processor!
+     * Saving / loading snapshots is not supported between calls until nullptr is returned.
+     */
+    const OracleQueryMetadata* getFinishedUserQuery()
+    {
+        // currently finished query?
+        if (!finishedUserQueryIndexQueue.size())
+            return nullptr;
+
+        // lock for accessing engine data
+        LockGuard lockGuard(lock);
+
+        // get index and update list
+        uint32_t queryIndex;
+        finishedUserQueryIndexQueue.extract(queryIndex);
+
+        // get query metadata
+        const OracleQueryMetadata& oqm = queries[queryIndex];
+        ASSERT(oqm.type == ORACLE_QUERY_TYPE_USER_QUERY);
+
+        return &oqm;
     }
 
     // Drop all queries of the previous epoch.
@@ -2648,6 +2687,19 @@ public:
             ASSERT(queryIndex < oracleQueryCount);
             const OracleQueryMetadata& oqm = queries[queryIndex];
             ASSERT(oqm.status != ORACLE_QUERY_STATUS_PENDING);
+            ASSERT(oqm.type != ORACLE_QUERY_TYPE_USER_QUERY);
+        }
+
+        // check index of finished user queries
+        queryIdxCount = finishedUserQueryIndexQueue.size();
+        queryIndices = finishedUserQueryIndexQueue.data();
+        for (uint32_t i = 0; i < queryIdxCount; ++i)
+        {
+            const uint32_t queryIndex = queryIndices[i];
+            ASSERT(queryIndex < oracleQueryCount);
+            const OracleQueryMetadata& oqm = queries[queryIndex];
+            ASSERT(oqm.status != ORACLE_QUERY_STATUS_PENDING);
+            ASSERT(oqm.type == ORACLE_QUERY_TYPE_USER_QUERY);
         }
 
         // check subscribers

--- a/src/oracle_core/snapshot_files.h
+++ b/src/oracle_core/snapshot_files.h
@@ -26,6 +26,7 @@ struct OracleEngineSnapshotData
     UnsortedMultiset<uint32_t, MAX_SIMULTANEOUS_ORACLE_QUERIES> pendingCommitReplyStateIndices;
     UnsortedMultiset<uint32_t, MAX_SIMULTANEOUS_ORACLE_QUERIES> pendingRevealReplyStateIndices;
     MinHeap<uint32_t, MAX_SIMULTANEOUS_ORACLE_QUERIES> notificationQueryIndexQueue;
+    MinHeap<uint32_t, MAX_SIMULTANEOUS_ORACLE_QUERIES> finishedUserQueryIndexQueue;
     uint64_t revenuePoints[NUMBER_OF_COMPUTORS];
     int32_t usedSubscriptionSlots;
     int32_t usedSubscriberSlots;
@@ -57,6 +58,7 @@ bool OracleEngine::saveSnapshot(unsigned short epoch, CHAR16* directory) const
     copyMemory(engineData.pendingCommitReplyStateIndices, pendingCommitReplyStateIndices);
     copyMemory(engineData.pendingRevealReplyStateIndices, pendingRevealReplyStateIndices);
     copyMemory(engineData.notificationQueryIndexQueue, notificationQueryIndexQueue);
+    copyMemory(engineData.finishedUserQueryIndexQueue, finishedUserQueryIndexQueue);
     copyMemory(engineData.revenuePoints, revenuePoints);
     copyMemory(engineData.stats, stats);
 
@@ -152,6 +154,7 @@ bool OracleEngine::loadSnapshot(unsigned short epoch, CHAR16* directory)
     copyMemory(pendingCommitReplyStateIndices, engineData.pendingCommitReplyStateIndices);
     copyMemory(pendingRevealReplyStateIndices, engineData.pendingRevealReplyStateIndices);
     copyMemory(notificationQueryIndexQueue, engineData.notificationQueryIndexQueue);
+    copyMemory(finishedUserQueryIndexQueue, engineData.finishedUserQueryIndexQueue);
     copyMemory(revenuePoints, engineData.revenuePoints);
     copyMemory(stats, engineData.stats);
     if (oracleQueryCount > MAX_ORACLE_QUERIES || queryStorageBytesUsed > ORACLE_QUERY_STORAGE_SIZE

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3528,6 +3528,70 @@ static void processTick(unsigned long long processorNumber)
         oracleNotification = oracleEngine.getNotification();
     }
 
+    // Process finished oracle user queries (doge mining share validation replies)
+    const OracleQueryMetadata* finishedUserQuery = oracleEngine.getFinishedUserQuery();
+    while (finishedUserQuery)
+    {
+        if (finishedUserQuery->interfaceIndex == OI::DogeShareValidation::oracleInterfaceIndex)
+        {
+            OI::DogeShareValidation::OracleReply reply;
+            if (finishedUserQuery->status == ORACLE_QUERY_STATUS_SUCCESS
+                && oracleEngine.getOracleReply(finishedUserQuery->queryId, &reply, sizeof(reply)))
+            {
+                // Oracle reply is available
+                if (reply.isValid)
+                {
+                    // Share is valid
+                    // TODO: implement share counting
+                }
+                else
+                {
+                    // Share is invalid
+                    // TODO: handle or remove this else block
+                }
+            }
+            else
+            {
+                // Oracle query failed -> lookup and resend user query tx if it is from own comp pool
+                // TODO: limit repetition?
+                ASSERT(finishedUserQuery->type == ORACLE_QUERY_TYPE_USER_QUERY);
+                ASSERT(ts.tickInCurrentEpochStorage(finishedUserQuery->queryTick));
+                const uint64_t* tsTickTransactionOffsets
+                    = ts.tickTransactionOffsets.getByTickInCurrentEpoch(finishedUserQuery->queryTick);
+                const uint32_t txSlotInTickData = finishedUserQuery->typeVar.user.queryTxIndex;
+                ASSERT(txSlotInTickData < NUMBER_OF_TRANSACTIONS_PER_TICK);
+                const auto* prevTx = (OracleUserQueryTransactionPrefix*)ts.tickTransactions.ptr(
+                    tsTickTransactionOffsets[txSlotInTickData]);
+                ASSERT(finishedUserQuery->interfaceIndex == prevTx->oracleInterfaceIndex);
+                if (prevTx->inputSize
+                    == OracleUserQueryTransactionPrefix::minInputSize() + sizeof(OI::DogeShareValidation::OracleQuery))
+                {
+                    for (unsigned int i = 0; i < computorSeedsCount; ++i)
+                    {
+                        if (computorPublicKeys[i] == prevTx->sourcePublicKey)
+                        {
+                            // Copy and update tx
+                            __ScopedScratchpad scratchpad(MAX_TRANSACTION_SIZE, /*initZero=*/false);
+                            auto* tx = (OracleUserQueryTransactionPrefix*)scratchpad.ptr;
+                            const uint64_t txSizeWithoutSignature = sizeof(OracleUserQueryTransactionPrefix)
+                                                                    + sizeof(OI::DogeShareValidation::OracleQuery);
+                            copyMem(tx, prevTx, txSizeWithoutSignature);
+                            tx->tick = system.tick + TICK_TRANSACTIONS_PUBLICATION_OFFSET;
+
+                            // Sign and send tx
+                            m256i digest;
+                            KangarooTwelve(tx, sizeof(Transaction) + prevTx->inputSize, digest.m256i_u8, sizeof(digest));
+                            sign(computorSubseeds[i].m256i_u8, computorPublicKeys[i].m256i_u8, digest.m256i_u8, tx->signaturePtr());
+                            enqueueResponse(NULL, tx->totalSize(), BROADCAST_TRANSACTION, 0, tx);
+                            break;
+                       }
+                    }
+                }
+            }
+        }
+        finishedUserQuery = oracleEngine.getFinishedUserQuery();
+    }
+
     // The last executionFeeReport for the previous phase is published by comp <NUMBER_OF_COMPUTORS - 1> (0-indexed) in the last tick t1 of the
     // previous phase (t1 % NUMBER_OF_COMPUTORS == NUMBER_OF_COMPUTORS - 1) for inclusion in tick t2 = t1 + TICK_TRANSACTIONS_PUBLICATION_OFFSET.
     // Tick t2 corresponds to tick <TICK_TRANSACTIONS_PUBLICATION_OFFSET - 1> of the current phase.

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3098,7 +3098,17 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
 
                 case OracleUserQueryTransactionPrefix::transactionType():
                 {
-                    const bool error = (oracleEngine.startUserQuery((OracleUserQueryTransactionPrefix*)transaction, transactionIndex) < 0);
+                    // check for special cases
+                    const auto* queryTx = (const OracleUserQueryTransactionPrefix*)transaction;
+                    bool forceZeroFee = false;
+                    if (queryTx->oracleInterfaceIndex == OI::DogeShareValidation::oracleInterfaceIndex)
+                    {
+                        // doge share validation query does not cost fees for computors
+                        forceZeroFee = computorIndex(queryTx->sourcePublicKey) >= 0;
+                    }
+
+                    // start user query
+                    const bool error = (oracleEngine.startUserQuery(queryTx, transactionIndex, forceZeroFee) < 0);
                     if (error && transaction->amount)
                     {
                         oracleEngine.refundFees(transaction->sourcePublicKey, transaction->amount);

--- a/test/oracle_engine.cpp
+++ b/test/oracle_engine.cpp
@@ -323,6 +323,7 @@ TEST(OracleEngine, ContractQuerySuccess)
 
 	// no notifications
 	EXPECT_EQ(oracleEngine1.getNotification(), nullptr);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 
 	//-------------------------------------------------------------------------
 	// create and process enough reply commit tx to trigger reveal tx
@@ -412,6 +413,7 @@ TEST(OracleEngine, ContractQuerySuccess)
 
 	// no additional notifications
 	EXPECT_EQ(oracleEngine1.getNotification(), nullptr);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 
 	EXPECT_EQ(oracleEngine1.getOracleQueryStatus(queryId), ORACLE_QUERY_STATUS_SUCCESS);
 
@@ -585,6 +587,7 @@ TEST(OracleEngine, ContractQueryUnresolvable)
 
 	// no additional notifications
 	EXPECT_EQ(oracleEngine1.getNotification(), nullptr);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 
 	EXPECT_EQ(oracleEngine1.getOracleQueryStatus(queryId), ORACLE_QUERY_STATUS_UNRESOLVABLE);
 
@@ -745,6 +748,7 @@ TEST(OracleEngine, ContractQueryWrongKnowledgeProof)
 
 	// no additional notifications
 	EXPECT_EQ(oracleEngine1.getNotification(), nullptr);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 
 	EXPECT_EQ(oracleEngine1.getOracleQueryStatus(queryId), ORACLE_QUERY_STATUS_UNRESOLVABLE);
 
@@ -823,6 +827,7 @@ TEST(OracleEngine, ContractQueryTimeout)
 
 	// no additional notifications
 	EXPECT_EQ(oracleEngine1.getNotification(), nullptr);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 
 	EXPECT_EQ(oracleEngine1.getOracleQueryStatus(queryId), ORACLE_QUERY_STATUS_TIMEOUT);
 
@@ -1116,6 +1121,7 @@ TEST(OracleEngine, MultiContractQuerySuccess)
 	// no additional notifications
 	EXPECT_EQ(oracleEngine1.getNotification(), nullptr);
 	EXPECT_EQ(pendingNotificationQueryIds.size(), 0);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 
 	//-------------------------------------------------------------------------
 	// revenue
@@ -1257,6 +1263,7 @@ TEST(OracleEngine, UserQuerySuccess)
 
 	// no notifications
 	EXPECT_EQ(oracleEngine1.getNotification(), nullptr);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 
 	//-------------------------------------------------------------------------
 	// create and process enough reply commit tx to trigger reveal tx
@@ -1352,6 +1359,12 @@ TEST(OracleEngine, UserQuerySuccess)
 	oracleEngine1.checkStateConsistencyWithAssert();
 	oracleEngine2.checkStateConsistencyWithAssert();
 	oracleEngine3.checkStateConsistencyWithAssert();
+
+	// User query notification test
+	const OracleQueryMetadata* oqm = oracleEngine1.getFinishedUserQuery();
+	EXPECT_NE(oqm, nullptr);
+	EXPECT_EQ(oqm->queryId, queryId);
+	EXPECT_EQ(oracleEngine1.getFinishedUserQuery(), nullptr);
 }
 
 // For simplified checking of timestamps define + for adding minutes
@@ -1833,6 +1846,8 @@ TEST(OracleEngine, Subscription)
 		{ CCF_CONTRACT_INDEX },
 		notificationProcId, qid26, ORACLE_QUERY_STATUS_TIMEOUT, subscriptionId0);
 	EXPECT_EQ(oracleEngine.getNotification(), nullptr);
+
+	EXPECT_EQ(oracleEngine.getFinishedUserQuery(), nullptr);
 
 	oracleEngine.checkStateConsistencyWithAssert();
 }


### PR DESCRIPTION
- Set DogeShareValidation query fee to 0 for computors
- Process doge validation replies / resend on timeout
- OracleEngine: add queue for getting finished user queries