### PR TITLE
Don't record own computor's duplicated invalid nonce.

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -2903,14 +2903,6 @@ static void processTickTransactionSolution(const MiningSolutionTransaction* tran
                         break;
                     }
                 }
-                if (j == system.numberOfSolutions
-                    && system.numberOfSolutions < MAX_NUMBER_OF_SOLUTIONS)
-                {
-                    system.solutions[system.numberOfSolutions].computorPublicKey = transaction->sourcePublicKey;
-                    system.solutions[system.numberOfSolutions].miningSeed = transaction->miningSeed;
-                    system.solutions[system.numberOfSolutions].nonce = transaction->nonce;
-                    solutionPublicationTicks[system.numberOfSolutions++] = SOLUTION_RECORDED_FLAG;
-                }
 
                 RELEASE(solutionsLock);
 


### PR DESCRIPTION
This PR fix unvalidated solutions recorded in system.solutions on duplicate submission.

In `processTickTransactionSolution`, when `minerSolutionFlags` detects a duplicate (publicKey, miningSeed, nonce), the else branch skips scoring but still records into system.solutions[] if the entry doesn't exist. This allows invalid solutions (rejected on first submission) to be recorded on second submission without any score check.
This bug is limited to the node's own F2 display and solution publication, `minerScores` are unaffected.

**Fix**: remove the unconditional add new entry block from the duplicate path. The existing dedup search and SOLUTION_RECORDED_FLAG marking for legitimate entries is preserved.