### PR TITLE
Replace inline mask-based check with isPublicKeyOfContract.

### DIFF
--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3233,15 +3233,9 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
                 // Contracts are identified by their index stored in the first 64 bits of the id, all
                 // other bits are zeroed. However, the max number of contracts is limited to 2^32 - 1,
                 // only 32 bits are used for the contract index.
-                // TODO: measure run-time of this check vs the check implemented in isPublicKeyOfContract() in gtest
-                // with a large number of keys; modify the function if the check used here is faster; replace this
-                // and such checks at other places by calls to isPublicKeyOfContract()
-                m256i maskedDestinationPublicKey = transaction->destinationPublicKey;
-                maskedDestinationPublicKey.m256i_u64[0] &= ~(MAX_NUMBER_OF_CONTRACTS - 1ULL);
-                unsigned int contractIndex = (unsigned int)transaction->destinationPublicKey.m256i_u64[0];
-                if (isZero(maskedDestinationPublicKey)
-                    && contractIndex < contractCount)
+                if (isPublicKeyOfContract(transaction->destinationPublicKey))
                 {
+                    unsigned int contractIndex = (unsigned int)transaction->destinationPublicKey.m256i_u64[0];
                     // Contract transactions
                     if (system.epoch == (contractDescriptions[contractIndex].constructionEpoch - 1))
                     {
@@ -3656,10 +3650,7 @@ static void processTick(unsigned long long processorNumber)
                     }
                     else
                     {
-                        m256i masked = transaction->destinationPublicKey;
-                        masked.m256i_u64[0] &= ~(unsigned long long)(MAX_NUMBER_OF_CONTRACTS - 1);
-                        unsigned int cIdx = (unsigned int)transaction->destinationPublicKey.m256i_u64[0];
-                        if (isZero(masked) && cIdx < contractCount)
+                        if (isPublicKeyOfContract(transaction->destinationPublicKey))
                         {
                             nContractTx++;
                         }

--- a/test/contract_core.cpp
+++ b/test/contract_core.cpp
@@ -5,6 +5,9 @@
 #define TRACK_MAX_STACK_BUFFER_SIZE
 #include "../src/contract_core/stack_buffer.h"
 #include "../src/contract_core/contract_action_tracker.h"
+#include "contract_testing.h"
+
+#include <chrono>
 
 TEST(TestCoreContractCore, StackBuffer)
 {
@@ -164,4 +167,57 @@ TEST(TestCoreContractCore, ContractActionTracker)
     EXPECT_EQ(at.getOverallQuTransferBalance(id2), 300);
 
     at.freeBuffer();
+}
+
+static inline bool isPublicKeyOfContractMaskedCheck(const m256i& publicKey)
+{
+    m256i masked = publicKey;
+    masked.m256i_u64[0] &= ~(MAX_NUMBER_OF_CONTRACTS - 1ULL);
+    unsigned int cIdx = (unsigned int)publicKey.m256i_u64[0];
+    return isZero(masked) && cIdx < contractCount;
+}
+
+TEST(TestCoreContractCore, isPublicKeyOfContract)
+{
+    constexpr size_t N = 10000000;
+    std::vector<m256i> keys(N);
+    for (auto& key : keys)
+    {
+        key.setRandomValue();
+        if ((key.m256i_u64[0] & 0xFF) < 51) // 51/256 ~= 20% of keys are surely contract public key
+        {
+            key.m256i_u64[0] %= contractCount;
+            key.m256i_u64[1] = 0;
+            key.m256i_u64[2] = 0;
+            key.m256i_u64[3] = 0;
+        }
+    }
+    unsigned long long checksumA = 0;
+    unsigned long long checksumB = 0;
+    auto t0 = std::chrono::steady_clock::now();
+    for (const auto& k : keys)
+    {
+        checksumA += static_cast<unsigned long long>(isPublicKeyOfContractMaskedCheck(k));
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    for (const auto& k : keys)
+    {
+        checksumB += static_cast<unsigned long long>(isPublicKeyOfContract(k));
+    }
+    auto t2 = std::chrono::steady_clock::now();
+
+    double nsPerCallA = std::chrono::duration<double, std::nano>(t1 - t0).count() / N;
+    double nsPerCallB = std::chrono::duration<double, std::nano>(t2 - t1).count() / N;
+    double totalMsA = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    double totalMsB = std::chrono::duration<double, std::milli>(t2 - t1).count();
+
+    std::cout << "isPublicKeyOfContractMaskedCheck: " << totalMsA << " ms total, " << nsPerCallA << " ns/call\n";
+    std::cout << "isPublicKeyOfContract:            " << totalMsB << " ms total, " << nsPerCallB << " ns/call\n";
+    EXPECT_EQ(checksumA, checksumB);
+
+    // 2 versions should have the same value
+    for (unsigned int i = 0; i < 1024; ++i)
+    {
+        EXPECT_EQ(isPublicKeyOfContractMaskedCheck(keys[i]), isPublicKeyOfContract(keys[i]));
+    }
 }


### PR DESCRIPTION
This PR,
- Replaces both occurrences of the inline pattern in qubic.cpp (processTick transaction dispatch and tx classification counters) and removes the related TODO. 
- Benchmark (10M random keys, ~20% valid contract keys, Release build) get ~6x speedup.
- Adds a regression benchmark in test/contract_core.cpp so future changes to either form are compared.