### PR TITLE
Reject operations targeting non-active contracts

### DIFF
--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -382,6 +382,14 @@ const QpiContextProcedureCall* QPI::QpiContextProcedureCall::__qpiConstructProce
         return nullptr;
     }
 
+    // Check if called contract is active in current epoch
+    if (system.epoch < contractDescriptions[procContractIndex].constructionEpoch
+        || system.epoch >= contractDescriptions[procContractIndex].destructionEpoch)
+    {
+        callError = CallErrorContractInErrorState;
+        return nullptr;
+    }
+
     // Check if called contract has sufficient execution fee reserve (can be skipped for system callbacks)
     if (!skipFeeCheck && getContractFeeReserve(procContractIndex) <= 0)
     {

--- a/src/contract_core/contract_exec.h
+++ b/src/contract_core/contract_exec.h
@@ -386,7 +386,7 @@ const QpiContextProcedureCall* QPI::QpiContextProcedureCall::__qpiConstructProce
     if (system.epoch < contractDescriptions[procContractIndex].constructionEpoch
         || system.epoch >= contractDescriptions[procContractIndex].destructionEpoch)
     {
-        callError = CallErrorContractInErrorState;
+        callError = CallErrorContractInactive;
         return nullptr;
     }
 

--- a/src/contract_core/qpi_asset_impl.h
+++ b/src/contract_core/qpi_asset_impl.h
@@ -396,6 +396,8 @@ sint64 QPI::QpiContextProcedureCall::acquireShares(
     if (sourcePossessionManagingContractIndex == _currentContractIndex
         || sourcePossessionManagingContractIndex == 0
         || sourcePossessionManagingContractIndex >= contractCount
+        || system.epoch < contractDescriptions[sourcePossessionManagingContractIndex].constructionEpoch
+        || system.epoch >= contractDescriptions[sourcePossessionManagingContractIndex].destructionEpoch
         || numberOfShares <= 0
         || offeredTransferFee < 0)
     {

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -71,6 +71,7 @@ namespace QPI
 		CallErrorContractInErrorState = 1,      // Called contract is already in error state
 		CallErrorInsufficientFees = 2,          // Called contract has no execution fee reserve
 		CallErrorAllocationFailed = 3,          // Failed to allocate context on stack
+		CallErrorContractInactive = 4,			// Called contract has been inactive
 	};
 
 	typedef uint128_t uint128;


### PR DESCRIPTION
With the fix for `releaseShares` , the following functions are automatically safe because they can no longer reach a non-active contract through the call chain that releaseShares gates. 
Add epoch checks to these as defensive measures:
- `acquireShares()`: defensive check added for robustness.
- `__qpiConstructProcedureCallContext()`: defensive epoch check added as a catch-all for all current and future callback paths.