### PR TITLE
Reenable execution fees for digest computation

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -434,11 +434,10 @@ static void getComputerDigest(m256i& digest)
                 _interlockedadd64(&contractTotalExecutionTime[digestIndex], executionTime);
                 // do not charge contract 0 state digest computation,
                 // only charge execution time if contract is already constructed/not in IPO
-                // TODO: enable this after adding proper tracking of contract state writes
-                //if (digestIndex > 0 && system.epoch >= contractDescriptions[digestIndex].constructionEpoch)
-                //{
-                //    executionTimeAccumulator.addTime(digestIndex, executionTime);
-                //}
+                if (digestIndex > 0 && system.epoch >= contractDescriptions[digestIndex].constructionEpoch)
+                {
+                    executionTimeAccumulator.addTime(digestIndex, executionTime);
+                }
 
                 // Gather data for comparing different versions of K12
                 if (K12MeasurementsCount < 500)


### PR DESCRIPTION
SC state changes are now tracked more fine-grained, hence we can reenable the execution fee deduction for digest computations.

See commit where we disabled it: https://github.com/qubic/core/commit/0d6002b1