### PR TITLE
Hotfix for tx status addon

### DIFF
--- a/src/addons/tx_status_request.h
+++ b/src/addons/tx_status_request.h
@@ -23,8 +23,8 @@ typedef struct
     m256i digest;
 } ConfirmedTx;
 
-constexpr unsigned long long confirmedTxCurrentEpochLength = (((unsigned long long)MAX_NUMBER_OF_TICKS_PER_EPOCH) * NUMBER_OF_TRANSACTIONS_PER_TICK / TRANSACTION_SPARSENESS);
-constexpr unsigned long long confirmedTxPreviousEpochLength = (((unsigned long long)TICKS_TO_KEEP_FROM_PRIOR_EPOCH) * NUMBER_OF_TRANSACTIONS_PER_TICK / TRANSACTION_SPARSENESS);
+constexpr unsigned long long confirmedTxCurrentEpochLength = (((unsigned long long)MAX_NUMBER_OF_TICKS_PER_EPOCH) * NUMBER_OF_TRANSACTIONS_PER_TICK);
+constexpr unsigned long long confirmedTxPreviousEpochLength = (((unsigned long long)TICKS_TO_KEEP_FROM_PRIOR_EPOCH) * NUMBER_OF_TRANSACTIONS_PER_TICK);
 constexpr unsigned long long confirmedTxLength = confirmedTxCurrentEpochLength + confirmedTxPreviousEpochLength;
 
 // Memory to store confirmed TX's (arrays store data of current epoch, followed by last ticks of previous epoch)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -2739,6 +2739,7 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
                     if (error && transaction->amount)
                     {
                         oracleEngine.refundFees(transaction->sourcePublicKey, transaction->amount);
+                        moneyFlew = false;
                     }
                 }
                 break;


### PR DESCRIPTION
This epoch, the integration reported that starting with tick 49869260, the tx status addon behaved incorrectly, not providing any tx info in response to `RequestTxStatus`.

Computor operator commonly increase the `TRANSACTION_SPARSENESS` value compared to the vanilla setting. Next to the size of the transaction body storage buffer, it also influences the maximum number of transactions that can be stored by the tx status addon. This probably led to the problem, because the buffer went full due to the increased number of tx (doge oracle commits).

This PR increases the `confirmedTx` buffer size, making it ready for the maximum number of tx supported per epoch.

It also fixes that moneyflew was set in case of `OracleUserQueryTransaction` errors (when the fee is reimbursed).