### PR TITLE
Doge share validation: full task info and verify oracle reply

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -26,9 +26,10 @@ The following transaction types (`tx->inputType`) are defined:
 - `FileTrailerTransaction`, type 5, defined in `src/files/files.h`.
 - `OracleReplyCommitTransactionPrefix`, type 6, defined in `src/oracle_core/oracle_transactions.h`.
 - `OracleReplyRevealTransactionPrefix`, type 7, defined in `src/oracle_core/oracle_transactions.h`.
-- `CustomMiningSolutionTransaction`, type 8, defined in `src/mining/mining.h`.
+- `CustomMiningSolutionTransaction`, type 8, defined in `src/mining/mining.h`. (will be reclaimed if XMR is removed)
 - `ExecutionFeeReportTransactionPrefix`, type 9, defined in `src/network_messages/execution_fees.h`.
 - `OracleUserQueryTransactionPrefix`, type 10, defined in `src/oracle_core/oracle_transactions.h`.
+- `DogeMiningShareTransaction`, type 11, defined in `src/mining/mining.h`.
 
 
 ## Peer Sharing

--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -264,15 +264,20 @@ bool CustomQubicMiningStorage::isQueryEqual(uint8_t customMiningType, unsigned i
 {
     if (customMiningType == CustomMiningType::DOGE)
     {
+        // A doge query is treated as equal if the jobId and the solution (nonce, extraNonce2, time) are all the same.
         const auto* dogeQuery = reinterpret_cast<const OI::DogeShareValidation::OracleQuery*>(typeSpecificOracleQuery);
+        if (dogeQuery->jobId != dogeOracleQueries[queryIndex].jobId)
+            return false;
         for (int i = 0; i < 4; ++i)
         {
             if (dogeQuery->solutionNonce.get(i) != dogeOracleQueries[queryIndex].solutionNonce.get(i))
                 return false;
+            if (dogeQuery->solutionTime.get(i) != dogeOracleQueries[queryIndex].solutionTime.get(i))
+                return false;
         }
-        for (int i = 0; i < 32; ++i)
+        for (int i = 0; i < 8; ++i)
         {
-            if (dogeQuery->taskPartialHeaderPrevBlockHash.get(i) != dogeOracleQueries[queryIndex].taskPartialHeaderPrevBlockHash.get(i))
+            if (dogeQuery->solutionExtraNonce2.get(i) != dogeOracleQueries[queryIndex].solutionExtraNonce2.get(i))
                 return false;
         }
         return true;

--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -374,6 +374,9 @@ bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsign
 
             if (additionalDataSize > 0)
                 copyMem(dogeTasks[nextDogeTaskId].additionalData, taskAsCharPtr + combinedTaskStructSize, additionalDataSize);
+            // Zero out the leftover tail.
+            if (additionalDataSize < OI::DogeShareValidation::OracleQuery::additionalDataSize)
+                setMem(dogeTasks[nextDogeTaskId].additionalData + additionalDataSize, OI::DogeShareValidation::OracleQuery::additionalDataSize - additionalDataSize, 0);
 
             typeSpecificTaskIndex = nextDogeTaskId;
             nextDogeTaskId = (nextDogeTaskId + 1) % maxNumTasks;

--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -17,7 +17,7 @@
 class CustomQubicMiningStorage
 {
 public:
-    static constexpr unsigned int scheduleOracleQueryTickOffset = 8; // offset of 8 ticks to ensure propagation through the network
+    static constexpr unsigned int scheduleOracleQueryTickOffset = 6; // offset of 6 ticks to ensure propagation through the network
 
     static constexpr unsigned int maxNumTasks = 16;
 

--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -10,6 +10,7 @@
 #include "oracle_core/oracle_interfaces_def.h"
 #include "network_messages/custom_mining.h"
 #include "contract_core/qpi_hash_map_impl.h"
+#include "oracle_core/oracle_interfaces_def.h"
 #include "kangaroo_twelve.h"
 
 
@@ -23,12 +24,26 @@ public:
     // A struct for storing an active doge mining task on the node.
     struct StoredDogeMiningTask
     {
+        uint64_t jobId;
+
         uint8_t dispatcherTarget[32]; // dispatcher target, usually easier than pool and network difficulty, full 32-byte representation
 
-        // Full header can be constructed via concatenating version + prevHash + merkleRoot + miner's nTime + nBits + miner's nonce.
         uint8_t version[4]; // 4 bytes version
-        uint8_t prevHash[32]; // 32 bytes prevBlockHash
         uint8_t nBits[4]; // 4 bytes network difficulty (nBits)
+        uint8_t prevHash[32]; // 32 bytes prevBlockHash
+        uint32_t extraNonce1NumBytes;
+        uint32_t coinbase1NumBytes;
+        uint32_t coinbase2NumBytes;
+        uint32_t numMerkleBranches;
+
+        uint8_t additionalData[OI::DogeShareValidation::OracleQuery::additionalDataSize];
+        // Layout for additional data:
+        // - extraNonce1
+        // - coinbase1
+        // - coinbase2
+        // - merkleBranch1NumBytes (unsigned int), ... , merkleBranchNNumBytes (unsigned int)
+        // - merkleBranch1, ... , merkleBranchN
+        // Note: The size of the components contained in the additional data varies, hence the total occupied bytes in the array is not fixed.
     };
 
     enum OracleQueryStatus : uint8_t
@@ -312,10 +327,17 @@ bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsign
         if (task->customMiningType == CustomMiningType::DOGE)
         {
             // Type-specific task info is stored behind general CustomQubicMiningTask struct.
-            if (size < sizeof(CustomQubicMiningTask) + sizeof(QubicDogeMiningTask))
+            static constexpr unsigned int combinedTaskStructSize = sizeof(CustomQubicMiningTask) + sizeof(QubicDogeMiningTask);
+            if (size < combinedTaskStructSize)
                 return false;
+            unsigned int additionalDataSize = size - combinedTaskStructSize;
+            if (additionalDataSize > OI::DogeShareValidation::OracleQuery::additionalDataSize)
+                return false;
+
+            const auto* taskAsCharPtr = reinterpret_cast<const char*>(task);
+
             unsigned int& nextDogeTaskId = nextTaskIndex[CustomMiningType::DOGE];
-            const QubicDogeMiningTask* dogeTask = reinterpret_cast<const QubicDogeMiningTask*>(reinterpret_cast<const char*>(task) + sizeof(CustomQubicMiningTask));
+            const QubicDogeMiningTask* dogeTask = reinterpret_cast<const QubicDogeMiningTask*>(taskAsCharPtr + sizeof(CustomQubicMiningTask));
             if (dogeTask->cleanJobQueue)
             {
                 setMem(activeTasks[CustomMiningType::DOGE], maxNumTasks * sizeof(uint64_t), 0);
@@ -329,10 +351,19 @@ bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsign
                 // If not cleaning job queue, we will override the oldest task. Clean the corresponding solution hash set.
                 receivedSolutions[CustomMiningType::DOGE * maxNumTasks + nextDogeTaskId].reset();
             }
+            dogeTasks[nextDogeTaskId].jobId = task->jobId;
             convertTargetCompactToFull(dogeTask->dispatcherDifficulty, dogeTasks[nextDogeTaskId].dispatcherTarget);
-            copyMem(dogeTasks[nextDogeTaskId].nBits, dogeTask->nBits, 4);
             copyMem(dogeTasks[nextDogeTaskId].version, dogeTask->version, 4);
+            copyMem(dogeTasks[nextDogeTaskId].nBits, dogeTask->nBits, 4);
             copyMem(dogeTasks[nextDogeTaskId].prevHash, dogeTask->prevHash, 32);
+            dogeTasks[nextDogeTaskId].extraNonce1NumBytes = dogeTask->extraNonce1NumBytes;
+            dogeTasks[nextDogeTaskId].coinbase1NumBytes = dogeTask->coinbase1NumBytes;
+            dogeTasks[nextDogeTaskId].coinbase2NumBytes = dogeTask->coinbase2NumBytes;
+            dogeTasks[nextDogeTaskId].numMerkleBranches = dogeTask->numMerkleBranches;
+
+            if (additionalDataSize > 0)
+                copyMem(dogeTasks[nextDogeTaskId].additionalData, taskAsCharPtr + combinedTaskStructSize, additionalDataSize);
+
             typeSpecificTaskIndex = nextDogeTaskId;
             nextDogeTaskId = (nextDogeTaskId + 1) % maxNumTasks;
         }

--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -19,7 +19,7 @@ class CustomQubicMiningStorage
 public:
     static constexpr unsigned int scheduleOracleQueryTickOffset = 8; // offset of 8 ticks to ensure propagation through the network
 
-    static constexpr unsigned int maxNumTasks = 32;
+    static constexpr unsigned int maxNumTasks = 16;
 
     // A struct for storing an active doge mining task on the node.
     struct StoredDogeMiningTask
@@ -343,19 +343,10 @@ bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsign
 
             unsigned int& nextDogeTaskId = nextTaskIndex[CustomMiningType::DOGE];
             const QubicDogeMiningTask* dogeTask = reinterpret_cast<const QubicDogeMiningTask*>(taskAsCharPtr + sizeof(CustomQubicMiningTask));
-            if (dogeTask->cleanJobQueue)
-            {
-                setMem(activeTasks[CustomMiningType::DOGE], maxNumTasks * sizeof(uint64_t), 0);
-                for (int t = 0; t < maxNumTasks; ++t)
-                    receivedSolutions[CustomMiningType::DOGE * maxNumTasks + t].reset();
-                setMem(dogeTasks, sizeof(dogeTasks), 0);
-                nextDogeTaskId = 0;
-            }
-            else
-            {
-                // If not cleaning job queue, we will override the oldest task. Clean the corresponding solution hash set.
-                receivedSolutions[CustomMiningType::DOGE * maxNumTasks + nextDogeTaskId].reset();
-            }
+
+            // If maxNumTasks is already reached, we will override the oldest task. Clean the corresponding solution hash set.
+            receivedSolutions[CustomMiningType::DOGE * maxNumTasks + nextDogeTaskId].reset();
+
             dogeTasks[nextDogeTaskId].jobId = task->jobId;
             convertTargetCompactToFull(dogeTask->dispatcherDifficulty, dogeTasks[nextDogeTaskId].dispatcherTarget);
             copyMem(dogeTasks[nextDogeTaskId].version, dogeTask->version, 4);

--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -17,7 +17,7 @@
 class CustomQubicMiningStorage
 {
 public:
-    static constexpr unsigned int scheduleOracleQueryTickOffset = 6; // offset of 6 ticks to ensure propagation through the network
+    static constexpr unsigned int scheduleOracleQueryTickOffset = 8; // offset of 8 ticks to ensure propagation through the network
 
     static constexpr unsigned int maxNumTasks = 16;
 

--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -93,6 +93,9 @@ public:
     // the task description is written into the provided pointer.
     int addSolution(const CustomQubicMiningSolution* solution, unsigned int size, unsigned char* taskDescription = nullptr);
 
+    // Return true if the solution belongs to an active task and has not been counted for revenue points before, false otherwise.
+    bool countSolutionForRevenue(uint8_t customMiningType, uint64_t jobId, const m256i& solutionHash);
+
     // Return true if there is an active task with the given jobId and customMiningType, false otherwise.
     bool containsTask(uint8_t customMiningType, uint64_t jobId);
 
@@ -138,10 +141,17 @@ private:
     unsigned int nextTaskIndex[CustomMiningType::TOTAL_NUM_TYPES];
     OracleQueryInfo oracleQueries[CustomMiningType::TOTAL_NUM_TYPES][maxNumTasks * maxNumSolutionsPerTask];
 
-    // For each task, we store a set of received solution hashes to prevent duplicate solutions.
+    // For each task, we store a set of received solution hashes to prevent sending oracle queries for duplicate solutions.
+    // Currently, only own solutions (i.e. from any comp index running on the node) are stored.
     // Two-dimensional array [CustomMiningType::TOTAL_NUM_TYPES][maxNumTasks] indexed by mining type and type-specific task index.
     QPI::HashSet<m256i, maxNumSolutionsPerTask>* receivedSolutions;
     static constexpr unsigned long long receivedSolutionsSize = CustomMiningType::TOTAL_NUM_TYPES * maxNumTasks * sizeof(QPI::HashSet<m256i, maxNumSolutionsPerTask>);
+
+    // For each task, we store a set of solution hashes that were already counted for revenue points to prevent counting duplicates.
+    // Any solution from any computor that received a valid oracle reply is stored.
+    // Two-dimensional array [CustomMiningType::TOTAL_NUM_TYPES][maxNumTasks] indexed by mining type and type-specific task index.
+    QPI::HashSet<m256i, maxNumSolutionsPerTask>* countedRevSolutions;
+    static constexpr unsigned long long countedRevSolutionsSize = CustomMiningType::TOTAL_NUM_TYPES * maxNumTasks * sizeof(QPI::HashSet<m256i, maxNumSolutionsPerTask>);
 
     // Storage for type-specific task descriptions.
     StoredDogeMiningTask dogeTasks[maxNumTasks];
@@ -307,6 +317,8 @@ bool CustomQubicMiningStorage::init()
 
     if (!allocPoolWithErrorLog(L"CustomQubicMiningStorage::receivedSolutions ", receivedSolutionsSize, (void**)&receivedSolutions, __LINE__))
         return false;
+    if (!allocPoolWithErrorLog(L"CustomQubicMiningStorage::countedRevSolutions ", countedRevSolutionsSize, (void**)&countedRevSolutions, __LINE__))
+        return false;
 
     setMem(dogeTasks, sizeof(dogeTasks), 0);
     setMem(dogeOracleQueries, sizeof(dogeOracleQueries), 0);
@@ -320,6 +332,8 @@ void CustomQubicMiningStorage::deinit()
 {
     if (receivedSolutions)
         freePool(receivedSolutions);
+    if (countedRevSolutions)
+        freePool(countedRevSolutions);
 }
 
 bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsigned int size)
@@ -344,8 +358,9 @@ bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsign
             unsigned int& nextDogeTaskId = nextTaskIndex[CustomMiningType::DOGE];
             const QubicDogeMiningTask* dogeTask = reinterpret_cast<const QubicDogeMiningTask*>(taskAsCharPtr + sizeof(CustomQubicMiningTask));
 
-            // If maxNumTasks is already reached, we will override the oldest task. Clean the corresponding solution hash set.
+            // If maxNumTasks is already reached, we will override the oldest task. Clean the corresponding solution hash sets.
             receivedSolutions[CustomMiningType::DOGE * maxNumTasks + nextDogeTaskId].reset();
+            countedRevSolutions[CustomMiningType::DOGE * maxNumTasks + nextDogeTaskId].reset();
 
             dogeTasks[nextDogeTaskId].jobId = task->jobId;
             convertTargetCompactToFull(dogeTask->dispatcherDifficulty, dogeTasks[nextDogeTaskId].dispatcherTarget);
@@ -407,6 +422,30 @@ int CustomQubicMiningStorage::addSolution(const CustomQubicMiningSolution* solut
     QPI::sint64 indexAdded = receivedSolutions[solution->customMiningType * maxNumTasks + typeSpecificTaskIndex].add(digest);
 
     return (indexAdded == QPI::NULL_INDEX) ? 0 : 1;
+}
+
+bool CustomQubicMiningStorage::countSolutionForRevenue(uint8_t customMiningType, uint64_t jobId, const m256i& solutionHash)
+{
+    if (customMiningType >= CustomMiningType::TOTAL_NUM_TYPES)
+        return false; // unsupported mining type
+
+    LockGuard guard(lock);
+
+    // Check if the solution corresponds to an active task.
+    int typeSpecificTaskIndex = findTask(customMiningType, jobId);
+    if (typeSpecificTaskIndex < 0)
+        return false;
+
+    if (countedRevSolutions[customMiningType * maxNumTasks + typeSpecificTaskIndex].contains(solutionHash))
+        return false;
+
+    // Try to add the solution hash to the hash set for this task. May return NULL_INDEX if the set is full.
+    // If the set ever gets full, we have to increase maxNumSolutionsPerTask.
+    ASSERT(countedRevSolutions[customMiningType * maxNumTasks + typeSpecificTaskIndex].population()
+        < countedRevSolutions[customMiningType * maxNumTasks + typeSpecificTaskIndex].capacity());
+    QPI::sint64 indexAdded = countedRevSolutions[customMiningType * maxNumTasks + typeSpecificTaskIndex].add(solutionHash);
+
+    return (indexAdded != QPI::NULL_INDEX);
 }
 
 bool CustomQubicMiningStorage::containsTask(uint8_t customMiningType, uint64_t jobId)

--- a/src/mining/mining.h
+++ b/src/mining/mining.h
@@ -60,6 +60,16 @@ struct CustomMiningSolutionTransaction : public Transaction
     }
 };
 
+// Define in doc/protocol.md
+constexpr int DOGE_MINING_SHARE_COUNTER_INPUT_TYPE = 11;
+struct DogeMiningShareTransaction : public Transaction
+{
+    static constexpr unsigned char transactionType()
+    {
+        return DOGE_MINING_SHARE_COUNTER_INPUT_TYPE;
+    }
+};
+
 struct CustomMiningTaskV2 {
     unsigned long long taskIndex;
     unsigned char m_template[896];
@@ -139,6 +149,7 @@ struct BroadcastCustomMiningTransaction
 };
 
 static BroadcastCustomMiningTransaction gCustomMiningBroadcastTxBuffer[NUMBER_OF_COMPUTORS];
+static BroadcastCustomMiningTransaction gDogeMiningBroadcastTxBuffer[NUMBER_OF_COMPUTORS];
 
 class CustomMiningSharesCounter
 {
@@ -181,6 +192,7 @@ protected:
     }
 
 public:
+
     static constexpr unsigned int _customMiningSolutionCounterDataSize = sizeof(_shareCount) + sizeof(_accumulatedSharesCount);
     void init()
     {
@@ -1232,6 +1244,7 @@ static CustomMininingCache<CustomMiningSolutionV2CacheEntry, MAX_NUMBER_OF_CUSTO
 
 static CustomMiningStorage gCustomMiningStorage;
 static CustomMiningStats gCustomMiningStats;
+static CustomMiningStats gDogeMiningStats;
 
 
 static int customMiningInitialize()

--- a/src/oracle_interfaces/DogeShareValidation.h
+++ b/src/oracle_interfaces/DogeShareValidation.h
@@ -1,8 +1,3 @@
-#pragma once
-
-#include "network_messages/common_def.h"
-#include "oracle_core/oracle_transactions.h"
-
 using namespace QPI;
 
 /**
@@ -32,9 +27,8 @@ struct DogeShareValidation
         uint32 coinbase2NumBytes;
         uint32 numMerkleBranches;
 
-        static constexpr uint64 additionalDataSize = MAX_INPUT_SIZE
-            - (32 + 4 + 4 + 8 + 4 + 4 + 32 + 4 * sizeof(uint32)) // size of all previous struct members
-            - OracleUserQueryTransactionPrefix::minInputSize();
+        static constexpr uint64 additionalDataSize = MAX_ORACLE_QUERY_SIZE
+            - (32 + 4 + 4 + 8 + 4 + 4 + 32 + 4 * sizeof(uint32)); // size of all previous struct members
 
         uint8 additionalData[additionalDataSize];
         // Layout for additional data:
@@ -46,7 +40,7 @@ struct DogeShareValidation
         // Note: The size of the components contained in the additional data varies, hence the total occupied bytes in the array is not fixed.
     };
 
-    static_assert(sizeof(OracleQuery) + OracleUserQueryTransactionPrefix::minInputSize() == MAX_INPUT_SIZE, "DogeShareValidation::OracleQuery has wrong size");
+    static_assert(sizeof(OracleQuery) == MAX_ORACLE_QUERY_SIZE, "DogeShareValidation::OracleQuery has wrong size");
 
     /// Oracle reply data / output of the oracle machine
     struct OracleReply

--- a/src/oracle_interfaces/DogeShareValidation.h
+++ b/src/oracle_interfaces/DogeShareValidation.h
@@ -1,3 +1,8 @@
+#pragma once
+
+#include "network_messages/common_def.h"
+#include "oracle_core/oracle_transactions.h"
+
 using namespace QPI;
 
 /**
@@ -13,19 +18,41 @@ struct DogeShareValidation
     /// Oracle query data / input to the oracle machine
     struct OracleQuery
     {
-        Array<uint8, 4> taskPartialHeaderVersion;
-        Array<uint8, 32> taskPartialHeaderPrevBlockHash;
-        Array<uint8, 32> solutionMerkleRoot;
-        Array<uint8, 4> solutionTime;
-        Array<uint8, 4> taskPartialHeaderDifficultyNBits;
-        Array<uint8, 4> solutionNonce;
         Array<uint8, 32> target;
+
+        Array<uint8, 4> solutionTime;
+        Array<uint8, 4> solutionNonce;
+        Array<uint8, 8> solutionExtraNonce2;
+        
+        Array<uint8, 4> taskPartialHeaderVersion;
+        Array<uint8, 4> taskPartialHeaderDifficultyNBits;
+        Array<uint8, 32> taskPartialHeaderPrevBlockHash;
+        uint32 extraNonce1NumBytes;
+        uint32 coinbase1NumBytes;
+        uint32 coinbase2NumBytes;
+        uint32 numMerkleBranches;
+
+        static constexpr uint64 additionalDataSize = MAX_INPUT_SIZE
+            - (32 + 4 + 4 + 8 + 4 + 4 + 32 + 4 * sizeof(uint32)) // size of all previous struct members
+            - OracleUserQueryTransactionPrefix::minInputSize();
+
+        uint8 additionalData[additionalDataSize];
+        // Layout for additional data:
+        // - extraNonce1
+        // - coinbase1
+        // - coinbase2
+        // - merkleBranch1NumBytes (unsigned int), ... , merkleBranchNNumBytes (unsigned int)
+        // - merkleBranch1, ... , merkleBranchN
+        // Note: The size of the components contained in the additional data varies, hence the total occupied bytes in the array is not fixed.
     };
+
+    static_assert(sizeof(OracleQuery) + OracleUserQueryTransactionPrefix::minInputSize() == MAX_INPUT_SIZE, "DogeShareValidation::OracleQuery has wrong size");
 
     /// Oracle reply data / output of the oracle machine
     struct OracleReply
     {
         bit isValid;
+        uint32 compIndex;
     };
 
     /// Return query fee, which may depend on the specific query (for example on the oracle).

--- a/src/oracle_interfaces/DogeShareValidation.h
+++ b/src/oracle_interfaces/DogeShareValidation.h
@@ -13,11 +13,13 @@ struct DogeShareValidation
     /// Oracle query data / input to the oracle machine
     struct OracleQuery
     {
-        Array<uint8, 32> target;
+        uint64 jobId;
 
         Array<uint8, 4> solutionTime;
         Array<uint8, 4> solutionNonce;
         Array<uint8, 8> solutionExtraNonce2;
+
+        Array<uint8, 32> target;
         
         Array<uint8, 4> taskPartialHeaderVersion;
         Array<uint8, 4> taskPartialHeaderDifficultyNBits;
@@ -28,7 +30,7 @@ struct DogeShareValidation
         uint32 numMerkleBranches;
 
         static constexpr uint64 additionalDataSize = MAX_ORACLE_QUERY_SIZE
-            - (32 + 4 + 4 + 8 + 4 + 4 + 32 + 4 * sizeof(uint32)); // size of all previous struct members
+            - (sizeof(uint64) + 32 + 4 + 4 + 8 + 4 + 4 + 32 + 4 * sizeof(uint32)); // size of all previous struct members
 
         uint8 additionalData[additionalDataSize];
         // Layout for additional data:
@@ -45,8 +47,8 @@ struct DogeShareValidation
     /// Oracle reply data / output of the oracle machine
     struct OracleReply
     {
-        bit isValid;
         uint32 compIndex;
+        bit isValid;
     };
 
     /// Return query fee, which may depend on the specific query (for example on the oracle).

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -27,7 +27,16 @@ static const unsigned char whiteListPeers[][4] = {
 };
 */
 
-#define SEND_DOGE_ORACLE_QUERIES
+// Enables basic DOGE oracle query handling, i.e. an oracle query tx is broadcasted once when a solution from an associated comp pool arrives.
+#define BASIC_DOGE_ORACLE_QUERIES 1
+// Enables retry mechanisms for DOGE oracle queries where the query tx was either not included in the scheduled tick or the oracle query failed (e.g. timeout).
+#define RETRY_DOGE_ORACLE_QUERIES 1
+
+// DO NOT CHANGE: Basic DOGE oracle queries need to be enabled to support the retry mechanisms.
+#if RETRY_DOGE_ORACLE_QUERIES && !BASIC_DOGE_ORACLE_QUERIES
+#undef BASIC_DOGE_ORACLE_QUERIES
+#define BASIC_DOGE_ORACLE_QUERIES 1
+#endif
 
 // Enter static IPs of one or multiple oracle machine node(s). This node will connect to these and try to keep the
 // connection open for low latency. The oracle machine nodes also need to whitelist the IP of this core node.

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -65,6 +65,7 @@ static_assert(AUTO_FORCE_NEXT_TICK_THRESHOLD* TARGET_TICK_DURATION >= PEER_REFRE
 // Addons: If you don't know it, leave it 0.
 #define ADDON_TX_STATUS_REQUEST 0
 
+
 //////////////////////////////////////////////////////////////////////////
 // Config options that should NOT be changed by operators
 

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -92,6 +92,7 @@ static unsigned short CUSTOM_MINING_CACHE_FILE_NAME[] = L"custom_mining_cache.??
 static unsigned short CONTRACT_EXEC_FEES_ACC_FILE_NAME[] = L"contract_exec_fees_acc.???";
 static unsigned short CONTRACT_EXEC_FEES_REC_FILE_NAME[] = L"contract_exec_fees_rec.???";
 static unsigned short REVENUE_DATA_END_OF_EPOCH_FILE_NAME[] = L"revenue_data.eoe";
+static unsigned short REVENUE_DATA_SNAPSHOT_FILE_NAME[] = L"revenue_data.???";
 
 static constexpr unsigned long long HYPERIDENTITY_NUMBER_OF_INPUT_NEURONS = 512;     // K
 static constexpr unsigned long long HYPERIDENTITY_NUMBER_OF_OUTPUT_NEURONS = 512;    // L

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3635,40 +3635,47 @@ static void processTick(unsigned long long processorNumber)
     {
         if (finishedUserQuery->interfaceIndex == OI::DogeShareValidation::oracleInterfaceIndex)
         {
-            OI::DogeShareValidation::OracleReply reply;
-            if (finishedUserQuery->status == ORACLE_QUERY_STATUS_SUCCESS
-                && oracleEngine.getOracleReply(finishedUserQuery->queryId, &reply, sizeof(reply)))
+            // Look up query tx to get query data.
+            ASSERT(finishedUserQuery->type == ORACLE_QUERY_TYPE_USER_QUERY);
+            ASSERT(ts.tickInCurrentEpochStorage(finishedUserQuery->queryTick));
+            const uint64_t* tsTickTransactionOffsets
+                = ts.tickTransactionOffsets.getByTickInCurrentEpoch(finishedUserQuery->queryTick);
+            const uint32_t txSlotInTickData = finishedUserQuery->typeVar.user.queryTxIndex;
+            ASSERT(txSlotInTickData < NUMBER_OF_TRANSACTIONS_PER_TICK);
+            const auto* prevTx = (OracleUserQueryTransactionPrefix*)ts.tickTransactions.ptr(
+                tsTickTransactionOffsets[txSlotInTickData]);
+            ASSERT(finishedUserQuery->interfaceIndex == prevTx->oracleInterfaceIndex);
+            if (prevTx->inputSize
+                == OracleUserQueryTransactionPrefix::minInputSize() + sizeof(OI::DogeShareValidation::OracleQuery))
             {
-                // Oracle query was successful, remove from storage.
-                customQubicMiningStorage.removeOracleQuery(finishedUserQuery->interfaceIndex, finishedUserQuery->queryId);
-
-                // Oracle reply is available
-                if (reply.isValid)
+                OI::DogeShareValidation::OracleReply reply;
+                if (finishedUserQuery->status == ORACLE_QUERY_STATUS_SUCCESS
+                    && oracleEngine.getOracleReply(finishedUserQuery->queryId, &reply, sizeof(reply)))
                 {
-                    // Share is valid
-                    // TODO: implement share counting
+                    // Oracle query was successful, remove from storage.
+                    customQubicMiningStorage.removeOracleQuery(finishedUserQuery->interfaceIndex, finishedUserQuery->queryId);
+
+                    // Oracle reply is available
+                    if (reply.isValid)
+                    {
+                        // Share is valid: Count rev points if this share belongs to an active task (i.e. still contained
+                        // in the customQubicMiningStorage) and this solution has not been counted before.
+                        const auto* queryData = reinterpret_cast<const OI::DogeShareValidation::OracleQuery*>(prevTx->inputPtr() + OracleUserQueryTransactionPrefix::minInputSize());
+                        unsigned char solutionBuffer[16];
+                        copyMem(solutionBuffer, &queryData->solutionTime, 4);
+                        copyMem(solutionBuffer + 4, &queryData->solutionNonce, 4);
+                        copyMem(solutionBuffer + 8, &queryData->solutionExtraNonce2, 8);
+                        m256i solutionHash;
+                        KangarooTwelve(solutionBuffer, 16, solutionHash.m256i_u8, sizeof(solutionHash));
+                        if (customQubicMiningStorage.countSolutionForRevenue(CustomMiningType::DOGE, queryData->jobId, solutionHash))
+                        {
+                            // dogeRev[reply.compIndex]++;
+                        }
+                    }
                 }
                 else
                 {
-                    // Share is invalid
-                    // TODO: handle or remove this else block
-                }
-            }
-            else
-            {
-                // Oracle query failed -> lookup and resend user query tx if it is from own comp pool
-                ASSERT(finishedUserQuery->type == ORACLE_QUERY_TYPE_USER_QUERY);
-                ASSERT(ts.tickInCurrentEpochStorage(finishedUserQuery->queryTick));
-                const uint64_t* tsTickTransactionOffsets
-                    = ts.tickTransactionOffsets.getByTickInCurrentEpoch(finishedUserQuery->queryTick);
-                const uint32_t txSlotInTickData = finishedUserQuery->typeVar.user.queryTxIndex;
-                ASSERT(txSlotInTickData < NUMBER_OF_TRANSACTIONS_PER_TICK);
-                const auto* prevTx = (OracleUserQueryTransactionPrefix*)ts.tickTransactions.ptr(
-                    tsTickTransactionOffsets[txSlotInTickData]);
-                ASSERT(finishedUserQuery->interfaceIndex == prevTx->oracleInterfaceIndex);
-                if (prevTx->inputSize
-                    == OracleUserQueryTransactionPrefix::minInputSize() + sizeof(OI::DogeShareValidation::OracleQuery))
-                {
+                    // Oracle query failed -> resend user query tx if it is from own comp pool
                     for (unsigned int i = 0; i < computorSeedsCount; ++i)
                     {
                         if (computorPublicKeys[i] == prevTx->sourcePublicKey)
@@ -3694,7 +3701,7 @@ static void processTick(unsigned long long processorNumber)
                                 }
                             }
                             break;
-                       }
+                        }
                     }
                 }
             }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -4540,7 +4540,11 @@ static void endEpoch()
         for (unsigned int computorIndex = 0; computorIndex < NUMBER_OF_COMPUTORS; computorIndex++)
         {
             // Compute initial computor revenue, reducing arbitrator revenue
+#if USE_REVENUE_V2
+            long long revenue = gEpochRevenueData.v2Revenue[computorIndex];
+#else
             long long revenue = gRevenueComponents.revenue[computorIndex];
+#endif
             arbitratorRevenue -= revenue;
 
             // Reduce computor revenue based on revenue donation table agreed on by quorum

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3610,6 +3610,11 @@ static void processTick(unsigned long long processorNumber)
 
         // Process all transaction of the tick
         PROFILE_NAMED_SCOPE_BEGIN("processTick(): process transactions");
+        unsigned int nTickLeaderTx = 0;
+        unsigned int nProtocolTx = 0;
+        unsigned int nContractTx = 0;
+        unsigned int nOtherTx = 0;
+        const m256i& tickLeaderKey = broadcastedComputors.computors.publicKeys[system.tick % NUMBER_OF_COMPUTORS];
         for (unsigned int transactionIndex = 0; transactionIndex < NUMBER_OF_TRANSACTIONS_PER_TICK; transactionIndex++)
         {
             if (!isZero(nextTickData.transactionDigests[transactionIndex]))
@@ -3619,6 +3624,29 @@ static void processTick(unsigned long long processorNumber)
                     Transaction* transaction = ts.tickTransactions(tsCurrentTickTransactionOffsets[transactionIndex]);
                     logger.registerNewTx(transaction->tick, transactionIndex);
                     processTickTransaction(transaction, transactionIndex, processorNumber);
+
+                    if (transaction->sourcePublicKey == tickLeaderKey)
+                    {
+                        nTickLeaderTx++;
+                    }
+                    else if (isZero(transaction->destinationPublicKey))
+                    {
+                        nProtocolTx++;
+                    }
+                    else
+                    {
+                        m256i masked = transaction->destinationPublicKey;
+                        masked.m256i_u64[0] &= ~(unsigned long long)(MAX_NUMBER_OF_CONTRACTS - 1);
+                        unsigned int cIdx = (unsigned int)transaction->destinationPublicKey.m256i_u64[0];
+                        if (isZero(masked) && cIdx < contractCount)
+                        {
+                            nContractTx++;
+                        }
+                        else
+                        {
+                            nOtherTx++;
+                        }
+                    }
                 }
                 else
                 {
@@ -3627,6 +3655,18 @@ static void processTick(unsigned long long processorNumber)
                         criticalSituation = 1;
                     }
                 }
+            }
+        }
+        // Record per-tick TX counts for V2 revenue (counted here where TX bodies are guaranteed present)
+        {
+            unsigned int tickOffset = system.tick - system.initialTick;
+            if (tickOffset < MAX_NUMBER_OF_TICKS_PER_EPOCH)
+            {
+                gEpochRevenueData.perTickTxTickLeaderCount[tickOffset] = (unsigned short)nTickLeaderTx;
+                gEpochRevenueData.perTickTxCount[tickOffset] = (unsigned short)(nProtocolTx + nContractTx + nOtherTx);
+                gEpochRevenueData.perTickProtocolTxCount[tickOffset] = (unsigned short)nProtocolTx;
+                gEpochRevenueData.perTickContractTxCount[tickOffset] = (unsigned short)nContractTx;
+                gEpochRevenueData.perTickOtherTxCount[tickOffset] = (unsigned short)nOtherTx;
             }
         }
         PROFILE_SCOPE_END();
@@ -4368,6 +4408,7 @@ static void beginEpoch()
     setMem(system.futureComputors, sizeof(system.futureComputors), 0);
 
     resetCustomMining();
+    setMem(&gEpochRevenueData, sizeof(gEpochRevenueData), 0);
 
     // Reset resource testing digest at beginning of the epoch
     // there are many global variables that were init at declaration, may need to re-check all of them again
@@ -4459,76 +4500,10 @@ static void endEpoch()
             gEpochRevenueData.dogeMiningScore[i] = gDogeMiningSharesCounter.getSharesCount(i);
         }
 
-        // Revenue V2: filter transactions. Run here but have not applied yet
-        // Make sure run after gRevenueComponents is calculated because it use some of data
+        // Per-tick TX counts already recorded during processTick()
         gEpochRevenueData.initialTick = system.initialTick;
         gEpochRevenueData.totalTicks = system.tick - system.initialTick;
-        for (unsigned int tick = system.initialTick; tick < system.tick; tick++)
-        {
-            const m256i& tickLeaderPublicKey = broadcastedComputors.computors.publicKeys[tick % NUMBER_OF_COMPUTORS];
 
-            // Defensive lock, actually at the end of epoch, no more tick data written. 
-            ts.tickData.acquireLock();
-            unsigned int tickOffset = tick - system.initialTick;
-            TickData& td = ts.tickData.getByTickInCurrentEpoch(tick);
-            if ((td.epoch == system.epoch) && (tickOffset < MAX_NUMBER_OF_TICKS_PER_EPOCH))
-            {
-                unsigned int nTickLeader = 0;
-                unsigned int nProtocol = 0;
-                unsigned int nContract = 0;
-                unsigned int nOther = 0;
-                auto* offsets = ts.tickTransactionOffsets.getByTickInCurrentEpoch(tick);
-                for (unsigned int i = 0; i < NUMBER_OF_TRANSACTIONS_PER_TICK; i++)
-                {
-                    if (isZero(td.transactionDigests[i]))
-                    {
-                        continue;
-                    }
-
-                    // Make sure tx body existed
-                    if (!offsets[i])
-                    {
-                        continue;
-                    }
-
-                    const Transaction* tx = ts.tickTransactions(offsets[i]);
-
-                    // skip leader's own txs
-                    if (tx->sourcePublicKey == tickLeaderPublicKey)
-                    {
-                        nTickLeader++;
-                        continue;
-                    }
-
-                    if (isZero(tx->destinationPublicKey))
-                    {
-                        nProtocol++;
-                    }
-                    else
-                    {
-                        m256i masked = tx->destinationPublicKey;
-                        masked.m256i_u64[0] &= ~(unsigned long long)(MAX_NUMBER_OF_CONTRACTS - 1);
-                        unsigned int cIdx = (unsigned int)tx->destinationPublicKey.m256i_u64[0];
-                        if (isZero(masked) && cIdx < contractCount)
-                        {
-                            nContract++;
-                        }
-                        else
-                        {
-                            nOther++;
-                        }
-                    }
-
-                }
-                gEpochRevenueData.perTickTxTickLeaderCount[tickOffset] = (unsigned short)nTickLeader;
-
-                gEpochRevenueData.perTickTxCount[tickOffset] = (unsigned short)(nProtocol + nContract + nOther);
-                gEpochRevenueData.perTickProtocolTxCount[tickOffset] = (unsigned short)nProtocol;
-                gEpochRevenueData.perTickContractTxCount[tickOffset] = (unsigned short)nContract;
-                gEpochRevenueData.perTickOtherTxCount[tickOffset] = (unsigned short)nOther;
-            }
-            ts.tickData.releaseLock();
-        }
         // Fetch oracle revenue points (accumulated during epoch, reset at beginEpoch)
         {
             OracleRevenuePoints oracleRevPoints;
@@ -4862,7 +4837,18 @@ static bool saveAllNodeStates()
         logToConsole(L"Failed to save etalon tick and other states");
         return false;
     }
-    
+
+    // Save V2 per-tick TX counts (recorded during processTick)
+    REVENUE_DATA_SNAPSHOT_FILE_NAME[sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME) / sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME[0]) - 4] = system.epoch / 100 + L'0';
+    REVENUE_DATA_SNAPSHOT_FILE_NAME[sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME) / sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME[0]) - 3] = (system.epoch % 100) / 10 + L'0';
+    REVENUE_DATA_SNAPSHOT_FILE_NAME[sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME) / sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME[0]) - 2] = system.epoch % 10 + L'0';
+    savedSize = save(REVENUE_DATA_SNAPSHOT_FILE_NAME, sizeof(gEpochRevenueData), (unsigned char*)&gEpochRevenueData, directory);
+    if (savedSize != sizeof(gEpochRevenueData))
+    {
+        logToConsole(L"Failed to save revenue data snapshot");
+        return false;
+    }
+
     CHAR16 SPECTRUM_DIGEST_FILE_NAME[] = L"snapshotSpectrumDigest";
     savedSize = save(SPECTRUM_DIGEST_FILE_NAME, spectrumDigestsSizeInByte, (unsigned char*)spectrumDigests, directory);
     logToConsole(L"Saving spectrum digests");
@@ -5029,6 +5015,17 @@ static bool loadAllNodeStates()
     voteCounter.loadAllDataFromArray(nodeStateBuffer.voteCounterData);
     gCustomMiningSharesCounter.loadAllDataFromArray(nodeStateBuffer.customMiningSharesCounterData);
     gDogeMiningSharesCounter.loadAllDataFromArray(nodeStateBuffer.dogeMiningSharesCounterData);
+
+    // Load V2 per-tick TX counts
+    REVENUE_DATA_SNAPSHOT_FILE_NAME[sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME) / sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME[0]) - 4] = system.epoch / 100 + L'0';
+    REVENUE_DATA_SNAPSHOT_FILE_NAME[sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME) / sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME[0]) - 3] = (system.epoch % 100) / 10 + L'0';
+    REVENUE_DATA_SNAPSHOT_FILE_NAME[sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME) / sizeof(REVENUE_DATA_SNAPSHOT_FILE_NAME[0]) - 2] = system.epoch % 10 + L'0';
+    long long revenueDataSize = load(REVENUE_DATA_SNAPSHOT_FILE_NAME, sizeof(gEpochRevenueData), (unsigned char*)&gEpochRevenueData, directory);
+    if (revenueDataSize != sizeof(gEpochRevenueData))
+    {
+        logToConsole(L"Failed to load revenue data snapshot, starting with zero counts");
+        setMem(&gEpochRevenueData, sizeof(gEpochRevenueData), 0);
+    }
 
     // update own computor indices
     for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -227,6 +227,11 @@ static constexpr unsigned int gScoreMultiplier[score_engine::AlgoType::MaxAlgoCo
 static unsigned int gCustomMiningSharesCount[NUMBER_OF_COMPUTORS] = { 0 };
 static CustomMiningSharesCounter gCustomMiningSharesCounter;
 
+// DOGE merged-mining shares (separate pipeline from XMR custom mining)
+static volatile char gDogeMiningSharesCountLock = 0;
+static unsigned int gDogeMiningSharesCount[NUMBER_OF_COMPUTORS] = { 0 };
+static CustomMiningSharesCounter gDogeMiningSharesCounter;
+
 static CustomQubicMiningStorage customQubicMiningStorage;
 
 // variables and declare for persisting state
@@ -254,6 +259,7 @@ struct
     unsigned int numberOfMiners;
     unsigned int numberOfTransactions;
     unsigned char customMiningSharesCounterData[CustomMiningSharesCounter::_customMiningSolutionCounterDataSize];
+    unsigned char dogeMiningSharesCounterData[CustomMiningSharesCounter::_customMiningSolutionCounterDataSize];
 } nodeStateBuffer;
 #endif
 static bool saveContractStateFiles(CHAR16* directory = NULL);
@@ -1526,6 +1532,7 @@ static void processBroadcastCustomMiningTask(RequestResponseHeader* header)
         enqueueResponse(NULL, header);
 #ifdef SEND_DOGE_ORACLE_QUERIES
         customQubicMiningStorage.addTask(reinterpret_cast<const CustomQubicMiningTask*>(payload), messageSize - SIGNATURE_SIZE);
+        ATOMIC_INC64(gDogeMiningStats.phaseV2.tasks);
 #endif
     }
 }
@@ -1577,8 +1584,12 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
                 {
                     // Check if the solution is added successfully (active task, no duplicate) before sending oracle query.
                     CustomQubicMiningStorage::StoredDogeMiningTask task;
+                    ATOMIC_INC64(gDogeMiningStats.phaseV2.shares);
                     if (customQubicMiningStorage.addSolution(sol, messageSize - SIGNATURE_SIZE, reinterpret_cast<unsigned char*>(&task)) < 0)
+                    {
+                        ATOMIC_INC64(gDogeMiningStats.phaseV2.duplicated);
                         return;
+                    }
 
                     unsigned char buffer[sizeof(OracleUserQueryTransactionPrefix)
                         + sizeof(OI::DogeShareValidation::OracleQuery) + SIGNATURE_SIZE];
@@ -2055,6 +2066,7 @@ static void beginCustomMiningPhase()
     gSystemCustomMiningSolutionV2Cache.reset();
     gCustomMiningStorage.reset();
     gCustomMiningStats.phaseResetAndEpochAccumulate();
+    gDogeMiningStats.phaseResetAndEpochAccumulate();
 }
 
 // resetPhase: If true, allows reinitializing mining seed and the custom mining phase flag
@@ -3179,6 +3191,12 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
                 }
                 break;
 
+                case DogeMiningShareTransaction::transactionType():
+                {
+                    gDogeMiningSharesCounter.processTransactionData(transaction, dataLock);
+                }
+                break;
+
                 case EXECUTION_FEE_REPORT_INPUT_TYPE:
                 {
                     executionFeeReportCollector.processTransactionData(transaction, dataLock);
@@ -3287,7 +3305,7 @@ static void makeAndBroadcastTickVotesTransaction(int i, BroadcastFutureTickData&
     }
 }
 
-static bool makeAndBroadcastCustomMiningTransaction(int i, BroadcastFutureTickData& td, int txSlot)
+static bool makeAndBroadcastXMRMiningTransaction(int i, BroadcastFutureTickData& td, int txSlot)
 {
     if (!gCustomMiningBroadcastTxBuffer[i].isBroadcasted)
     {
@@ -3314,6 +3332,56 @@ static bool makeAndBroadcastCustomMiningTransaction(int i, BroadcastFutureTickDa
                 if (!tsReqTickTransactionOffsets[txSlot]) // not yet have value
                 {
                     if (ts.nextTickTransactionOffset + transactionSize <= ts.tickTransactions.storageSpaceCurrentEpoch) //have enough space
+                    {
+                        td.tickData.transactionDigests[txSlot] = m256i(digest);
+                        tsReqTickTransactionOffsets[txSlot] = ts.nextTickTransactionOffset;
+                        copyMem(ts.tickTransactions(ts.nextTickTransactionOffset), &payload, transactionSize);
+                        ts.nextTickTransactionOffset += transactionSize;
+                    }
+                }
+                ts.tickTransactions.releaseLock();
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+// Generic mining share broadcast helper.
+// Takes the broadcast buffer + counter by reference so it can be reused for
+// any CustomMiningSharesCounter-based pipeline (DOGE today; future mining types tomorrow).
+// XMR currently has its own dedicated function (makeAndBroadcastXMRMiningTransaction)
+// which will be retired along with XMR custom mining itself.
+static bool makeAndBroadcastCustomMiningTransaction(
+    BroadcastCustomMiningTransaction* broadcastTxBuffer,
+    CustomMiningSharesCounter& sharesCounter,
+    int i,
+    BroadcastFutureTickData& td,
+    int txSlot)
+{
+    if (!broadcastTxBuffer[i].isBroadcasted)
+    {
+        broadcastTxBuffer[i].isBroadcasted = true;
+        auto& payload = broadcastTxBuffer[i].payload;
+        if (sharesCounter.isEmptyPacket(payload.packedScore) == false)
+        {
+            payload.transaction.tick = system.tick + TICK_TRANSACTIONS_PUBLICATION_OFFSET;
+            payload.dataLock = td.tickData.timelock;
+            unsigned char digest[32];
+            KangarooTwelve(&payload.transaction, sizeof(payload.transaction) + sizeof(payload.packedScore) + sizeof(payload.dataLock), digest, sizeof(digest));
+            sign(computorSubseeds[ownComputorIndicesMapping[i]].m256i_u8, computorPublicKeys[ownComputorIndicesMapping[i]].m256i_u8, digest, payload.signature);
+            enqueueResponse(NULL, sizeof(payload), BROADCAST_TRANSACTION, 0, &payload);
+
+            unsigned int tickIndex = ts.tickToIndexCurrentEpoch(td.tickData.tick);
+            unsigned int transactionSize = sizeof(payload);
+            KangarooTwelve(&payload, transactionSize, digest, sizeof(digest));
+            auto* tsReqTickTransactionOffsets = ts.tickTransactionOffsets.getByTickIndex(tickIndex);
+            if (txSlot < NUMBER_OF_TRANSACTIONS_PER_TICK)
+            {
+                ts.tickTransactions.acquireLock();
+                if (!tsReqTickTransactionOffsets[txSlot])
+                {
+                    if (ts.nextTickTransactionOffset + transactionSize <= ts.tickTransactions.storageSpaceCurrentEpoch)
                     {
                         td.tickData.transactionDigests[txSlot] = m256i(digest);
                         tsReqTickTransactionOffsets[txSlot] = ts.nextTickTransactionOffset;
@@ -3672,8 +3740,18 @@ static void processTick(unsigned long long processorNumber)
                             // TODO: Verify that the task description in the query matches the task description in the storage to decline revenue
                             // for comps tampering with the task description in their query. Not sure how likely this is to happen.
                             
-                            // dogeRev[reply.compIndex]++;
+                            ATOMIC_INC64(gDogeMiningStats.phaseV2.valid);
+                            if (reply.compIndex < NUMBER_OF_COMPUTORS)
+                            {
+                                ACQUIRE(gDogeMiningSharesCountLock);
+                                gDogeMiningSharesCount[reply.compIndex]++;
+                                RELEASE(gDogeMiningSharesCountLock);
+                            }
                         }
+                    }
+                    else
+                    {
+                        ATOMIC_INC64(gDogeMiningStats.phaseV2.invalid);
                     }
                 }
                 else
@@ -3829,6 +3907,44 @@ static void processTick(unsigned long long processorNumber)
             ACQUIRE(gCustomMiningSharesCountLock);
             setMem(gCustomMiningSharesCount, sizeof(gCustomMiningSharesCount), 0);
             RELEASE(gCustomMiningSharesCountLock);
+
+            // Prepare DOGE mining share broadcast TX (one per own computor; buffer only — send deferred)
+            long long dogeMiningCountOverflow = 0;
+            for (unsigned int i = 0; i < numberOfOwnComputorIndices; i++)
+            {
+                ACQUIRE(gDogeMiningSharesCountLock);
+                for (int k = 0; k < NUMBER_OF_COMPUTORS; k++)
+                {
+                    if (gDogeMiningSharesCount[k] > CUSTOM_MINING_SOLUTION_SHARES_COUNT_MAX_VAL)
+                    {
+                        if (gDogeMiningSharesCount[k] > dogeMiningCountOverflow)
+                        {
+                            dogeMiningCountOverflow = gDogeMiningSharesCount[k];
+                        }
+                        gDogeMiningSharesCount[k] = CUSTOM_MINING_SOLUTION_SHARES_COUNT_MAX_VAL;
+                    }
+                }
+                gDogeMiningSharesCounter.registerNewShareCount(gDogeMiningSharesCount);
+                RELEASE(gDogeMiningSharesCountLock);
+
+                auto& dogePayload = gDogeMiningBroadcastTxBuffer[i].payload;
+                dogePayload.transaction.sourcePublicKey = computorPublicKeys[ownComputorIndicesMapping[i]];
+                dogePayload.transaction.destinationPublicKey = m256i::zero();
+                dogePayload.transaction.amount = 0;
+                dogePayload.transaction.tick = 0;
+                dogePayload.transaction.inputType = DogeMiningShareTransaction::transactionType();
+                dogePayload.transaction.inputSize = sizeof(dogePayload.packedScore) + sizeof(dogePayload.dataLock);
+                gDogeMiningSharesCounter.compressNewSharesPacket(ownComputorIndices[i], dogePayload.packedScore);
+                gDogeMiningBroadcastTxBuffer[i].isBroadcasted = false;
+            }
+
+            // Keep the max of overflow case
+            ATOMIC_MAX64(gDogeMiningStats.maxOverflowShareCount, dogeMiningCountOverflow);
+
+            // Reset the phase counter
+            ACQUIRE(gDogeMiningSharesCountLock);
+            setMem(gDogeMiningSharesCount, sizeof(gDogeMiningSharesCount), 0);
+            RELEASE(gDogeMiningSharesCountLock);
         }
     }
 
@@ -3906,7 +4022,13 @@ static void processTick(unsigned long long processorNumber)
                     {
                         // insert & broadcast external mining score packet (containing the score for each computor on the last external mining phase)
                         // this type of tx is only broadcasted in internal mining phases
-                        if (makeAndBroadcastCustomMiningTransaction(i, broadcastedFutureTickData, nextTxIndex))
+                        if (makeAndBroadcastXMRMiningTransaction(i, broadcastedFutureTickData, nextTxIndex))
+                        {
+                            nextTxIndex++;
+                        }
+
+                        // insert & broadcast DOGE mining score packet
+                        if (makeAndBroadcastCustomMiningTransaction(gDogeMiningBroadcastTxBuffer, gDogeMiningSharesCounter, i, broadcastedFutureTickData, nextTxIndex))
                         {
                             nextTxIndex++;
                         }
@@ -4140,16 +4262,21 @@ static void resetCustomMining()
     gCustomMiningSharesCounter.init();
     setMem(gCustomMiningSharesCount, sizeof(gCustomMiningSharesCount), 0);
 
+    gDogeMiningSharesCounter.init();
+    setMem(gDogeMiningSharesCount, sizeof(gDogeMiningSharesCount), 0);
+
     gSystemCustomMiningSolutionV2Cache.reset();
     for (int i = 0; i < NUMBER_OF_COMPUTORS; ++i)
     {
         // Initialize the broadcast transaction buffer. Assume the all previous is broadcasted.
         gCustomMiningBroadcastTxBuffer[i].isBroadcasted = true;
+        gDogeMiningBroadcastTxBuffer[i].isBroadcasted = true;
     }
     gCustomMiningStorage.reset();
 
     // Clear all data of epoch
     gCustomMiningStats.epochReset();
+    gDogeMiningStats.epochReset();
 }
 
 static void beginEpoch()
@@ -4313,6 +4440,13 @@ static void endEpoch()
                 gRevenueComponents.voteScore,
                 gRevenueComponents.customMiningScore,
                 gRevenueComponents.revenue);
+        }
+
+        // Collect mining scores for V2
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            gEpochRevenueData.xmrMiningScore[i] = gRevenueComponents.customMiningScore[i];
+            gEpochRevenueData.dogeMiningScore[i] = gDogeMiningSharesCounter.getSharesCount(i);
         }
 
         // Revenue V2: filter transactions. Run here but have not applied yet
@@ -4704,6 +4838,7 @@ static bool saveAllNodeStates()
     nodeStateBuffer.numberOfTransactions = numberOfTransactions;    
     voteCounter.saveAllDataToArray(nodeStateBuffer.voteCounterData);
     gCustomMiningSharesCounter.saveAllDataToArray(nodeStateBuffer.customMiningSharesCounterData);
+    gDogeMiningSharesCounter.saveAllDataToArray(nodeStateBuffer.dogeMiningSharesCounterData);
 
     CHAR16 NODE_STATE_FILE_NAME[] = L"snapshotNodeMiningState";
     savedSize = save(NODE_STATE_FILE_NAME, sizeof(nodeStateBuffer), (unsigned char*)&nodeStateBuffer, directory);
@@ -4879,6 +5014,7 @@ static bool loadAllNodeStates()
     loadMiningSeedFromFile = true;
     voteCounter.loadAllDataFromArray(nodeStateBuffer.voteCounterData);
     gCustomMiningSharesCounter.loadAllDataFromArray(nodeStateBuffer.customMiningSharesCounterData);
+    gDogeMiningSharesCounter.loadAllDataFromArray(nodeStateBuffer.dogeMiningSharesCounterData);
 
     // update own computor indices
     for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
@@ -7395,6 +7531,10 @@ static void processKeyPresses()
 
             setText(message, L"CustomMining: ");
             gCustomMiningStats.appendLog(message);
+            logToConsole(message);
+
+            setText(message, L"DogeMining: ");
+            gDogeMiningStats.appendLog(message);
             logToConsole(message);
         }
         break;

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1530,7 +1530,7 @@ static void processBroadcastCustomMiningTask(RequestResponseHeader* header)
     if (verify(dogeDispatcherPubkey, digest.m256i_u8, payload + (messageSize - SIGNATURE_SIZE)))
     {
         enqueueResponse(NULL, header);
-#ifdef SEND_DOGE_ORACLE_QUERIES
+#if BASIC_DOGE_ORACLE_QUERIES
         customQubicMiningStorage.addTask(reinterpret_cast<const CustomQubicMiningTask*>(payload), messageSize - SIGNATURE_SIZE);
         ATOMIC_INC64(gDogeMiningStats.phaseV2.tasks);
 #endif
@@ -1564,7 +1564,7 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
         // Broadcast the solution to peers.
         enqueueResponse(NULL, header);
 
-#ifdef SEND_DOGE_ORACLE_QUERIES
+#if BASIC_DOGE_ORACLE_QUERIES
         if (sol->customMiningType == CustomMiningType::DOGE)
         {
             if (messageSize - SIGNATURE_SIZE < sizeof(CustomQubicMiningSolution) + sizeof(QubicDogeMiningSolution))
@@ -1619,7 +1619,9 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
                     queryData->numMerkleBranches = task.numMerkleBranches;
                     copyMem(queryData->additionalData, task.additionalData, OI::DogeShareValidation::OracleQuery::additionalDataSize);
 
+#if RETRY_DOGE_ORACLE_QUERIES
                     customQubicMiningStorage.addOracleQuery(tx);
+#endif
 
                     if (isMainMode()) // only main node should send oracle queries
                     {
@@ -3165,6 +3167,7 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
                     int64_t queryId = oracleEngine.startUserQuery(queryTx, transactionIndex, forceZeroFee);
                     const bool error = queryId < 0;
 
+#if RETRY_DOGE_ORACLE_QUERIES
                     if (queryTx->oracleInterfaceIndex == OI::DogeShareValidation::oracleInterfaceIndex)
                     {
                         if (error)
@@ -3177,6 +3180,7 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
                             customQubicMiningStorage.markOracleQueryStarted((const OracleUserQueryTransactionPrefix*)transaction, queryId);
                         }
                     }
+#endif
 
                     if (error && transaction->amount)
                     {
@@ -3628,6 +3632,7 @@ static void processTick(unsigned long long processorNumber)
         PROFILE_SCOPE_END();
     }
 
+#if RETRY_DOGE_ORACLE_QUERIES
     // Resend oracle queries for share validation if they were scheduled for but not included in this tick.
     int currentQueryIndex = customQubicMiningStorage.getNextScheduledQueryIndexForTick(CustomMiningType::DOGE, /*currentQueryIndex=*/-1, system.tick);
     while (currentQueryIndex >= 0)
@@ -3671,6 +3676,7 @@ static void processTick(unsigned long long processorNumber)
         }
         currentQueryIndex = customQubicMiningStorage.getNextScheduledQueryIndexForTick(CustomMiningType::DOGE, currentQueryIndex, system.tick);
     }
+#endif
 
     // Generate subscription queries (may create queries that immediately timeout if the network was stuck)
     oracleEngine.generateSubscriptionQueries();
@@ -3720,8 +3726,10 @@ static void processTick(unsigned long long processorNumber)
                 if (finishedUserQuery->status == ORACLE_QUERY_STATUS_SUCCESS
                     && oracleEngine.getOracleReply(finishedUserQuery->queryId, &reply, sizeof(reply)))
                 {
+#if RETRY_DOGE_ORACLE_QUERIES
                     // Oracle query was successful, remove from storage.
                     customQubicMiningStorage.removeOracleQuery(finishedUserQuery->interfaceIndex, finishedUserQuery->queryId);
+#endif
 
                     // Oracle reply is available
                     if (reply.isValid)
@@ -3754,6 +3762,7 @@ static void processTick(unsigned long long processorNumber)
                         ATOMIC_INC64(gDogeMiningStats.phaseV2.invalid);
                     }
                 }
+#if RETRY_DOGE_ORACLE_QUERIES
                 else
                 {
                     // Oracle query failed -> resend user query tx if it is from own comp pool
@@ -3785,6 +3794,7 @@ static void processTick(unsigned long long processorNumber)
                         }
                     }
                 }
+#endif
             }
         }
         finishedUserQuery = oracleEngine.getFinishedUserQuery();

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3669,6 +3669,9 @@ static void processTick(unsigned long long processorNumber)
                         KangarooTwelve(solutionBuffer, 16, solutionHash.m256i_u8, sizeof(solutionHash));
                         if (customQubicMiningStorage.countSolutionForRevenue(CustomMiningType::DOGE, queryData->jobId, solutionHash))
                         {
+                            // TODO: Verify that the task description in the query matches the task description in the storage to decline revenue
+                            // for comps tampering with the task description in their query. Not sure how likely this is to happen.
+                            
                             // dogeRev[reply.compIndex]++;
                         }
                     }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1592,16 +1592,21 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
                     tx->inputSize = OracleUserQueryTransactionPrefix::minInputSize() + sizeof(OI::DogeShareValidation::OracleQuery);
                     tx->oracleInterfaceIndex = OI::DogeShareValidation::oracleInterfaceIndex;
                     tx->timeoutMilliseconds = 30000;
-                    unsigned char* queryData = buffer + sizeof(OracleUserQueryTransactionPrefix);
-                    // Full header can be constructed via concatenating version + prevHash + merkleRoot + miner's nTime + nBits + miner's nonce.
-                    unsigned int offset = 0;
-                    copyMem(queryData + offset, task.version, 4); offset += 4;
-                    copyMem(queryData + offset, task.prevHash, 32); offset += 32;
-                    copyMem(queryData + offset, dogeSol->merkleRoot, 32); offset += 32;
-                    copyMem(queryData + offset, dogeSol->nTime, 4); offset += 4;
-                    copyMem(queryData + offset, task.nBits, 4); offset += 4;
-                    copyMem(queryData + offset, dogeSol->nonce, 4); offset += 4;
-                    copyMem(queryData + offset, task.dispatcherTarget, 32); offset += 32;
+
+                    auto* queryData = reinterpret_cast<OI::DogeShareValidation::OracleQuery*>(buffer + sizeof(OracleUserQueryTransactionPrefix));
+                    queryData->jobId = task.jobId;
+                    copyMem(&queryData->solutionTime, dogeSol->nTime, 4);
+                    copyMem(&queryData->solutionNonce, dogeSol->nonce, 4);
+                    copyMem(&queryData->solutionExtraNonce2, dogeSol->extraNonce2, 8);
+                    copyMem(&queryData->target, task.dispatcherTarget, 32);
+                    copyMem(&queryData->taskPartialHeaderVersion, task.version, 4);
+                    copyMem(&queryData->taskPartialHeaderDifficultyNBits, task.nBits, 4);
+                    copyMem(&queryData->taskPartialHeaderPrevBlockHash, task.prevHash, 32);
+                    queryData->extraNonce1NumBytes = task.extraNonce1NumBytes;
+                    queryData->coinbase1NumBytes = task.coinbase1NumBytes;
+                    queryData->coinbase2NumBytes = task.coinbase2NumBytes;
+                    queryData->numMerkleBranches = task.numMerkleBranches;
+                    copyMem(queryData->additionalData, task.additionalData, OI::DogeShareValidation::OracleQuery::additionalDataSize);
 
                     customQubicMiningStorage.addOracleQuery(tx);
 

--- a/src/revenue.h
+++ b/src/revenue.h
@@ -6,6 +6,10 @@
 #include "vote_counter.h"
 #include "public_settings.h"
 
+// Revenue V2: set to 1 to use the new revenue formula (additive bonus + sliding window + oracle)
+// set to 0 to use V1 formula (multiplicative: tx * vote * mining)
+#define USE_REVENUE_V2 1
+
 
 static unsigned long long gVoteScoreBuffer[NUMBER_OF_COMPUTORS];
 static unsigned long long gCustomMiningScoreBuffer[NUMBER_OF_COMPUTORS];

--- a/src/revenue.h
+++ b/src/revenue.h
@@ -48,15 +48,18 @@ struct RevenueComponents
 } gRevenueComponents;
 
 // Get the lower bound that start to separate the QUORUM region of score
-unsigned long long getQuorumScore(const unsigned long long* score)
+unsigned long long getQuorumScore(
+    const unsigned long long* score,
+    const unsigned int numberOfComputors = NUMBER_OF_COMPUTORS,
+    const unsigned int quorum = QUORUM)
 {
     unsigned long long sortedScore[QUORUM + 1];
     // Sort revenue scores to get lowest score of quorum
-    setMem(sortedScore, sizeof(sortedScore), 0);
-    for (unsigned short computorIndex = 0; computorIndex < NUMBER_OF_COMPUTORS; computorIndex++)
+    setMem(sortedScore, (quorum + 1) * sizeof(unsigned long long), 0);
+    for (unsigned short computorIndex = 0; computorIndex < numberOfComputors; computorIndex++)
     {
-        sortedScore[QUORUM] = score[computorIndex];
-        unsigned int i = QUORUM;
+        sortedScore[quorum] = score[computorIndex];
+        unsigned int i = quorum;
         while (i
             && sortedScore[i - 1] < sortedScore[i])
         {
@@ -65,11 +68,11 @@ unsigned long long getQuorumScore(const unsigned long long* score)
             sortedScore[i--] = tmp;
         }
     }
-    if (!sortedScore[QUORUM - 1])
+    if (!sortedScore[quorum - 1])
     {
-        sortedScore[QUORUM - 1] = 1;
+        sortedScore[quorum - 1] = 1;
     }
-    return sortedScore[QUORUM - 1];
+    return sortedScore[quorum - 1];
 }
 
 // This function will sort the score take the 450th score at reference score
@@ -79,14 +82,16 @@ unsigned long long getQuorumScore(const unsigned long long* score)
 static void computeRevFactor(
     const unsigned long long* score,
     const unsigned long long scalingThreshold,
-    unsigned long long* outputScoreFactor)
+    unsigned long long* outputScoreFactor,
+    const unsigned int numberOfComputors = NUMBER_OF_COMPUTORS,
+    const unsigned int quorum = QUORUM)
 {
     ASSERT(scalingThreshold > 0);
 
     // Sort revenue scores to get lowest score of quorum
-    unsigned long long quorumScore = getQuorumScore(score);
+    unsigned long long quorumScore = getQuorumScore(score, numberOfComputors, quorum);
 
-    for (unsigned int computorIndex = 0; computorIndex < NUMBER_OF_COMPUTORS; computorIndex++)
+    for (unsigned int computorIndex = 0; computorIndex < numberOfComputors; computorIndex++)
     {
         unsigned long long scoreFactor = 0;
         if (score[computorIndex] == 0)
@@ -167,6 +172,15 @@ static constexpr unsigned long long REVENUE_BONUS_CAP = 256; // capacity for non
 static constexpr unsigned int REVENUE_W_TX = 17;             // mandatory weight: TX (85%)
 static constexpr unsigned int REVENUE_W_ORACLE = 3;          // mandatory weight: Oracle (15%)
 static constexpr unsigned int REVENUE_W_SUM = REVENUE_W_TX + REVENUE_W_ORACLE;  // 20
+// Mining group quorum ratio: 2/3 of each group (same ratio as global QUORUM/NUMBER_OF_COMPUTORS)
+static constexpr unsigned int REVENUE_MINING_QUORUM_NUMERATOR = 2;
+static constexpr unsigned int REVENUE_MINING_QUORUM_DENOMINATOR = 3;
+// Mining group assignment strategy (template parameter for computeGroupMiningFactor)
+enum MiningGroupStrategy
+{
+    MINING_GROUP_BY_MAX = 0,    // max(doge, xmr) determines group (robust against gaming)
+    MINING_GROUP_BY_ANY_DOGE,   // any DOGE share > 0 assigns to DOGE group (simple)
+};
 // M_combined is computed as (W_TX*scoreTx + W_ORACLE*scoreOracle) / W_SUM first → [0, S]
 // Then formula: revenue = ipc × M × (S² + B×E) / (S × (S+B) × S)
 static constexpr unsigned long long REVENUE_DIVISOR = REVENUE_SCALE * (REVENUE_SCALE + REVENUE_BONUS_CAP) * REVENUE_SCALE; // 1024 × 1280 × 1024 = 1,342,177,280
@@ -186,6 +200,8 @@ struct EpochRevenueData
     // Per-computor arrays (NUMBER_OF_COMPUTORS entries each)
     unsigned long long slidingWindowTxScore[NUMBER_OF_COMPUTORS];   // new sliding window accumulated score
     unsigned long long oracleScore[NUMBER_OF_COMPUTORS];            // oracle commit/reveal revenue points
+    unsigned long long xmrMiningScore[NUMBER_OF_COMPUTORS];           // XMR custom mining shares (raw)
+    unsigned long long dogeMiningScore[NUMBER_OF_COMPUTORS];        // DOGE merged-mining shares (raw)
     long long v2Revenue[NUMBER_OF_COMPUTORS];                       // V2 shadow output
 
     // Per-tick TX counts — existing total + 3 categories
@@ -198,15 +214,104 @@ struct EpochRevenueData
 
 static EpochRevenueData gEpochRevenueData;
 
+// Mining group classification
+enum MiningGroup : unsigned char
+{
+    MINING_GROUP_XMR = 0,
+    MINING_GROUP_DOGE = 1,
+};
+
 // Intermediate buffers for V2 revenue computation
 struct RevenueV2Buffers
 {
     unsigned int slidingWindowLogScore[MAX_NUMBER_OF_TICKS_PER_EPOCH];
     unsigned long long txFactor[NUMBER_OF_COMPUTORS];
     unsigned long long oracleFactor[NUMBER_OF_COMPUTORS];
-    unsigned long long miningFactor[NUMBER_OF_COMPUTORS];
+    unsigned long long miningFactor[NUMBER_OF_COMPUTORS];          // group-based mining factor (E)
+    MiningGroup miningGroup[NUMBER_OF_COMPUTORS];                  // which group each computor belongs to
+
+    // Scratch buffers for computeGroupMiningFactor (avoid large stack allocations)
+    unsigned int dogeIndices[NUMBER_OF_COMPUTORS];
+    unsigned int xmrIndices[NUMBER_OF_COMPUTORS];
+    unsigned long long dogeGroupScores[NUMBER_OF_COMPUTORS];
+    unsigned long long xmrGroupScores[NUMBER_OF_COMPUTORS];
+    unsigned long long dogeGroupFactors[NUMBER_OF_COMPUTORS];
+    unsigned long long xmrGroupFactors[NUMBER_OF_COMPUTORS];
 };
 static RevenueV2Buffers gRevenueV2Buffers;
+
+// Compute mining factor using group-based quorum normalization.
+// Each computor is assigned to DOGE or XMR group based on their shares.
+// The quorum threshold is 2/3 of each group size, computed independently.
+template <MiningGroupStrategy strategy = MINING_GROUP_BY_MAX>
+static void computeGroupMiningFactor(
+    const unsigned long long* xmrScore,
+    const unsigned long long* dogeScore,
+    const unsigned long long scalingThreshold,
+    unsigned long long* outputMiningFactor,
+    MiningGroup* outputMiningGroup)
+{
+    ASSERT(scalingThreshold > 0);
+
+    // Classify each computor into DOGE or XMR group
+    unsigned int dogeGroupSize = 0;
+    unsigned int xmrGroupSize = 0;
+
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        bool isDoge;
+        if constexpr (strategy == MINING_GROUP_BY_ANY_DOGE)
+        {
+            isDoge = (dogeScore[i] > 0);
+        }
+        else
+        {
+            isDoge = (dogeScore[i] >= xmrScore[i] && dogeScore[i] > 0);
+        }
+
+        if (isDoge)
+        {
+            outputMiningGroup[i] = MINING_GROUP_DOGE;
+            gRevenueV2Buffers.dogeIndices[dogeGroupSize] = i;
+            gRevenueV2Buffers.dogeGroupScores[dogeGroupSize] = dogeScore[i];
+            dogeGroupSize++;
+        }
+        else
+        {
+            outputMiningGroup[i] = MINING_GROUP_XMR;
+            gRevenueV2Buffers.xmrIndices[xmrGroupSize] = i;
+            gRevenueV2Buffers.xmrGroupScores[xmrGroupSize] = xmrScore[i];
+            xmrGroupSize++;
+        }
+    }
+
+    // Compute factors per group using computeRevFactor with 2/3 quorum
+    if (dogeGroupSize > 0)
+    {
+        unsigned int dogeQuorumRank =
+            (dogeGroupSize * REVENUE_MINING_QUORUM_NUMERATOR + REVENUE_MINING_QUORUM_DENOMINATOR - 1)
+            / REVENUE_MINING_QUORUM_DENOMINATOR;
+        computeRevFactor(gRevenueV2Buffers.dogeGroupScores, scalingThreshold, gRevenueV2Buffers.dogeGroupFactors, dogeGroupSize, dogeQuorumRank);
+    }
+
+    if (xmrGroupSize > 0)
+    {
+        unsigned int xmrQuorumRank =
+            (xmrGroupSize * REVENUE_MINING_QUORUM_NUMERATOR + REVENUE_MINING_QUORUM_DENOMINATOR - 1)
+            / REVENUE_MINING_QUORUM_DENOMINATOR;
+        computeRevFactor(gRevenueV2Buffers.xmrGroupScores, scalingThreshold, gRevenueV2Buffers.xmrGroupFactors, xmrGroupSize, xmrQuorumRank);
+    }
+
+    // Map group factors back to computor indices
+    for (unsigned int g = 0; g < dogeGroupSize; g++)
+    {
+        outputMiningFactor[gRevenueV2Buffers.dogeIndices[g]] = gRevenueV2Buffers.dogeGroupFactors[g];
+    }
+    for (unsigned int g = 0; g < xmrGroupSize; g++)
+    {
+        outputMiningFactor[gRevenueV2Buffers.xmrIndices[g]] = gRevenueV2Buffers.xmrGroupFactors[g];
+    }
+}
 
 static void computeRevenueV2(EpochRevenueData& rEpochReveneuData)
 {
@@ -288,17 +393,27 @@ static void computeRevenueV2(EpochRevenueData& rEpochReveneuData)
         }
     }
 
-    computeRevFactor(gRevenueComponents.customMiningScore, REVENUE_SCALE, gRevenueV2Buffers.miningFactor);
+    // Mining factor: group-based (DOGE vs XMR), 2/3 quorum per group
+    // Each computor is assigned to the group where they have more shares
+    // E = factor normalized within the computor's own group
+    computeGroupMiningFactor(
+        rEpochReveneuData.xmrMiningScore,
+        rEpochReveneuData.dogeMiningScore,
+        REVENUE_SCALE,
+        gRevenueV2Buffers.miningFactor,
+        gRevenueV2Buffers.miningGroup);
 
-    // Combine: M = weighted average of mandatory factors (TX + Oracle), E = bonus (mining)
+    // Combine: M = weighted average of mandatory factors (TX + Oracle), E = group mining factor
     // M = (W_TX*scoreTx + W_ORACLE*scoreOracle) / W_SUM  in  [0, S]
     // revenue = ipc × M × (S² + B×E) / (S × (S+B) × S)
     for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
     {
-        unsigned long long scoreTx = gRevenueV2Buffers.txFactor[i];          // [0, S]
-        unsigned long long scoreOracle = gRevenueV2Buffers.oracleFactor[i];  // [0, S]
-        unsigned long long E = gRevenueV2Buffers.miningFactor[i];         // [0, S]
+        unsigned long long scoreTx = gRevenueV2Buffers.txFactor[i];         // [0, S]
+        unsigned long long scoreOracle = gRevenueV2Buffers.oracleFactor[i]; // [0, S]
+        unsigned long long E = gRevenueV2Buffers.miningFactor[i];           // [0, S]
+
         unsigned long long M = (REVENUE_W_TX * scoreTx + REVENUE_W_ORACLE * scoreOracle) / REVENUE_W_SUM;  // [0, S]
+
         unsigned long long numerator = M * (REVENUE_SCALE * REVENUE_SCALE + REVENUE_BONUS_CAP * E);
         rEpochReveneuData.v2Revenue[i] = (long long)(REVENUE_IPC * numerator / REVENUE_DIVISOR);
     }

--- a/src/revenue.h
+++ b/src/revenue.h
@@ -57,6 +57,12 @@ unsigned long long getQuorumScore(
     const unsigned int numberOfComputors = NUMBER_OF_COMPUTORS,
     const unsigned int quorum = QUORUM)
 {
+    ASSERT((quorum > 0) && (quorum <= QUORUM));
+    if ((quorum == 0) || (quorum > QUORUM))
+    {
+        return 1;
+    }
+
     unsigned long long sortedScore[QUORUM + 1];
     // Sort revenue scores to get lowest score of quorum
     setMem(sortedScore, (quorum + 1) * sizeof(unsigned long long), 0);

--- a/src/ticking/pending_txs_pool.h
+++ b/src/ticking/pending_txs_pool.h
@@ -24,8 +24,8 @@
 class PendingTxsPool
 {
 protected:
-    // The PendingTxsPool will always leave space for the three protocol-level txs (tick votes, custom mining, contract execution fees).
-    static constexpr unsigned int maxNumTxsPerTick = NUMBER_OF_TRANSACTIONS_PER_TICK - 3;
+    // The PendingTxsPool will always leave space for the four protocol-level txs (tick votes, XMR mining, custom mining, contract execution fees).
+    static constexpr unsigned int maxNumTxsPerTick = NUMBER_OF_TRANSACTIONS_PER_TICK - 4;
     static constexpr unsigned long long maxNumTxsTotal = PENDING_TXS_POOL_NUM_TICKS * maxNumTxsPerTick;
 
     // Sizes of different buffers in bytes

--- a/src/ticking/pending_txs_pool.h
+++ b/src/ticking/pending_txs_pool.h
@@ -82,7 +82,10 @@ protected:
             if (balance > 0)
             {
                 if (isZero(tx->destinationPublicKey) && tx->amount == 0LL
-                    && (tx->inputType == VOTE_COUNTER_INPUT_TYPE || tx->inputType == CustomMiningSolutionTransaction::transactionType() || tx->inputType == ExecutionFeeReportTransactionPrefix::transactionType()))
+                    && (tx->inputType == VOTE_COUNTER_INPUT_TYPE 
+                        || tx->inputType == CustomMiningSolutionTransaction::transactionType() 
+                        || tx->inputType == DogeMiningShareTransaction::transactionType()
+                        || tx->inputType == ExecutionFeeReportTransactionPrefix::transactionType()))
                 {
                     // protocol-level tx always have max priority
                     return INT64_MAX;

--- a/test/revenue.cpp
+++ b/test/revenue.cpp
@@ -7,6 +7,11 @@
 #include "../src/revenue.h"
 
 #include <fstream>
+#include <memory>
+
+#ifndef CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP
+#define CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP 10
+#endif
 
 std::string TEST_DIR = "data/";
 std::vector <std::string> REVENUE_FILES = {
@@ -55,7 +60,7 @@ TEST(TestCoreRevenue, ComputeRevFactor)
     unsigned long long dataFactor[NUMBER_OF_COMPUTORS];
 
     // All zeros. No reveue for alls
-    setMem(data, sizeof(data), 0); 
+    setMem(data, sizeof(data), 0);
     computeRevFactor(data, scaleFactor, dataFactor);
     for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
     {
@@ -154,6 +159,386 @@ TEST(TestCoreRevenue, GeneralTest)
         EXPECT_LE(revenuePerComputors[i], arbitratorRevenue);
         EXPECT_GE(revenuePerComputors[i], 0);
     }
+}
+
+// V2 bonus factor end-to-end: run full computeRevenueV2 with different XMR/DOGE
+// combinations. Oracle zero -> fallback (full factor). Uniform TX -> full factor.
+// M = S for all cases, revenue depends only on E = (xmrFactor + dogeFactor) / 2.
+TEST(TestCoreRevenue, V2BonusFactorCombination)
+{
+    constexpr unsigned int TOTAL_TICKS = NUMBER_OF_COMPUTORS * 2;  // must be multiple of 676 for equal rotation
+    static_assert(TOTAL_TICKS >= REVENUE_WINDOW_SIZE, "need enough ticks for sliding window");
+    constexpr unsigned long long S = REVENUE_SCALE;
+    constexpr unsigned long long B = REVENUE_BONUS_CAP;
+
+    // EpochRevenueData is ~17 MB; allocate on the heap to avoid stack overflow.
+    auto dataPtr = std::make_unique<EpochRevenueData>();
+    EpochRevenueData& data = *dataPtr;
+
+    // Helper: setup uniform epoch data for each sub-case
+    // All oracle scores zero -> fallback gives full oracle factor
+    // Uniform TX -> all computors get full TX factor -> M = S
+    auto resetData = [&]()
+        {
+            setMem(&data, sizeof(data), 0);
+            data.initialTick = 0;
+            data.totalTicks = TOTAL_TICKS;
+            for (unsigned int t = 0; t < TOTAL_TICKS; t++)
+            {
+                data.perTickTxCount[t] = 100;
+            }
+        };
+
+    // Both XMR and DOGE full and equal -> tie goes to DOGE group, all uniform -> E = S -> revenue = IPC (100%)
+    resetData();
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        data.xmrMiningScore[i] = 1000;
+        data.dogeMiningScore[i] = 1000;
+    }
+    computeRevenueV2(data);
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(data.v2Revenue[i], REVENUE_IPC);
+    }
+
+    // XMR full, DOGE zero -> all 676 in XMR group, uniform 1000 -> E = S -> revenue = IPC
+    resetData();
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        data.xmrMiningScore[i] = 1000;
+        data.dogeMiningScore[i] = 0;
+    }
+    computeRevenueV2(data);
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(data.v2Revenue[i], REVENUE_IPC);
+    }
+
+    // XMR zero, DOGE full -> all 676 in DOGE group, uniform 1000 -> E = S -> revenue = IPC (symmetric)
+    resetData();
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        data.xmrMiningScore[i] = 0;
+        data.dogeMiningScore[i] = 1000;
+    }
+    computeRevenueV2(data);
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(data.v2Revenue[i], REVENUE_IPC);
+    }
+
+    // Both zero -> all in XMR group with score 0 -> factor 0 -> E = 0 -> revenue = IPC * S/(S+B) ~ 80%
+    resetData();
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        data.xmrMiningScore[i] = 0;
+        data.dogeMiningScore[i] = 0;
+    }
+    computeRevenueV2(data);
+    {
+        unsigned long long numerator = S * (S * S);
+        long long expected = (long long)((unsigned long long)REVENUE_IPC * numerator / REVENUE_DIVISOR);
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            EXPECT_EQ(data.v2Revenue[i], expected);
+        }
+        // Sanity: base revenue should be ~80% of IPC
+        EXPECT_GT(expected, REVENUE_IPC * 79 / 100);
+        EXPECT_LT(expected, REVENUE_IPC * 81 / 100);
+    }
+
+    // Mixed: half DOGE-dominant, half XMR-dominant -> two equal-sized groups, each uniform internally
+    // Both groups: 338 computors, uniform 1000, quorum rank ceil(338*2/3)=226, all >= quorum -> E = S
+    resetData();
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS / 2; i++)
+    {
+        data.xmrMiningScore[i] = 100;
+        data.dogeMiningScore[i] = 1000;  // DOGE > XMR -> DOGE group
+    }
+    for (unsigned int i = NUMBER_OF_COMPUTORS / 2; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        data.xmrMiningScore[i] = 1000;
+        data.dogeMiningScore[i] = 100;   // XMR > DOGE -> XMR group
+    }
+    computeRevenueV2(data);
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(data.v2Revenue[i], REVENUE_IPC);
+    }
+}
+
+// V2 overflow and extreme value tests.
+// Verify that no intermediate computation overflows u64 under worst-case inputs.
+TEST(TestCoreRevenue, V2OverflowExtremeValues)
+{
+    constexpr unsigned long long S = REVENUE_SCALE;
+    constexpr unsigned long long B = REVENUE_BONUS_CAP;
+    constexpr unsigned long long ipc = (unsigned long long)REVENUE_IPC;
+    constexpr unsigned long long u64Max = 0xFFFFFFFFFFFFFFFFULL;
+
+    // Formula intermediate: IPC * M * (S^2 + B*E)
+    //    Max case: M=S=1024, E=S=1024
+    //    numerator = 1024 * (1048576 + 262144) = 1,342,177,280
+    //    product = 1,479,289,940 * 1,342,177,280 ~ 1.985e18 (headroom ~9.3x)
+    {
+        unsigned long long maxNumerator = S * (S * S + B * S);
+        EXPECT_EQ(maxNumerator, 1342177280ULL);
+        EXPECT_LE(maxNumerator, u64Max / ipc);
+
+        unsigned long long maxProduct = ipc * maxNumerator;
+        EXPECT_LE(maxProduct, u64Max);
+
+        // Full factors -> revenue == IPC
+        unsigned long long result = maxProduct / REVENUE_DIVISOR;
+        EXPECT_EQ(result, ipc);
+
+        // Headroom at least 9x
+        EXPECT_GE(u64Max / maxProduct, 9ULL);
+    }
+
+    // Sliding window per-tick score: logScore * S * WINDOW_SIZE
+    //    Max logScore = 7099 (gTxRevenuePoints[1024])
+    //    Per-tick max = 7099 * 1024 * 1351 = 9,820,926,976 (fits u32? no, needs u64)
+    {
+        unsigned long long perTickMax = (unsigned long long)maxTxRevPoints * S * REVENUE_WINDOW_SIZE;
+        EXPECT_EQ(perTickMax, 9820926976ULL);
+        EXPECT_LE(perTickMax, u64Max);
+    }
+
+    // Sliding window accumulated per computor across full epoch
+    //    Each computor gets MAX_NUMBER_OF_TICKS_PER_EPOCH / 676 ticks
+    //    Max accumulated = perTickMax * ticksPerComputor ~ 2.51e13
+    {
+        unsigned long long perTickMax = (unsigned long long)maxTxRevPoints * S * REVENUE_WINDOW_SIZE;
+        unsigned long long ticksPerComputor = MAX_NUMBER_OF_TICKS_PER_EPOCH / NUMBER_OF_COMPUTORS;
+        unsigned long long maxAccum = perTickMax * ticksPerComputor;
+        EXPECT_LE(maxAccum, u64Max);
+        // Headroom should be very large (>100000x)
+        EXPECT_GT(u64Max / maxAccum, 100000ULL);
+    }
+
+    // computeRevFactor overflow: score[i] * scalingThreshold
+    //    Max mining score per computor: 1023 shares/phase * 675 reporters * ~1278 phases ~ 882M
+    //    score * S = 882M * 1024 ~ 9.04e11 -> must fit u64
+    {
+        unsigned long long maxSharesPerPhase = (1ULL << CUSTOM_MINING_SOLUTION_NUM_BIT_PER_COMP) - 1;
+        unsigned long long phaseCycles = MAX_NUMBER_OF_TICKS_PER_EPOCH / (2 * NUMBER_OF_COMPUTORS);
+        unsigned long long maxReporters = NUMBER_OF_COMPUTORS - 1;
+        unsigned long long maxMiningScore = maxSharesPerPhase * maxReporters * phaseCycles;
+        unsigned long long intermediate = maxMiningScore * S;
+        EXPECT_LE(intermediate, u64Max);
+    }
+
+    // End-to-end: run computeRevenueV2 with max TX (1024/tick), max mining scores,
+    //    full epoch worth of ticks. Must not produce negative or >IPC revenue.
+    {
+        constexpr unsigned int TOTAL_TICKS = REVENUE_WINDOW_SIZE + NUMBER_OF_COMPUTORS * 10;
+        // EpochRevenueData is ~17 MB; allocate on the heap to avoid stack overflow.
+        auto dataPtr = std::make_unique<EpochRevenueData>();
+        EpochRevenueData& data = *dataPtr;
+        setMem(&data, sizeof(data), 0);
+        data.initialTick = 0;
+        data.totalTicks = TOTAL_TICKS;
+        for (unsigned int t = 0; t < TOTAL_TICKS; t++)
+        {
+            data.perTickTxCount[t] = 1024;
+        }
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            data.xmrMiningScore[i] = 1000000;
+            data.dogeMiningScore[i] = 1000000;
+        }
+        computeRevenueV2(data);
+
+        long long totalRevenue = 0;
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            EXPECT_GE(data.v2Revenue[i], 0);
+            EXPECT_LE(data.v2Revenue[i], REVENUE_IPC);
+            totalRevenue += data.v2Revenue[i];
+        }
+        EXPECT_LE(totalRevenue, ISSUANCE_RATE);
+        EXPECT_GT(totalRevenue, 0LL);
+    }
+
+    // Zero everything: totalTicks=0, all scores zero -> no crash, zero revenue
+    {
+        // EpochRevenueData is ~17 MB; allocate on the heap to avoid stack overflow.
+        auto dataPtr = std::make_unique<EpochRevenueData>();
+        EpochRevenueData& data = *dataPtr;
+        setMem(&data, sizeof(data), 0);
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            gRevenueComponents.customMiningScore[i] = 0;
+        }
+        computeRevenueV2(data);
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            EXPECT_EQ(data.v2Revenue[i], 0);
+        }
+    }
+}
+
+// Group-based mining factor tests (XMR vs DOGE).
+static void zeroScores(unsigned long long* scores)
+{
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        scores[i] = 0;
+    }
+}
+
+TEST(TestCoreRevenue, V2GroupMining_Classification)
+{
+    constexpr unsigned long long S = REVENUE_SCALE;
+    static unsigned long long xmrScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long dogeScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long miningFactor[NUMBER_OF_COMPUTORS];
+    static MiningGroup miningGroup[NUMBER_OF_COMPUTORS];
+
+    zeroScores(xmrScore);
+    zeroScores(dogeScore);
+
+    for (unsigned int i = 0; i < 200; i++)
+    {
+        dogeScore[i] = 1000;
+        xmrScore[i]  = 100;
+    }
+    for (unsigned int i = 200; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        xmrScore[i] = 1000;
+    }
+
+    computeGroupMiningFactor<MINING_GROUP_BY_MAX>(xmrScore, dogeScore, S, miningFactor, miningGroup);
+
+    for (unsigned int i = 0; i < 200; i++)
+    {
+        EXPECT_EQ(miningGroup[i], MINING_GROUP_DOGE);
+    }
+    for (unsigned int i = 200; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(miningGroup[i], MINING_GROUP_XMR);
+    }
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(miningFactor[i], S);
+    }
+}
+
+TEST(TestCoreRevenue, V2GroupMining_AllZero)
+{
+    constexpr unsigned long long S = REVENUE_SCALE;
+    static unsigned long long xmrScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long dogeScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long miningFactor[NUMBER_OF_COMPUTORS];
+    static MiningGroup miningGroup[NUMBER_OF_COMPUTORS];
+
+    zeroScores(xmrScore);
+    zeroScores(dogeScore);
+
+    computeGroupMiningFactor<MINING_GROUP_BY_MAX>(xmrScore, dogeScore, S, miningFactor, miningGroup);
+
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(miningFactor[i], 0ULL);
+        EXPECT_EQ(miningGroup[i], MINING_GROUP_XMR);
+    }
+}
+
+TEST(TestCoreRevenue, V2GroupMining_LocalQuorum)
+{
+    constexpr unsigned long long S = REVENUE_SCALE;
+    static unsigned long long xmrScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long dogeScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long miningFactor[NUMBER_OF_COMPUTORS];
+    static MiningGroup miningGroup[NUMBER_OF_COMPUTORS];
+
+    zeroScores(xmrScore);
+    zeroScores(dogeScore);
+
+    for (unsigned int i = 0; i < 200; i++)
+    {
+        dogeScore[i] = 1000;
+    }
+    for (unsigned int i = 200; i < 300; i++)
+    {
+        dogeScore[i] = 500;
+    }
+    for (unsigned int i = 300; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        xmrScore[i] = 800;
+    }
+
+    computeGroupMiningFactor<MINING_GROUP_BY_MAX>(xmrScore, dogeScore, S, miningFactor, miningGroup);
+
+    for (unsigned int i = 0; i < 200; i++)
+    {
+        EXPECT_EQ(miningGroup[i], MINING_GROUP_DOGE);
+        EXPECT_EQ(miningFactor[i], S);
+    }
+    for (unsigned int i = 200; i < 300; i++)
+    {
+        EXPECT_EQ(miningGroup[i], MINING_GROUP_DOGE);
+        EXPECT_EQ(miningFactor[i], S / 2);
+    }
+    for (unsigned int i = 300; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(miningGroup[i], MINING_GROUP_XMR);
+        EXPECT_EQ(miningFactor[i], S);
+    }
+}
+
+TEST(TestCoreRevenue, V2GroupMining_TieBreakGoesToDoge)
+{
+    constexpr unsigned long long S = REVENUE_SCALE;
+    static unsigned long long xmrScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long dogeScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long miningFactor[NUMBER_OF_COMPUTORS];
+    static MiningGroup miningGroup[NUMBER_OF_COMPUTORS];
+
+    zeroScores(xmrScore);
+    zeroScores(dogeScore);
+
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        xmrScore[i]  = 500;
+        dogeScore[i] = 500;
+    }
+
+    computeGroupMiningFactor<MINING_GROUP_BY_MAX>(xmrScore, dogeScore, S, miningFactor, miningGroup);
+
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        EXPECT_EQ(miningGroup[i], MINING_GROUP_DOGE);
+        EXPECT_EQ(miningFactor[i], S);
+    }
+}
+
+TEST(TestCoreRevenue, V2GroupMining_AnyDogeStrategy)
+{
+    constexpr unsigned long long S = REVENUE_SCALE;
+    static unsigned long long xmrScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long dogeScore[NUMBER_OF_COMPUTORS];
+    static unsigned long long miningFactor[NUMBER_OF_COMPUTORS];
+    static MiningGroup miningGroup[NUMBER_OF_COMPUTORS];
+
+    zeroScores(xmrScore);
+    zeroScores(dogeScore);
+
+    xmrScore[0] = 1000;
+    dogeScore[0] = 1;
+    for (unsigned int i = 1; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        xmrScore[i] = 1000;
+    }
+
+    computeGroupMiningFactor<MINING_GROUP_BY_MAX>(xmrScore, dogeScore, S, miningFactor, miningGroup);
+    EXPECT_EQ(miningGroup[0], MINING_GROUP_XMR);
+
+    computeGroupMiningFactor<MINING_GROUP_BY_ANY_DOGE>(xmrScore, dogeScore, S, miningFactor, miningGroup);
+    EXPECT_EQ(miningGroup[0], MINING_GROUP_DOGE);
+    EXPECT_EQ(miningFactor[0], S);
 }
 
 // Simulate the revenue fomula from real data


### PR DESCRIPTION
This PR introduces the following changes:
- Change doge oracle query to include the full task description. This enables the oracle to calculate the merkle root from scratch to verify the extraNonce2 (and hence the computor index).
- Change the doge oracle reply to contain the computor index derived from the extraNonce2 for easy revenue counting.
- Add a check for the doge oracle reply if the share belongs to an active task and has not been counted for revenue before.