### PR TITLE
Fix compiler-dependent behavior with input qpi bit outside range 0/1

### DIFF
--- a/doc/contracts.md
+++ b/doc/contracts.md
@@ -612,8 +612,11 @@ Global constants, structs and classes must begin with the name of the contract s
 
 There is a limit for recursion and depth of nested contract function / procedure calls (the limit is 10 at the moment).
 
-The input and output structs of contract user procedures and functions may only use integer and boolean types (such as `uint64`, `sint8`, `bit`) as well as `id`, `Array`, and `BitArray`, and struct types containing only allowed types.
+The input and output structs of contract user procedures and functions may only use integer types (such as `uint64`, `sint8`, `bit`) as well as `id`, `Array`, and `BitArray`, and struct types containing only allowed types.
 Complex types that may have an inconsistent internal state, such as `Collection`, are forbidden in the public interface of a contract.
+
+Please note that `bit` is defined as an 8-byte integer type, because the contract execution runtime cannot enforce that input variables with the `bit` type always have the values 0 or 1 only, which some compilers assume when generating code using boolean variables.
+If your code requires the input `bit varName` to be either 0 or 1 (integer representation of false or true), with mapping all non-zero to 1, you may just ensure this in your contract code by running `input.varName = !!input.varName;`.
 
 
 ## General Change Management

--- a/doc/contracts.md
+++ b/doc/contracts.md
@@ -612,11 +612,8 @@ Global constants, structs and classes must begin with the name of the contract s
 
 There is a limit for recursion and depth of nested contract function / procedure calls (the limit is 10 at the moment).
 
-The input and output structs of contract user procedures and functions may only use integer types (such as `uint64`, `sint8`, `bit`) as well as `id`, `Array`, and `BitArray`, and struct types containing only allowed types.
+The input and output structs of contract user procedures and functions may only use integer and boolean types (such as `uint64`, `sint8`, `bit`) as well as `id`, `Array`, and `BitArray`, and struct types containing only allowed types.
 Complex types that may have an inconsistent internal state, such as `Collection`, are forbidden in the public interface of a contract.
-
-Please note that `bit` is defined as an 8-byte integer type, because the contract execution runtime cannot enforce that input variables with the `bit` type always have the values 0 or 1 only, which some compilers assume when generating code using boolean variables.
-If your code requires the input `bit varName` to be either 0 or 1 (integer representation of false or true), with mapping all non-zero to 1, you may just ensure this in your contract code by running `input.varName = !!input.varName;`.
 
 
 ## General Change Management

--- a/src/contract_core/qpi_spectrum_impl.h
+++ b/src/contract_core/qpi_spectrum_impl.h
@@ -4,7 +4,7 @@
 #include "spectrum/spectrum.h"
 
 
-bool QPI::QpiContextFunctionCall::getEntity(const m256i& id, QPI::Entity& entity) const
+QPI::bit QPI::QpiContextFunctionCall::getEntity(const m256i& id, QPI::Entity& entity) const
 {
     int index = spectrumIndex(id);
     if (index < 0)

--- a/src/contract_core/qpi_trivial_impl.h
+++ b/src/contract_core/qpi_trivial_impl.h
@@ -102,7 +102,7 @@ unsigned char QPI::QpiContextFunctionCall::dayOfWeek(unsigned char year, unsigne
 	return dayIndex(year, month, day) % 7;
 }
 
-bool QPI::QpiContextFunctionCall::signatureValidity(const m256i& entity, const m256i& digest, const Array<signed char, 64>& signature) const
+QPI::bit QPI::QpiContextFunctionCall::signatureValidity(const m256i& entity, const m256i& digest, const Array<signed char, 64>& signature) const
 {
 	return verify(entity.m256i_u8, digest.m256i_u8, reinterpret_cast<const unsigned char*>(&signature));
 }

--- a/src/contracts/QBond.h
+++ b/src/contracts/QBond.h
@@ -924,11 +924,11 @@ protected:
 
         if (input.operation == 0)
         {
-            output.result = state.mut()._commissionFreeAddresses.remove(input.user);
+            output.result = state.mut()._commissionFreeAddresses.remove(input.user) != NULL_INDEX;
         }
         else
         {
-            output.result = state.mut()._commissionFreeAddresses.add(input.user);
+            output.result = state.mut()._commissionFreeAddresses.add(input.user) != NULL_INDEX;
         }
     }
 

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -39,7 +39,7 @@ namespace QPI
 
 	*/
 
-	typedef bool bit;
+	typedef char bit;
 	typedef signed char sint8;
 	typedef unsigned char uint8;
 	typedef signed short sint16;

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -39,7 +39,21 @@ namespace QPI
 
 	*/
 
-	typedef char bit;
+	// Boolean type ensuring that input values > 1 are mapped to 1.
+	struct bit
+	{
+		bit(bool v = false) : charValue(v)
+		{
+		}
+
+		operator bool() const
+		{
+			return !!charValue;
+		}
+
+		char charValue;
+	};
+
 	typedef signed char sint8;
 	typedef unsigned char uint8;
 	typedef signed short sint16;

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -854,6 +854,8 @@ namespace QPI
 		// Set bit with given index to the given value
 		inline void set(uint64 index, bit value)
 		{
+			// before setting the bit, make sure value is casted from char to bool (integer value 0 or 1 only)
+			value = !!value;
 			_values[(index >> 6) & (_elements - 1)] = (_values[(index >> 6) & (_elements - 1)] & (~(1ULL << (index & 63)))) | (((uint64)value) << (index & 63));
 		}
 

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -854,8 +854,6 @@ namespace QPI
 		// Set bit with given index to the given value
 		inline void set(uint64 index, bit value)
 		{
-			// before setting the bit, make sure value is casted from char to bool (integer value 0 or 1 only)
-			value = !!value;
 			_values[(index >> 6) & (_elements - 1)] = (_values[(index >> 6) & (_elements - 1)] & (~(1ULL << (index & 63)))) | (((uint64)value) << (index & 63));
 		}
 

--- a/test/qpi.cpp
+++ b/test/qpi.cpp
@@ -189,6 +189,37 @@ TEST(TestCoreQPI, Array)
         EXPECT_EQ((int)uint16_2.get(i), (int)(((2*i+2) << 8) | (2*i + 1)));
 }
 
+
+TEST(TestCoreQPI, Bit)
+{
+    QPI::bit b1;
+    EXPECT_EQ(b1, false);
+    EXPECT_EQ(b1, 0);
+
+    QPI::bit b2 = true;
+    EXPECT_EQ(b2, true);
+    EXPECT_EQ(b2, 1);
+
+    QPI::bit b3;
+    for (int i = 0; i < 256; ++i)
+    {
+        char c = i + INT8_MIN;
+        b3.charValue = c;
+        EXPECT_EQ(b3, c != 0);
+    }
+
+    EXPECT_TRUE(b1 != b2);
+    EXPECT_FALSE(b1 == b2);
+    EXPECT_TRUE(b1 != b3);
+    EXPECT_FALSE(b1 == b3);
+    EXPECT_TRUE(b2 == b3);
+    EXPECT_FALSE(b2 != b3);
+
+    b1 = b3;
+    EXPECT_TRUE(b1 == b3);
+    EXPECT_FALSE(b1 != b3);
+}
+
 TEST(TestCoreQPI, BitArray)
 {
     //QPI::BitArray<0> mustFail;
@@ -206,6 +237,15 @@ TEST(TestCoreQPI, BitArray)
     b1.set(0, 0);
     EXPECT_EQ(b1.get(0), 0);
     b1.set(0, true);
+    EXPECT_EQ(b1.get(0), 1);
+
+    // test with bit from user input outside 0-1 range
+    QPI::bit bit;
+    bit.charValue = 2;
+    b1.set(0, bit);
+    EXPECT_EQ(b1.get(0), 1);
+    bit.charValue = 3;
+    b1.set(0, bit);
     EXPECT_EQ(b1.get(0), 1);
 
     b1.setAll(0);


### PR DESCRIPTION
## Problem

So far, `QPI::bit` was defined as `bool`, making some compilers assume that a byte of this type can only have the values 0 or 1. 
As reported by dkat, some compilers translate an `if (bitValue)` to `cmpb 0, bitValue; jne FALSE_CASE;` and some generate `cmpb 1, bitValue; jne TRUE_CASE;`. This inconsistency is a problem when contract input bit variables are sent that are outside the expected range of [0, 1]. For example, some devs have sent the char '0' (integer representation 48) in a bit variable as contract input.

## Solution

In order to prevent that the compiler assumes the values 0 or 1 only, `QPI::bit` is defined as a struct with a member of type `char` with this fix PR. It provides a conversion operator mapping the char that may have arbitrary value to a correct bool (value 0 -> 0 and non-0 -> 1).