### PR TITLE
Speedup addition score

### DIFF
--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -36,6 +36,14 @@ struct MiningSolutionTransaction : public Transaction
         return sizeof(miningSeed) + sizeof(nonce);
     }
 
+    static bool isSolutionTransaction(const Transaction* tx)
+    {
+        return isZero(tx->destinationPublicKey)
+            && tx->inputType == transactionType()
+            && tx->amount >= minAmount()
+            && tx->inputSize >= minInputSize();
+    }
+
     m256i miningSeed;
     m256i nonce;
     unsigned char signature[SIGNATURE_SIZE];

--- a/src/mining/score_addition.h
+++ b/src/mining/score_addition.h
@@ -80,10 +80,11 @@ struct ScoreAddition
     alignas(64) char neuronValuesBuffer0[maxNumberOfNeurons * PADDED_SAMPLES];
     alignas(64) char neuronValuesBuffer1[maxNumberOfNeurons * PADDED_SAMPLES];
 
-    // Incoming synapses
-    alignas(64) unsigned int incomingSource[maxNumberOfNeurons * maxNumberOfNeighbors];
-    alignas(64) Synapse incomingSynapses[maxNumberOfNeurons * maxNumberOfNeighbors];
-    unsigned int incomingCount[maxNumberOfNeurons];
+    // Incoming synapses split by sign
+    alignas(64) unsigned int incomingPositiveSource[maxNumberOfNeurons * maxNumberOfNeighbors];
+    alignas(64) unsigned int incomingNegativeSource[maxNumberOfNeurons * maxNumberOfNeighbors];
+    unsigned int incomingPositiveCount[maxNumberOfNeurons];
+    unsigned int incomingNegativeCount[maxNumberOfNeurons];
 
     // For tracking/compacting sample after each tick
     alignas(64) unsigned int sampleMapping[PADDED_SAMPLES];
@@ -97,6 +98,11 @@ struct ScoreAddition
     unsigned long long numCachedOutputs;
     unsigned long long evolutionNeuronIdxCache[numberOfMutations];
     unsigned long long numCachedEvolution;
+
+    unsigned long long processNeuronOffsetCache[maxNumberOfNeurons];
+    unsigned long long numProcessNeuron;
+
+    alignas(64) int32_t synapseWeightLUT[256];
 
     // Buffers for cleaning up
     unsigned long long removalNeurons[maxNumberOfNeurons];
@@ -113,6 +119,17 @@ struct ScoreAddition
     void initMemory()
     {
         generateTrainingSet();
+
+        for (int b = 0; b < 256; b++)
+        {
+            char w[4];
+            for (int j = 0; j < 4; j++)
+            {
+                unsigned char ev = (unsigned char)((b >> (j * 2)) & 3);
+                w[j] = (ev == 2) ? (char)-1 : (ev == 3) ? (char)1 : (char)0;
+            }
+            copyMem(&synapseWeightLUT[b], w, 4);
+        }
     }
 
 
@@ -206,8 +223,10 @@ struct ScoreAddition
     {
         numCachedOutputs = 0;
         numCachedEvolution = 0;
+        numProcessNeuron = currentANN.population;
         for (unsigned long long i = 0; i < currentANN.population; i++)
         {
+            processNeuronOffsetCache[i] = i * PADDED_SAMPLES;
             if (currentANN.neuronTypes[i] == OUTPUT_NEURON_TYPE)
             {
                 outputNeuronIdxCache[numCachedOutputs++] = i;
@@ -577,118 +596,309 @@ struct ScoreAddition
         }
     }
 
-    // Helper macro to process a single neuron in tick processing
 #if defined(__AVX512F__)
-    #define PROCESS_NEURON_TICK(targetNeuron) \
-    { \
-        unsigned int numIncoming = incomingCount[targetNeuron]; \
-        const unsigned long long targetNeuronOffset = (targetNeuron) * maxNumberOfNeighbors; \
-        for (unsigned long long s = 0; s < activeSamplePad; s += BATCH_SIZE) \
-        { \
-            __m512i acc0 = _mm512_setzero_si512(); \
-            __m512i acc1 = _mm512_setzero_si512(); \
-            for (unsigned int i = 0; i < numIncoming; i++) \
-            { \
-                unsigned int srcNeuron = incomingSource[targetNeuronOffset + i]; \
-                __m512i weight512 = _mm512_set1_epi8(incomingSynapses[targetNeuronOffset + i]); \
-                __m512i srcValues = _mm512_loadu_si512((__m512i *)&prevNeuronValues[srcNeuron * PADDED_SAMPLES + s]); \
-                __mmask64 negMask = _mm512_movepi8_mask(weight512); \
-                __m512i negated = _mm512_sub_epi8(_mm512_setzero_si512(), srcValues); \
-                __m512i product = _mm512_mask_blend_epi8(negMask, srcValues, negated); \
-                __m256i lo = _mm512_extracti64x4_epi64(product, 0); \
-                __m256i hi = _mm512_extracti64x4_epi64(product, 1); \
-                acc0 = _mm512_add_epi16(acc0, _mm512_cvtepi8_epi16(lo)); \
-                acc1 = _mm512_add_epi16(acc1, _mm512_cvtepi8_epi16(hi)); \
-            } \
-            acc0 = _mm512_max_epi16(acc0, negOne16); \
-            acc0 = _mm512_min_epi16(acc0, one16); \
-            acc1 = _mm512_max_epi16(acc1, negOne16); \
-            acc1 = _mm512_min_epi16(acc1, one16); \
-            __m512i packed = _mm512_packs_epi16(acc0, acc1); \
-            packed = _mm512_permutexvar_epi64(packLoc, packed); \
-            _mm512_storeu_si512((__m512i *)&neuronValues[(targetNeuron) * PADDED_SAMPLES + s], packed); \
-        } \
+    void processNeuronTick512(
+        unsigned long long targetNeuronBase,
+        const unsigned int* positiveSources, unsigned int numPos,
+        const unsigned int* negativeSources, unsigned int numNeg,
+        unsigned long long activeSamplePad)
+    {
+        const __m512i one16 = _mm512_set1_epi16(1);
+        const __m512i negOne16 = _mm512_set1_epi16(-1);
+        const __m512i packLoc = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
+
+        unsigned long long s = 0;
+        for (; s + 2 * BATCH_SIZE <= activeSamplePad; s += 2 * BATCH_SIZE)
+        {
+            __m512i acc16_0a = _mm512_setzero_si512();
+            __m512i acc16_1a = _mm512_setzero_si512();
+            __m512i acc16_0b = _mm512_setzero_si512();
+            __m512i acc16_1b = _mm512_setzero_si512();
+            __m512i acc8a = _mm512_setzero_si512();
+            __m512i acc8b = _mm512_setzero_si512();
+            unsigned int count = 0;
+
+            for (unsigned int i = 0; i < numPos; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)positiveSources[i] * PADDED_SAMPLES;
+                acc8a = _mm512_add_epi8(acc8a, _mm512_loadu_si512((__m512i*)&prevNeuronValues[srcBase + s]));
+                acc8b = _mm512_add_epi8(acc8b, _mm512_loadu_si512((__m512i*)&prevNeuronValues[srcBase + s + BATCH_SIZE]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0a = _mm512_add_epi16(acc16_0a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 0)));
+                    acc16_1a = _mm512_add_epi16(acc16_1a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 1)));
+                    acc16_0b = _mm512_add_epi16(acc16_0b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 0)));
+                    acc16_1b = _mm512_add_epi16(acc16_1b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 1)));
+                    acc8a = _mm512_setzero_si512();
+                    acc8b = _mm512_setzero_si512();
+                    count = 0;
+                }
+            }
+            acc16_0a = _mm512_add_epi16(acc16_0a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 0)));
+            acc16_1a = _mm512_add_epi16(acc16_1a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 1)));
+            acc16_0b = _mm512_add_epi16(acc16_0b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 0)));
+            acc16_1b = _mm512_add_epi16(acc16_1b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 1)));
+
+            acc8a = _mm512_setzero_si512();
+            acc8b = _mm512_setzero_si512();
+            count = 0;
+            for (unsigned int i = 0; i < numNeg; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)negativeSources[i] * PADDED_SAMPLES;
+                acc8a = _mm512_add_epi8(acc8a, _mm512_loadu_si512((__m512i*)&prevNeuronValues[srcBase + s]));
+                acc8b = _mm512_add_epi8(acc8b, _mm512_loadu_si512((__m512i*)&prevNeuronValues[srcBase + s + BATCH_SIZE]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0a = _mm512_sub_epi16(acc16_0a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 0)));
+                    acc16_1a = _mm512_sub_epi16(acc16_1a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 1)));
+                    acc16_0b = _mm512_sub_epi16(acc16_0b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 0)));
+                    acc16_1b = _mm512_sub_epi16(acc16_1b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 1)));
+                    acc8a = _mm512_setzero_si512();
+                    acc8b = _mm512_setzero_si512();
+                    count = 0;
+                }
+            }
+            acc16_0a = _mm512_sub_epi16(acc16_0a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 0)));
+            acc16_1a = _mm512_sub_epi16(acc16_1a, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8a, 1)));
+            acc16_0b = _mm512_sub_epi16(acc16_0b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 0)));
+            acc16_1b = _mm512_sub_epi16(acc16_1b, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8b, 1)));
+
+            acc16_0a = _mm512_max_epi16(_mm512_min_epi16(acc16_0a, one16), negOne16);
+            acc16_1a = _mm512_max_epi16(_mm512_min_epi16(acc16_1a, one16), negOne16);
+            _mm512_storeu_si512((__m512i*)&neuronValues[targetNeuronBase + s],
+                _mm512_permutexvar_epi64(packLoc, _mm512_packs_epi16(acc16_0a, acc16_1a)));
+            acc16_0b = _mm512_max_epi16(_mm512_min_epi16(acc16_0b, one16), negOne16);
+            acc16_1b = _mm512_max_epi16(_mm512_min_epi16(acc16_1b, one16), negOne16);
+            _mm512_storeu_si512((__m512i*)&neuronValues[targetNeuronBase + s + BATCH_SIZE],
+                _mm512_permutexvar_epi64(packLoc, _mm512_packs_epi16(acc16_0b, acc16_1b)));
+        }
+
+        for (; s < activeSamplePad; s += BATCH_SIZE)
+        {
+            __m512i acc16_0 = _mm512_setzero_si512();
+            __m512i acc16_1 = _mm512_setzero_si512();
+            __m512i acc8 = _mm512_setzero_si512();
+            unsigned int count = 0;
+
+            for (unsigned int i = 0; i < numPos; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)positiveSources[i] * PADDED_SAMPLES;
+                acc8 = _mm512_add_epi8(acc8, _mm512_loadu_si512((__m512i*)&prevNeuronValues[srcBase + s]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0 = _mm512_add_epi16(acc16_0, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 0)));
+                    acc16_1 = _mm512_add_epi16(acc16_1, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 1)));
+                    acc8 = _mm512_setzero_si512();
+                    count = 0;
+                }
+            }
+            acc16_0 = _mm512_add_epi16(acc16_0, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 0)));
+            acc16_1 = _mm512_add_epi16(acc16_1, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 1)));
+
+            acc8 = _mm512_setzero_si512();
+            count = 0;
+            for (unsigned int i = 0; i < numNeg; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)negativeSources[i] * PADDED_SAMPLES;
+                acc8 = _mm512_add_epi8(acc8, _mm512_loadu_si512((__m512i*)&prevNeuronValues[srcBase + s]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0 = _mm512_sub_epi16(acc16_0, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 0)));
+                    acc16_1 = _mm512_sub_epi16(acc16_1, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 1)));
+                    acc8 = _mm512_setzero_si512();
+                    count = 0;
+                }
+            }
+            acc16_0 = _mm512_sub_epi16(acc16_0, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 0)));
+            acc16_1 = _mm512_sub_epi16(acc16_1, _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(acc8, 1)));
+
+            acc16_0 = _mm512_max_epi16(_mm512_min_epi16(acc16_0, one16), negOne16);
+            acc16_1 = _mm512_max_epi16(_mm512_min_epi16(acc16_1, one16), negOne16);
+            _mm512_storeu_si512((__m512i*)&neuronValues[targetNeuronBase + s],
+                _mm512_permutexvar_epi64(packLoc, _mm512_packs_epi16(acc16_0, acc16_1)));
+        }
     }
-#else
-    #define PROCESS_NEURON_TICK(targetNeuron) \
-    { \
-        unsigned int numIncoming = incomingCount[targetNeuron]; \
-        const unsigned long long targetNeuronOffset = (targetNeuron) * maxNumberOfNeighbors; \
-        for (unsigned long long s = 0; s < activeSamplePad; s += BATCH_SIZE) \
-        { \
-            __m256i acc0 = _mm256_setzero_si256(); \
-            __m256i acc1 = _mm256_setzero_si256(); \
-            for (unsigned int i = 0; i < numIncoming; i++) \
-            { \
-                unsigned int srcNeuron = incomingSource[targetNeuronOffset + i]; \
-                __m256i weight256 = _mm256_set1_epi8(incomingSynapses[targetNeuronOffset + i]); \
-                __m256i srcValues = _mm256_loadu_si256((__m256i *)&prevNeuronValues[srcNeuron * PADDED_SAMPLES + s]); \
-                __m256i negated = _mm256_sub_epi8(_mm256_setzero_si256(), srcValues); \
-                __m256i product = _mm256_blendv_epi8(srcValues, negated, weight256); \
-                __m128i lo = _mm256_castsi256_si128(product); \
-                __m128i hi = _mm256_extracti128_si256(product, 1); \
-                acc0 = _mm256_add_epi16(acc0, _mm256_cvtepi8_epi16(lo)); \
-                acc1 = _mm256_add_epi16(acc1, _mm256_cvtepi8_epi16(hi)); \
-            } \
-            acc0 = _mm256_max_epi16(acc0, negOne16); \
-            acc0 = _mm256_min_epi16(acc0, one16); \
-            acc1 = _mm256_max_epi16(acc1, negOne16); \
-            acc1 = _mm256_min_epi16(acc1, one16); \
-            __m256i packed = _mm256_packs_epi16(acc0, acc1); \
-            packed = _mm256_permute4x64_epi64(packed, 0xD8); \
-            _mm256_storeu_si256((__m256i *)&neuronValues[(targetNeuron) * PADDED_SAMPLES + s], packed); \
-        } \
+
+#else // AVX2
+    void processNeuronTick256(
+        unsigned long long targetNeuronBase,
+        const unsigned int* positiveSources, unsigned int numPos,
+        const unsigned int* negativeSources, unsigned int numNeg,
+        unsigned long long activeSamplePad)
+    {
+        const __m256i one16 = _mm256_set1_epi16(1);
+        const __m256i negOne16 = _mm256_set1_epi16(-1);
+
+        unsigned long long s = 0;
+        for (; s + 2 * BATCH_SIZE <= activeSamplePad; s += 2 * BATCH_SIZE)
+        {
+            __m256i acc16_0a = _mm256_setzero_si256();
+            __m256i acc16_1a = _mm256_setzero_si256();
+            __m256i acc16_0b = _mm256_setzero_si256();
+            __m256i acc16_1b = _mm256_setzero_si256();
+            __m256i acc8a = _mm256_setzero_si256();
+            __m256i acc8b = _mm256_setzero_si256();
+            unsigned int count = 0;
+
+            for (unsigned int i = 0; i < numPos; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)positiveSources[i] * PADDED_SAMPLES;
+                acc8a = _mm256_add_epi8(acc8a, _mm256_loadu_si256((__m256i*) & prevNeuronValues[srcBase + s]));
+                acc8b = _mm256_add_epi8(acc8b, _mm256_loadu_si256((__m256i*) & prevNeuronValues[srcBase + s + BATCH_SIZE]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0a = _mm256_add_epi16(acc16_0a, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8a)));
+                    acc16_1a = _mm256_add_epi16(acc16_1a, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8a, 1)));
+                    acc16_0b = _mm256_add_epi16(acc16_0b, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8b)));
+                    acc16_1b = _mm256_add_epi16(acc16_1b, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8b, 1)));
+                    acc8a = _mm256_setzero_si256();
+                    acc8b = _mm256_setzero_si256();
+                    count = 0;
+                }
+            }
+            acc16_0a = _mm256_add_epi16(acc16_0a, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8a)));
+            acc16_1a = _mm256_add_epi16(acc16_1a, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8a, 1)));
+            acc16_0b = _mm256_add_epi16(acc16_0b, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8b)));
+            acc16_1b = _mm256_add_epi16(acc16_1b, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8b, 1)));
+
+            acc8a = _mm256_setzero_si256();
+            acc8b = _mm256_setzero_si256();
+            count = 0;
+            for (unsigned int i = 0; i < numNeg; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)negativeSources[i] * PADDED_SAMPLES;
+                acc8a = _mm256_add_epi8(acc8a, _mm256_loadu_si256((__m256i*) & prevNeuronValues[srcBase + s]));
+                acc8b = _mm256_add_epi8(acc8b, _mm256_loadu_si256((__m256i*) & prevNeuronValues[srcBase + s + BATCH_SIZE]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0a = _mm256_sub_epi16(acc16_0a, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8a)));
+                    acc16_1a = _mm256_sub_epi16(acc16_1a, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8a, 1)));
+                    acc16_0b = _mm256_sub_epi16(acc16_0b, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8b)));
+                    acc16_1b = _mm256_sub_epi16(acc16_1b, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8b, 1)));
+                    acc8a = _mm256_setzero_si256();
+                    acc8b = _mm256_setzero_si256();
+                    count = 0;
+                }
+            }
+            acc16_0a = _mm256_sub_epi16(acc16_0a, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8a)));
+            acc16_1a = _mm256_sub_epi16(acc16_1a, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8a, 1)));
+            acc16_0b = _mm256_sub_epi16(acc16_0b, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8b)));
+            acc16_1b = _mm256_sub_epi16(acc16_1b, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8b, 1)));
+
+            acc16_0a = _mm256_max_epi16(_mm256_min_epi16(acc16_0a, one16), negOne16);
+            acc16_1a = _mm256_max_epi16(_mm256_min_epi16(acc16_1a, one16), negOne16);
+            _mm256_storeu_si256((__m256i*) & neuronValues[targetNeuronBase + s],
+                _mm256_permute4x64_epi64(_mm256_packs_epi16(acc16_0a, acc16_1a), 0xD8));
+            acc16_0b = _mm256_max_epi16(_mm256_min_epi16(acc16_0b, one16), negOne16);
+            acc16_1b = _mm256_max_epi16(_mm256_min_epi16(acc16_1b, one16), negOne16);
+            _mm256_storeu_si256((__m256i*) & neuronValues[targetNeuronBase + s + BATCH_SIZE],
+                _mm256_permute4x64_epi64(_mm256_packs_epi16(acc16_0b, acc16_1b), 0xD8));
+        }
+
+        for (; s < activeSamplePad; s += BATCH_SIZE)
+        {
+            __m256i acc16_0 = _mm256_setzero_si256();
+            __m256i acc16_1 = _mm256_setzero_si256();
+            __m256i acc8 = _mm256_setzero_si256();
+            unsigned int count = 0;
+
+            for (unsigned int i = 0; i < numPos; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)positiveSources[i] * PADDED_SAMPLES;
+                acc8 = _mm256_add_epi8(acc8, _mm256_loadu_si256((__m256i*) & prevNeuronValues[srcBase + s]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0 = _mm256_add_epi16(acc16_0, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8)));
+                    acc16_1 = _mm256_add_epi16(acc16_1, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8, 1)));
+                    acc8 = _mm256_setzero_si256();
+                    count = 0;
+                }
+            }
+            acc16_0 = _mm256_add_epi16(acc16_0, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8)));
+            acc16_1 = _mm256_add_epi16(acc16_1, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8, 1)));
+
+            acc8 = _mm256_setzero_si256();
+            count = 0;
+            for (unsigned int i = 0; i < numNeg; i++)
+            {
+                const unsigned long long srcBase = (unsigned long long)negativeSources[i] * PADDED_SAMPLES;
+                acc8 = _mm256_add_epi8(acc8, _mm256_loadu_si256((__m256i*) & prevNeuronValues[srcBase + s]));
+                count++;
+                if (count == 127)
+                {
+                    acc16_0 = _mm256_sub_epi16(acc16_0, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8)));
+                    acc16_1 = _mm256_sub_epi16(acc16_1, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8, 1)));
+                    acc8 = _mm256_setzero_si256();
+                    count = 0;
+                }
+            }
+            acc16_0 = _mm256_sub_epi16(acc16_0, _mm256_cvtepi8_epi16(_mm256_castsi256_si128(acc8)));
+            acc16_1 = _mm256_sub_epi16(acc16_1, _mm256_cvtepi8_epi16(_mm256_extracti128_si256(acc8, 1)));
+
+            acc16_0 = _mm256_max_epi16(_mm256_min_epi16(acc16_0, one16), negOne16);
+            acc16_1 = _mm256_max_epi16(_mm256_min_epi16(acc16_1, one16), negOne16);
+            _mm256_storeu_si256((__m256i*) & neuronValues[targetNeuronBase + s],
+                _mm256_permute4x64_epi64(_mm256_packs_epi16(acc16_0, acc16_1), 0xD8));
+        }
     }
 #endif
+
+    void processNeuronTick(unsigned long long targetNeuron, unsigned long long activeSamplePad)
+    {
+        const unsigned long long offset = targetNeuron * maxNumberOfNeighbors;
+        const unsigned long long base = targetNeuron * PADDED_SAMPLES;
+#if defined(__AVX512F__)
+        processNeuronTick512(base,
+            &incomingPositiveSource[offset], incomingPositiveCount[targetNeuron],
+            &incomingNegativeSource[offset], incomingNegativeCount[targetNeuron],
+            activeSamplePad);
+#else
+        processNeuronTick256(base,
+            &incomingPositiveSource[offset], incomingPositiveCount[targetNeuron],
+            &incomingNegativeSource[offset], incomingNegativeCount[targetNeuron],
+            activeSamplePad);
+#endif
+    }
 
     void processTick()
     {
         unsigned long long activeSamplePad = ((activeCount + BATCH_SIZE - 1) / BATCH_SIZE) * BATCH_SIZE;
 
-#if defined(__AVX512F__)
-        const __m512i one16 = _mm512_set1_epi16(1);
-        const __m512i negOne16 = _mm512_set1_epi16(-1);
-        const __m512i packLoc = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
-#else
-        const __m256i one16 = _mm256_set1_epi16(1);
-        const __m256i negOne16 = _mm256_set1_epi16(-1);
-#endif
-        // Process output neurons
         for (unsigned long long idx = 0; idx < numCachedOutputs; ++idx)
-        {
-            unsigned long long targetNeuron = outputNeuronIdxCache[idx];
-            PROCESS_NEURON_TICK(targetNeuron);
-        }
+            processNeuronTick(outputNeuronIdxCache[idx], activeSamplePad);
 
-        // Process evolution neurons
         for (unsigned long long idx = 0; idx < numCachedEvolution; ++idx)
-        {
-            unsigned long long targetNeuron = evolutionNeuronIdxCache[idx];
-            PROCESS_NEURON_TICK(targetNeuron);
-        }
+            processNeuronTick(evolutionNeuronIdxCache[idx], activeSamplePad);
     }
-#undef PROCESS_NEURON_TICK
 
     void loadTrainingData()
     {
         unsigned long long population = currentANN.population;
 
-        // Load input neuron values from training data
         unsigned long long inputIdx = 0;
         for (unsigned long long n = 0; n < population; n++)
         {
             if (currentANN.neuronTypes[n] == INPUT_NEURON_TYPE)
             {
-                copyMem(&neuronValues[n * PADDED_SAMPLES], &trainingInputs[inputIdx * PADDED_SAMPLES], PADDED_SAMPLES);
+                const unsigned long long offset = n * PADDED_SAMPLES;
+                copyMem(&neuronValues[offset], &trainingInputs[inputIdx * PADDED_SAMPLES], PADDED_SAMPLES);
+                copyMem(&prevNeuronValues[offset], &trainingInputs[inputIdx * PADDED_SAMPLES], PADDED_SAMPLES);
                 inputIdx++;
             }
             else
             {
-                // Non-input neurons: clear to zero
-                setMem(&neuronValues[n * PADDED_SAMPLES], PADDED_SAMPLES, 0);
+                const unsigned long long offset = n * PADDED_SAMPLES;
+                setMem(&neuronValues[offset], PADDED_SAMPLES, 0);
+                setMem(&prevNeuronValues[offset], PADDED_SAMPLES, 0);
             }
         }
-
     }
 
     // Convert the outgoing synapse to incomming style
@@ -700,10 +910,9 @@ struct ScoreAddition
         unsigned long long startIdx = getSynapseStartIndex();
         unsigned long long endIdx = getSynapseEndIndex();
 
-        // Clear counts
-        setMem(incomingCount, sizeof(incomingCount), 0);
+        setMem(incomingPositiveCount, sizeof(incomingPositiveCount), 0);
+        setMem(incomingNegativeCount, sizeof(incomingNegativeCount), 0);
 
-        // Convert outgoing synapses to incoming ones
         for (unsigned long long n = 0; n < population; n++)
         {
             const Synapse* kSynapses = getSynapses(n);
@@ -715,11 +924,16 @@ struct ScoreAddition
                 long long offset = bufferIndexToOffset(synIdx);
                 unsigned long long nnIndex = clampNeuronIndex((long long)n, offset);
 
-                unsigned int idx = incomingCount[nnIndex]++;
-                incomingSynapses[nnIndex * maxNumberOfNeighbors + idx] = weight;
-
-                // Cache the incomming neuron
-                incomingSource[nnIndex * maxNumberOfNeighbors + idx] = (unsigned int)n;
+                if (weight > 0)
+                {
+                    unsigned int idx = incomingPositiveCount[nnIndex]++;
+                    incomingPositiveSource[nnIndex * maxNumberOfNeighbors + idx] = (unsigned int)n;
+                }
+                else
+                {
+                    unsigned int idx = incomingNegativeCount[nnIndex]++;
+                    incomingNegativeSource[nnIndex * maxNumberOfNeighbors + idx] = (unsigned int)n;
+                }
             }
         }
     }
@@ -799,10 +1013,11 @@ struct ScoreAddition
                 if (writePos != s)
                 {
                     sampleMapping[writePos] = sampleMapping[s];
-                    for (unsigned long long n = 0; n < population; n++)
+                    for (unsigned long long n = 0; n < numProcessNeuron; n++)
                     {
-                        neuronValues[n * PADDED_SAMPLES + writePos] = neuronValues[n * PADDED_SAMPLES + s];
-                        prevNeuronValues[n * PADDED_SAMPLES + writePos] = prevNeuronValues[n * PADDED_SAMPLES + s];
+                        unsigned long long baseIdx = processNeuronOffsetCache[n];
+                        neuronValues[baseIdx + writePos] = neuronValues[baseIdx + s];
+                        prevNeuronValues[baseIdx + writePos] = prevNeuronValues[baseIdx + s];
                     }
                 }
                 writePos++;
@@ -900,9 +1115,9 @@ struct ScoreAddition
                     _mm512_storeu_si512((__m512i*)&sampleMapping[writePos + 48], map3);
 
                     // Neuron is char, 1 copy is enough
-                    for (unsigned long long n = 0; n < population; n++)
+                    for (unsigned long long n = 0; n < numProcessNeuron; n++)
                     {
-                        unsigned long long baseIdx = n * PADDED_SAMPLES;
+                        unsigned long long baseIdx = processNeuronOffsetCache[n];
 
                         __m512i curr = _mm512_loadu_si512((__m512i*)&neuronValues[baseIdx + s]);
                         __m512i prev = _mm512_loadu_si512((__m512i*)&prevNeuronValues[baseIdx + s]);
@@ -920,7 +1135,7 @@ struct ScoreAddition
                 // Load 4 blocks of 16 samples to adjust the sample index
                 static_assert(BATCH_SIZE / 16 == 4, "Compress loop assumes BATCH_SIZE / 16 == 4");
                 int offset = 0;
-                for (unsigned long long blockId = 0; blockId < BATCH_SIZE; blockId +=16)
+                for (unsigned long long blockId = 0; blockId < BATCH_SIZE; blockId += 16)
                 {
                     __mmask16 k16 = (__mmask16)((activeMask >> blockId) & 0xFFFF);
                     __m512i map = _mm512_loadu_si512((__m512i*)&sampleMapping[s + blockId]);
@@ -931,9 +1146,9 @@ struct ScoreAddition
 
 
                 // Adjust the neurons and previous neuron values
-                unsigned long long baseIdx = 0;
-                for (unsigned long long n = 0; n < population; n++, baseIdx += PADDED_SAMPLES)
+                for (unsigned long long n = 0; n < numProcessNeuron; n++)
                 {
+                    unsigned long long baseIdx = processNeuronOffsetCache[n];
                     __m512i curr = _mm512_loadu_si512((__m512i*)&neuronValues[baseIdx + s]);
                     __m512i prev = _mm512_loadu_si512((__m512i*)&prevNeuronValues[baseIdx + s]);
 
@@ -961,16 +1176,16 @@ struct ScoreAddition
             for (unsigned long long i = 0; i < numCachedOutputs; i++)
             {
                 unsigned long long n = outputNeuronIdxCache[i];
-                __m256i curr = _mm256_loadu_si256((__m256i*) &neuronValues[n * PADDED_SAMPLES + s]);
-                __m256i prev = _mm256_loadu_si256((__m256i*) &prevNeuronValues[n * PADDED_SAMPLES + s]);
+                __m256i curr = _mm256_loadu_si256((__m256i*) & neuronValues[n * PADDED_SAMPLES + s]);
+                __m256i prev = _mm256_loadu_si256((__m256i*) & prevNeuronValues[n * PADDED_SAMPLES + s]);
                 __m256i diff = _mm256_xor_si256(curr, prev);
                 unchangedVec = _mm256_andnot_si256(diff, unchangedVec);
             }
             for (unsigned long long i = 0; i < numCachedEvolution; i++)
             {
                 unsigned long long n = evolutionNeuronIdxCache[i];
-                __m256i curr = _mm256_loadu_si256((__m256i*)&neuronValues[n * PADDED_SAMPLES + s]);
-                __m256i prev = _mm256_loadu_si256((__m256i*)&prevNeuronValues[n * PADDED_SAMPLES + s]);
+                __m256i curr = _mm256_loadu_si256((__m256i*) & neuronValues[n * PADDED_SAMPLES + s]);
+                __m256i prev = _mm256_loadu_si256((__m256i*) & prevNeuronValues[n * PADDED_SAMPLES + s]);
                 __m256i diff = _mm256_xor_si256(curr, prev);
                 unchangedVec = _mm256_andnot_si256(diff, unchangedVec);
             }
@@ -1029,15 +1244,15 @@ struct ScoreAddition
                     __m256i map1 = _mm256_loadu_si256((__m256i*) & sampleMapping[s + 8]);
                     __m256i map2 = _mm256_loadu_si256((__m256i*) & sampleMapping[s + 16]);
                     __m256i map3 = _mm256_loadu_si256((__m256i*) & sampleMapping[s + 24]);
-                    _mm256_storeu_si256((__m256i*)& sampleMapping[writePos + 0], map0);
-                    _mm256_storeu_si256((__m256i*)& sampleMapping[writePos + 8], map1);
-                    _mm256_storeu_si256((__m256i*)& sampleMapping[writePos + 16], map2);
-                    _mm256_storeu_si256((__m256i*)& sampleMapping[writePos + 24], map3);
+                    _mm256_storeu_si256((__m256i*) & sampleMapping[writePos + 0], map0);
+                    _mm256_storeu_si256((__m256i*) & sampleMapping[writePos + 8], map1);
+                    _mm256_storeu_si256((__m256i*) & sampleMapping[writePos + 16], map2);
+                    _mm256_storeu_si256((__m256i*) & sampleMapping[writePos + 24], map3);
 
                     // Neuron is char, 1 copy is enough
-                    for (unsigned long long n = 0; n < population; n++)
+                    for (unsigned long long n = 0; n < numProcessNeuron; n++)
                     {
-                        unsigned long long baseIdx = n * PADDED_SAMPLES;
+                        unsigned long long baseIdx = processNeuronOffsetCache[n];
 
                         __m256i curr = _mm256_loadu_si256((__m256i*) & neuronValues[baseIdx + s]);
                         __m256i prev = _mm256_loadu_si256((__m256i*) & prevNeuronValues[baseIdx + s]);
@@ -1062,9 +1277,9 @@ struct ScoreAddition
                 }
 
                 // Separate update for better caching
-                for (unsigned long long n = 0; n < population; n++)
+                for (unsigned long long n = 0; n < numProcessNeuron; n++)
                 {
-                    unsigned long long baseIdx = n * PADDED_SAMPLES;
+                    unsigned long long baseIdx = processNeuronOffsetCache[n];
                     mask = (unsigned int)activeMask;
                     writeOffset = 0;
                     while (mask != 0)
@@ -1109,9 +1324,7 @@ struct ScoreAddition
             }
             activeCount = trainingSetSize;
 
-            // Load the training set and fill ANN value
             loadTrainingData();
-            copyMem(prevNeuronValues, neuronValues, population * PADDED_SAMPLES);
 
             // Cache the location of ouput and evolutionneurons
             cacheOutputEvoNeuronIndices();
@@ -1259,36 +1472,17 @@ struct ScoreAddition
             neuronIndices[outputNeuronIdx] = neuronIndices[neuronCount];
         }
 
-        // Synapse weight initialization
-        auto extractWeight = [](unsigned long long packedValue, unsigned long long position) -> char
-            {
-                unsigned char extractValue = static_cast<unsigned char>((packedValue >> (position * 2)) & 0b11);
-                switch (extractValue)
-                {
-                case 2:
-                    return -1;
-                case 3:
-                    return 1;
-                default:
-                    return 0;
-                }
-            };
-        for (unsigned long long i = 0; i < (maxNumberOfSynapses / 32); ++i)
+        // Synapse weight initialization via LUT: each byte encodes 4 weights (2 bits each),
+        // the LUT expands one byte to 4 signed chars in a single 32-bit store.
         {
-            for (unsigned long long j = 0; j < 32; ++j)
+            const unsigned char* packedBytes = (const unsigned char*)initValue->synapseWeight;
+            int32_t* synOut = (int32_t*)synapses;
+            // maxNumberOfSynapses is always a multiple of 4 (populationThreshold * maxNeighbors)
+            static_assert(maxNumberOfSynapses % 4 == 0, "maxNumberOfSynapses must be divisible by 4 for LUT unpacking");
+            const unsigned long long count = maxNumberOfSynapses / 4;
+            for (unsigned long long i = 0; i < count; i++)
             {
-                synapses[32 * i + j] = extractWeight(initValue->synapseWeight[i], j);
-            }
-        }
-
-        // Handle remaining synapses (if maxNumberOfSynapses not divisible by 32)
-        unsigned long long remainder = maxNumberOfSynapses % 32;
-        if (remainder > 0)
-        {
-            unsigned long long lastBlock = maxNumberOfSynapses / 32;
-            for (unsigned long long j = 0; j < remainder; ++j)
-            {
-                synapses[32 * lastBlock + j] = extractWeight(initValue->synapseWeight[lastBlock], j);
+                synOut[i] = synapseWeightLUT[packedBytes[i]];
             }
         }
 
@@ -1298,12 +1492,20 @@ struct ScoreAddition
         return score;
     }
 
+    void copyANN(ANN& dst, const ANN& src)
+    {
+        unsigned long long pop = src.population;
+        copyMem(dst.synapses, src.synapses, pop * maxNumberOfNeighbors * sizeof(Synapse));
+        copyMem(dst.neuronTypes, src.neuronTypes, pop);
+        dst.population = pop;
+    }
+
     // Main function for mining
     unsigned int computeScore(const unsigned char* publicKey, const unsigned char* nonce, const unsigned char* randomPool)
     {
         // Initialize
         unsigned int bestR = initializeANN(publicKey, nonce, randomPool);
-        copyMem(&bestANN, &currentANN, sizeof(bestANN));
+        copyANN(bestANN, currentANN);
 
         for (unsigned long long s = 0; s < numberOfMutations; ++s)
         {
@@ -1324,12 +1526,12 @@ struct ScoreAddition
             {
                 bestR = R;
                 // Better R. Save the state
-                copyMem(&bestANN, &currentANN, sizeof(bestANN));
+                copyANN(bestANN, currentANN);
             }
             else
             {
                 // Roll back
-                copyMem(&currentANN, &bestANN, sizeof(bestANN));
+                copyANN(currentANN, bestANN);
             }
 
             ASSERT(bestANN.population <= populationThreshold);

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -12,6 +12,9 @@
 
 #define MAX_NUMBER_OF_PROCESSORS 32
 #define NUMBER_OF_SOLUTION_PROCESSORS 12
+// Maximum number of NUMBER_OF_SOLUTION_PROCESSORS can be used for pre-process the mining solution
+// Must not exceed half of NUMBER_OF_SOLUTION_PROCESSORS. Set 0 to disable.
+#define NUMBER_OF_PREPROCESS_SOLUTION_PROCESSORS 4
 
 // Number of buffers available for executing contract functions in parallel; having more means reserving a bit more RAM (+1 = +32 MB)
 // and less waiting in request processors if there are more parallel contract function requests. The maximum value that may make sense

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -104,7 +104,7 @@ static constexpr unsigned long long ADDITION_NUMBER_OF_INPUT_NEURONS = 14;     /
 static constexpr unsigned long long ADDITION_NUMBER_OF_OUTPUT_NEURONS = 8;    // L
 static constexpr unsigned long long ADDITION_NUMBER_OF_TICKS = 1000;               // N
 static constexpr unsigned long long ADDITION_NUMBER_OF_NEIGHBORS = 728;    // 2M. Must be divided by 2
-static constexpr unsigned long long ADDITION_NUMBER_OF_MUTATIONS = 300;
+static constexpr unsigned long long ADDITION_NUMBER_OF_MUTATIONS = 500;
 static constexpr unsigned long long ADDITION_POPULATION_THRESHOLD = ADDITION_NUMBER_OF_INPUT_NEURONS + ADDITION_NUMBER_OF_OUTPUT_NEURONS + ADDITION_NUMBER_OF_MUTATIONS; // P
 static constexpr unsigned int ADDITION_SOLUTION_THRESHOLD_DEFAULT = 75200;
 

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -189,6 +189,11 @@ static unsigned long long contractProcessorIDs[MAX_NUMBER_OF_PROCESSORS]; // a l
 
 static unsigned long long solutionProcessorIDs[MAX_NUMBER_OF_PROCESSORS]; // a list of proc id that will process solution
 static bool solutionProcessorFlags[MAX_NUMBER_OF_PROCESSORS]; // flag array to indicate that whether a procId should help processing solutions or not
+static bool preprocessSolutionFlags[MAX_NUMBER_OF_PROCESSORS]; // subset of solution processors for pre-computing scores at broadcast time
+static_assert(
+    NUMBER_OF_PREPROCESS_SOLUTION_PROCESSORS <= NUMBER_OF_SOLUTION_PROCESSORS / 2,
+    "NUMBER_OF_PREPROCESS_SOLUTION_PROCESSORS must not exceed half of NUMBER_OF_SOLUTION_PROCESSORS");
+
 static int nTickProcessorIDs = 0;
 static int nRequestProcessorIDs = 0;
 static int nContractProcessorIDs = 0;
@@ -980,7 +985,7 @@ static void processBroadcastFutureTickData(Peer* peer, RequestResponseHeader* he
     }
 }
 
-static void processBroadcastTransaction(Peer* peer, RequestResponseHeader* header)
+static void processBroadcastTransaction(Peer* peer, RequestResponseHeader* header, unsigned long long processorNumber)
 {
     Transaction* request = header->getPayload<Transaction>();
     const unsigned int transactionSize = request->totalSize();
@@ -1038,6 +1043,23 @@ static void processBroadcastTransaction(Peer* peer, RequestResponseHeader* heade
                 }
             }
             ts.tickData.releaseLock();
+
+            // Pre-compute score for mining solution transactions to populate the scoreCache.
+            // This hides computation latency: the solution is published ~3 ticks before execution,
+            // so all 676 Computors get a cache HIT during processTickTransactionSolution().
+            // Only designated solution processors do this to avoid starving request processing.
+            // The deposit and balance of must be >= MiningSolutionTransaction::minAmount() to be proccessed
+            if (preprocessSolutionFlags[processorNumber]
+                && MiningSolutionTransaction::isSolutionTransaction(request))
+            {
+                const int spectrumIdx = spectrumIndex(request->sourcePublicKey);
+                if (spectrumIdx >= 0 && energy(spectrumIdx) >= MiningSolutionTransaction::minAmount())
+                {
+                    const m256i& solutionMiningSeed = *(m256i*)request->inputPtr();
+                    const m256i& solutionNonce = *(m256i*)(request->inputPtr() + 32);
+                    (*score)(processorNumber, request->sourcePublicKey, solutionMiningSeed, solutionNonce);
+                }
+            }
 
             // shortcut: oracle reply reveal transactions are analyzed immediately after receiving them (before execution of the tx),
             // in order to minimize the number of reveal transaction (one per oracle query is enough, so no reveal tx is generated
@@ -2207,7 +2229,7 @@ static void requestProcessor(void* ProcedureArgument)
 
                 case BROADCAST_TRANSACTION:
                 {
-                    processBroadcastTransaction(peer, header);
+                    processBroadcastTransaction(peer, header, processorNumber);
                 }
                 break;
 
@@ -7328,6 +7350,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
         for (int i = 0; i < MAX_NUMBER_OF_PROCESSORS; i++)
         {
             solutionProcessorFlags[i] = false;
+            preprocessSolutionFlags[i] = false;
         }
 
         for (unsigned int i = 0; i < numberOfAllProcessors && numberOfProcessors < MAX_NUMBER_OF_PROCESSORS; i++)
@@ -7379,6 +7402,10 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                     {
                         solutionProcessorFlags[i % NUMBER_OF_SOLUTION_PROCESSORS] = true;
                         solutionProcessorFlags[i] = true;
+                        if (nSolutionProcessorIDs < NUMBER_OF_PREPROCESS_SOLUTION_PROCESSORS)
+                        {
+                            preprocessSolutionFlags[i] = true;
+                        }
                         solutionProcessorIDs[nSolutionProcessorIDs++] = i;
                     }
                 }


### PR DESCRIPTION
This PR,
- Speed up the addition score computation
- More score caching by doing scoring in processBroadcastTransaction.
- Increase ADDITION_NUMBER_OF_MUTATIONS to 500.