### PR TITLE
Update contract-verify for oracle-related code

### DIFF
--- a/.github/workflows/contract-verify.yml
+++ b/.github/workflows/contract-verify.yml
@@ -41,6 +41,6 @@ jobs:
           echo "contract-filepaths=$files" >> "$GITHUB_OUTPUT"
       - name: Contract verify action step
         id: verify
-        uses: Franziska-Mueller/qubic-contract-verify@v1.0.6
+        uses: Franziska-Mueller/qubic-contract-verify@v1.0.7
         with:
           filepaths: '${{ steps.filepaths.outputs.contract-filepaths }}'

--- a/.github/workflows/contract-verify.yml
+++ b/.github/workflows/contract-verify.yml
@@ -41,6 +41,6 @@ jobs:
           echo "contract-filepaths=$files" >> "$GITHUB_OUTPUT"
       - name: Contract verify action step
         id: verify
-        uses: Franziska-Mueller/qubic-contract-verify@v1.0.7
+        uses: Franziska-Mueller/qubic-contract-verify@main
         with:
           filepaths: '${{ steps.filepaths.outputs.contract-filepaths }}'

--- a/.github/workflows/contract-verify.yml
+++ b/.github/workflows/contract-verify.yml
@@ -32,6 +32,8 @@ jobs:
       # Checkout repo to use files of the repo as input for container action
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'true'
       - name: Find all contract files to verify
         id: filepaths
         run: |

--- a/.github/workflows/contract-verify.yml
+++ b/.github/workflows/contract-verify.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Find all contract files to verify
         id: filepaths
         run: |
-          files=$(find src/contracts/ -maxdepth 1 -type f -name "*.h" ! -name "*QUtil*" ! -name "*TestExample*" ! -name "*math_lib*" ! -name "*qpi*" -printf "%p\n" | paste -sd, -)
+          files=$(find src/contracts/ -maxdepth 1 -type f -name "*.h" ! -name "*TestExample*" ! -name "*math_lib*" ! -name "*qpi*" -printf "%p\n" | paste -sd, -)
           echo "contract-filepaths=$files" >> "$GITHUB_OUTPUT"
       - name: Contract verify action step
         id: verify
-        uses: Franziska-Mueller/qubic-contract-verify@v1.0.5
+        uses: Franziska-Mueller/qubic-contract-verify@v1.0.6
         with:
           filepaths: '${{ steps.filepaths.outputs.contract-filepaths }}'


### PR DESCRIPTION
This PR updates the contract-verify tool to handle oracle-related code in smart contract files (see https://github.com/Franziska-Mueller/qubic-contract-verify/pull/5).
The automatic check of the QUtil contract that had been disabled in the past is reenabled.

The contract-verify repo and action have also been updated to use a pre-built docker image (mostly due to inability of github actions to handle the submodule in the verifier repo but it also comes with a nice speed boost of the workflow here because it skips building the docker container).