### PR TITLE
retry doge query only if task still active

### DIFF
--- a/src/mining/custom_qubic_mining_storage.h
+++ b/src/mining/custom_qubic_mining_storage.h
@@ -61,6 +61,7 @@ public:
         int64_t queryId;
         m256i sourcePublicKey;
         unsigned int numTries;
+        uint64_t taskId;
 
         static OracleQueryInfo makeDefault()
         {
@@ -70,7 +71,8 @@ public:
                 .status = SCHEDULED,
                 .queryId = -1,
                 .sourcePublicKey = m256i::zero(),
-                .numTries = 0
+                .numTries = 0,
+                .taskId = 0
             };
         }
     };
@@ -101,15 +103,19 @@ public:
 
     // Add a new oracle query. Return true if added successfully or the same query already exists. Return false if the storage is full
     // or the oracle interface is unrecognized.
-    bool addOracleQuery(const OracleUserQueryTransactionPrefix* queryTx);
+    bool addOracleQuery(const OracleUserQueryTransactionPrefix* queryTx, uint64_t jobId);
 
-    // Returns true if the fail counter for this query could be increased without hitting maxNumTries. In this case, the query's tick is updated
-    // to newScheduledTick, the status is set to SCHEDULED and the queryId is reset to -1. Returns false if the query is not found or the counter
-    // has hit maxNumTries. A query that has hit maxNumTries is removed from storage.
+    // Returns true if the fail counter for this query could be increased without hitting maxNumTries and the corresponding task is still active.
+    // In this case, the query's tick is updated to newScheduledTick, the status is set to SCHEDULED and the queryId is reset to -1.
+    // Returns false if the query is not found, the task is not active anymore, or the counter has hit maxNumTries.
+    // In these cases, the query is removed from storage.
     bool increaseOracleQueryFailCounterAndReschedule(unsigned int oracleInterfaceIndex, int64_t queryId, unsigned int newScheduledTick);
 
     // Remove the given oracle query from storage. Return true if removed successfully, false if the query is not found.
     bool removeOracleQuery(const OracleUserQueryTransactionPrefix* queryTx);
+
+    // Remove the oracle query at the given index from storage. Return true if removed successfully, false if the input type or index are out of range.
+    bool removeOracleQuery(uint8_t customMiningType, unsigned int queryIndex);
 
     // Remove the given oracle query from storage. Return true if removed successfully, false if the query is not found.
     // This method only works for queries with status STARTED that already have a valid queryId.
@@ -165,39 +171,39 @@ private:
     // Converts the compact representation of the target (4 bytes) to the full 32-byte representation, and writes it to the provided output pointer.
     // Expected input byte order: bytes 0 - 2 mantissa in little endian, byte 3 exponent.
     // Output byte order: little endian, i.e. least-significant byte in index 0.
-    static void convertTargetCompactToFull(const uint8_t* compact, uint8_t* full);
+    static void _convertTargetCompactToFull(const uint8_t* compact, uint8_t* full);
 
     // Map the oracle interface index to the corresponding custom mining type. Returns an invalid mining type if the oracle interface index is not recognized.
-    static uint8_t oracleInterfaceIndexToCustomMiningType(unsigned int oracleInterfaceIndex);
+    static uint8_t _oracleInterfaceIndexToCustomMiningType(unsigned int oracleInterfaceIndex);
 
     // Return the mining-type-specific index of the task with the given jobId and customMiningType, or -1 if not found.
     // The returned index can then be used to access the type-specific task descriptions and the solution hash set for this task.
     // Assumes the caller holds the lock and has verified valid range for customMiningType.
-    int findTask(uint8_t customMiningType, uint64_t jobId) const;
+    int _findTask(uint8_t customMiningType, uint64_t jobId) const;
 
     // Return the mining-type-specific index of the oracle query, or -1 if not found.
     // Assumes the caller holds the lock and has verified valid range for customMiningType.
-    int findOracleQuery(uint8_t customMiningType, const OracleUserQueryTransactionPrefix* queryTx) const;
+    int _findOracleQuery(uint8_t customMiningType, const OracleUserQueryTransactionPrefix* queryTx) const;
 
     // Return the mining-type-specific index of the oracle query, or -1 if not found.
     // Assumes the caller holds the lock and has verified valid range for customMiningType.
     // This method only works for queries with status STARTED that already have a valid queryId.
-    int findOracleQuery(uint8_t customMiningType, int64_t queryId) const;
+    int _findOracleQuery(uint8_t customMiningType, int64_t queryId) const;
 
     // Return true if the type-specific oracle query matches the stored query at the given index, false otherwise.
     // Assumes the caller holds the lock and has verified valid ranges for customMiningType and queryIndex.
-    bool isQueryEqual(uint8_t customMiningType, unsigned int queryIndex, const char* typeSpecificOracleQuery) const;
+    bool _isQueryEqual(uint8_t customMiningType, unsigned int queryIndex, const char* typeSpecificOracleQuery) const;
 
     // Remove the oracle query at the given index from storage.
     // Assumes the caller holds the lock and has verified valid ranges for customMiningType and queryIndex.
-    void removeOracleQuery(uint8_t customMiningType, unsigned int queryIndex);
+    void _removeOracleQuery(uint8_t customMiningType, unsigned int queryIndex);
 };
 
 // --- Implementation follows below ---
 
 // --- private methods ---
 
-void CustomQubicMiningStorage::convertTargetCompactToFull(const uint8_t* compact, uint8_t* full)
+void CustomQubicMiningStorage::_convertTargetCompactToFull(const uint8_t* compact, uint8_t* full)
 {
     setMem(full, 32, 0);
 
@@ -217,7 +223,7 @@ void CustomQubicMiningStorage::convertTargetCompactToFull(const uint8_t* compact
     }
 }
 
-uint8_t CustomQubicMiningStorage::oracleInterfaceIndexToCustomMiningType(unsigned int oracleInterfaceIndex)
+uint8_t CustomQubicMiningStorage::_oracleInterfaceIndexToCustomMiningType(unsigned int oracleInterfaceIndex)
 {
     if (oracleInterfaceIndex == OI::DogeShareValidation::oracleInterfaceIndex)
         return CustomMiningType::DOGE;
@@ -226,7 +232,7 @@ uint8_t CustomQubicMiningStorage::oracleInterfaceIndexToCustomMiningType(unsigne
     return CustomMiningType::TOTAL_NUM_TYPES;
 }
 
-int CustomQubicMiningStorage::findTask(uint8_t customMiningType, uint64_t jobId) const
+int CustomQubicMiningStorage::_findTask(uint8_t customMiningType, uint64_t jobId) const
 {
     ASSERT(customMiningType < CustomMiningType::TOTAL_NUM_TYPES);
 
@@ -238,7 +244,7 @@ int CustomQubicMiningStorage::findTask(uint8_t customMiningType, uint64_t jobId)
     return -1;
 }
 
-int CustomQubicMiningStorage::findOracleQuery(uint8_t customMiningType, const OracleUserQueryTransactionPrefix* queryTx) const
+int CustomQubicMiningStorage::_findOracleQuery(uint8_t customMiningType, const OracleUserQueryTransactionPrefix* queryTx) const
 {
     ASSERT(customMiningType < CustomMiningType::TOTAL_NUM_TYPES);
 
@@ -247,7 +253,7 @@ int CustomQubicMiningStorage::findOracleQuery(uint8_t customMiningType, const Or
         if (oracleQueries[customMiningType][i].tick == queryTx->tick &&
             oracleQueries[customMiningType][i].sourcePublicKey == queryTx->sourcePublicKey)
         {
-            if (isQueryEqual(customMiningType, i, reinterpret_cast<const char*>(queryTx) + sizeof(OracleUserQueryTransactionPrefix)))
+            if (_isQueryEqual(customMiningType, i, reinterpret_cast<const char*>(queryTx) + sizeof(OracleUserQueryTransactionPrefix)))
             {
                 return i;
             }
@@ -256,7 +262,7 @@ int CustomQubicMiningStorage::findOracleQuery(uint8_t customMiningType, const Or
     return -1;
 }
 
-int CustomQubicMiningStorage::findOracleQuery(uint8_t customMiningType, int64_t queryId) const
+int CustomQubicMiningStorage::_findOracleQuery(uint8_t customMiningType, int64_t queryId) const
 {
     ASSERT(customMiningType < CustomMiningType::TOTAL_NUM_TYPES);
 
@@ -271,7 +277,7 @@ int CustomQubicMiningStorage::findOracleQuery(uint8_t customMiningType, int64_t 
     return -1;
 }
 
-bool CustomQubicMiningStorage::isQueryEqual(uint8_t customMiningType, unsigned int queryIndex, const char* typeSpecificOracleQuery) const
+bool CustomQubicMiningStorage::_isQueryEqual(uint8_t customMiningType, unsigned int queryIndex, const char* typeSpecificOracleQuery) const
 {
     if (customMiningType == CustomMiningType::DOGE)
     {
@@ -297,7 +303,7 @@ bool CustomQubicMiningStorage::isQueryEqual(uint8_t customMiningType, unsigned i
     return false;
 }
 
-void CustomQubicMiningStorage::removeOracleQuery(uint8_t customMiningType, unsigned int queryIndex)
+void CustomQubicMiningStorage::_removeOracleQuery(uint8_t customMiningType, unsigned int queryIndex)
 {
     ASSERT(customMiningType < CustomMiningType::TOTAL_NUM_TYPES);
     ASSERT(queryIndex < maxNumTasks * maxNumSolutionsPerTask);
@@ -343,7 +349,7 @@ bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsign
 {
     LockGuard guard(lock);
 
-    if (findTask(task->customMiningType, task->jobId) < 0)
+    if (_findTask(task->customMiningType, task->jobId) < 0)
     {
         unsigned int typeSpecificTaskIndex = 0;
         if (task->customMiningType == CustomMiningType::DOGE)
@@ -366,7 +372,7 @@ bool CustomQubicMiningStorage::addTask(const CustomQubicMiningTask* task, unsign
             countedRevSolutions[CustomMiningType::DOGE * maxNumTasks + nextDogeTaskId].reset();
 
             dogeTasks[nextDogeTaskId].jobId = task->jobId;
-            convertTargetCompactToFull(dogeTask->dispatcherDifficulty, dogeTasks[nextDogeTaskId].dispatcherTarget);
+            _convertTargetCompactToFull(dogeTask->dispatcherDifficulty, dogeTasks[nextDogeTaskId].dispatcherTarget);
             copyMem(dogeTasks[nextDogeTaskId].version, dogeTask->version, 4);
             copyMem(dogeTasks[nextDogeTaskId].nBits, dogeTask->nBits, 4);
             copyMem(dogeTasks[nextDogeTaskId].prevHash, dogeTask->prevHash, 32);
@@ -403,7 +409,7 @@ int CustomQubicMiningStorage::addSolution(const CustomQubicMiningSolution* solut
     LockGuard guard(lock);
 
     // Check if the solution corresponds to an active task.
-    int typeSpecificTaskIndex = findTask(solution->customMiningType, solution->jobId);
+    int typeSpecificTaskIndex = _findTask(solution->customMiningType, solution->jobId);
     if (typeSpecificTaskIndex < 0)
         return -1;
 
@@ -438,7 +444,7 @@ bool CustomQubicMiningStorage::countSolutionForRevenue(uint8_t customMiningType,
     LockGuard guard(lock);
 
     // Check if the solution corresponds to an active task.
-    int typeSpecificTaskIndex = findTask(customMiningType, jobId);
+    int typeSpecificTaskIndex = _findTask(customMiningType, jobId);
     if (typeSpecificTaskIndex < 0)
         return false;
 
@@ -457,18 +463,18 @@ bool CustomQubicMiningStorage::countSolutionForRevenue(uint8_t customMiningType,
 bool CustomQubicMiningStorage::containsTask(uint8_t customMiningType, uint64_t jobId)
 {
     LockGuard guard(lock);
-    return findTask(customMiningType, jobId) >= 0;
+    return _findTask(customMiningType, jobId) >= 0;
 }
 
-bool CustomQubicMiningStorage::addOracleQuery(const OracleUserQueryTransactionPrefix* queryTx)
+bool CustomQubicMiningStorage::addOracleQuery(const OracleUserQueryTransactionPrefix* queryTx, uint64_t jobId)
 {
-    uint8_t customMiningType = oracleInterfaceIndexToCustomMiningType(queryTx->oracleInterfaceIndex);
+    uint8_t customMiningType = _oracleInterfaceIndexToCustomMiningType(queryTx->oracleInterfaceIndex);
     if (customMiningType >= CustomMiningType::TOTAL_NUM_TYPES)
         return false; // unsupported oracle interface
 
     LockGuard guard(lock);
 
-    if (findOracleQuery(customMiningType, queryTx) >= 0) // check if the query already exists, if yes we don't add it again but return true
+    if (_findOracleQuery(customMiningType, queryTx) >= 0) // check if the query already exists, if yes we don't add it again but return true
         return true;
 
     for (unsigned int i = 0; i < maxNumTasks * maxNumSolutionsPerTask; ++i)
@@ -480,6 +486,7 @@ bool CustomQubicMiningStorage::addOracleQuery(const OracleUserQueryTransactionPr
             oracleQueries[customMiningType][i].queryId = -1;
             oracleQueries[customMiningType][i].sourcePublicKey = queryTx->sourcePublicKey;
             oracleQueries[customMiningType][i].numTries = 0;
+            oracleQueries[customMiningType][i].taskId = jobId;
 
             if (queryTx->oracleInterfaceIndex == OI::DogeShareValidation::oracleInterfaceIndex)
             {
@@ -494,28 +501,29 @@ bool CustomQubicMiningStorage::addOracleQuery(const OracleUserQueryTransactionPr
 
 bool CustomQubicMiningStorage::increaseOracleQueryFailCounterAndReschedule(unsigned int oracleInterfaceIndex, int64_t queryId, unsigned int newScheduledTick)
 {
-    uint8_t customMiningType = oracleInterfaceIndexToCustomMiningType(oracleInterfaceIndex);
+    uint8_t customMiningType = _oracleInterfaceIndexToCustomMiningType(oracleInterfaceIndex);
     if (customMiningType >= CustomMiningType::TOTAL_NUM_TYPES)
         return false; // unsupported oracle interface
 
     LockGuard guard(lock);
 
-    int queryIndex = findOracleQuery(customMiningType, queryId);
+    int queryIndex = _findOracleQuery(customMiningType, queryId);
     if (queryIndex >= 0)
     {
         oracleQueries[customMiningType][queryIndex].numTries++;
-        if (oracleQueries[customMiningType][queryIndex].numTries >= oracleQueryMaxNumTries)
+
+        if (oracleQueries[customMiningType][queryIndex].numTries >= oracleQueryMaxNumTries
+            || _findTask(customMiningType, oracleQueries[customMiningType][queryIndex].taskId) < 0)
         {
-            removeOracleQuery(customMiningType, queryIndex);
+            _removeOracleQuery(customMiningType, queryIndex);
             return false;
         }
-        else
-        {
-            oracleQueries[customMiningType][queryIndex].tick = newScheduledTick;
-            oracleQueries[customMiningType][queryIndex].status = SCHEDULED;
-            oracleQueries[customMiningType][queryIndex].queryId = -1;
-            return true;
-        }
+
+        oracleQueries[customMiningType][queryIndex].tick = newScheduledTick;
+        oracleQueries[customMiningType][queryIndex].status = SCHEDULED;
+        oracleQueries[customMiningType][queryIndex].queryId = -1;
+
+        return true;  
     }
 
     return false;
@@ -523,34 +531,45 @@ bool CustomQubicMiningStorage::increaseOracleQueryFailCounterAndReschedule(unsig
 
 bool CustomQubicMiningStorage::removeOracleQuery(const OracleUserQueryTransactionPrefix* queryTx)
 {
-    uint8_t customMiningType = oracleInterfaceIndexToCustomMiningType(queryTx->oracleInterfaceIndex);
+    uint8_t customMiningType = _oracleInterfaceIndexToCustomMiningType(queryTx->oracleInterfaceIndex);
     if (customMiningType >= CustomMiningType::TOTAL_NUM_TYPES)
         return false; // unsupported oracle interface
 
     LockGuard guard(lock);
 
-    int queryIndex = findOracleQuery(customMiningType, queryTx);
+    int queryIndex = _findOracleQuery(customMiningType, queryTx);
     if (queryIndex >= 0)
     {
-        removeOracleQuery(customMiningType, queryIndex);
+        _removeOracleQuery(customMiningType, queryIndex);
         return true;
     }
 
     return false;
 }
 
+bool CustomQubicMiningStorage::removeOracleQuery(uint8_t customMiningType, unsigned int queryIndex)
+{
+    if (customMiningType >= CustomMiningType::TOTAL_NUM_TYPES || queryIndex >= maxNumTasks * maxNumSolutionsPerTask)
+        return false; // out of range input
+
+    LockGuard guard(lock);
+    _removeOracleQuery(customMiningType, queryIndex);
+
+    return true;
+}
+
 bool CustomQubicMiningStorage::removeOracleQuery(unsigned int oracleInterfaceIndex, int64_t queryId)
 {
-    uint8_t customMiningType = oracleInterfaceIndexToCustomMiningType(oracleInterfaceIndex);
+    uint8_t customMiningType = _oracleInterfaceIndexToCustomMiningType(oracleInterfaceIndex);
     if (customMiningType >= CustomMiningType::TOTAL_NUM_TYPES)
         return false; // unsupported oracle interface
 
     LockGuard guard(lock);
 
-    int queryIndex = findOracleQuery(customMiningType, queryId);
+    int queryIndex = _findOracleQuery(customMiningType, queryId);
     if (queryIndex >= 0)
     {
-        removeOracleQuery(customMiningType, queryIndex);
+        _removeOracleQuery(customMiningType, queryIndex);
         return true;
     }
 
@@ -559,13 +578,13 @@ bool CustomQubicMiningStorage::removeOracleQuery(unsigned int oracleInterfaceInd
 
 bool CustomQubicMiningStorage::markOracleQueryStarted(const OracleUserQueryTransactionPrefix* queryTx, int64_t queryId)
 {
-    uint8_t customMiningType = oracleInterfaceIndexToCustomMiningType(queryTx->oracleInterfaceIndex);
+    uint8_t customMiningType = _oracleInterfaceIndexToCustomMiningType(queryTx->oracleInterfaceIndex);
     if (customMiningType >= CustomMiningType::TOTAL_NUM_TYPES)
         return false; // unsupported oracle interface
 
     LockGuard guard(lock);
 
-    int queryIndex = findOracleQuery(customMiningType, queryTx);
+    int queryIndex = _findOracleQuery(customMiningType, queryTx);
     if (queryIndex >= 0)
     {
         oracleQueries[customMiningType][queryIndex].status = STARTED;

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -27,17 +27,6 @@ static const unsigned char whiteListPeers[][4] = {
 };
 */
 
-// Enables basic DOGE oracle query handling, i.e. an oracle query tx is broadcasted once when a solution from an associated comp pool arrives.
-#define BASIC_DOGE_ORACLE_QUERIES 1
-// Enables retry mechanisms for DOGE oracle queries where the query tx was either not included in the scheduled tick or the oracle query failed (e.g. timeout).
-#define RETRY_DOGE_ORACLE_QUERIES 1
-
-// DO NOT CHANGE: Basic DOGE oracle queries need to be enabled to support the retry mechanisms.
-#if RETRY_DOGE_ORACLE_QUERIES && !BASIC_DOGE_ORACLE_QUERIES
-#undef BASIC_DOGE_ORACLE_QUERIES
-#define BASIC_DOGE_ORACLE_QUERIES 1
-#endif
-
 // Enter static IPs of one or multiple oracle machine node(s). This node will connect to these and try to keep the
 // connection open for low latency. The oracle machine nodes also need to whitelist the IP of this core node.
 static const unsigned char oracleMachineIPs[][4] = {

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1442,7 +1442,7 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
                     queryData->numMerkleBranches = task.numMerkleBranches;
                     copyMem(queryData->additionalData, task.additionalData, OI::DogeShareValidation::OracleQuery::additionalDataSize);
 
-                    customQubicMiningStorage.addOracleQuery(tx);
+                    customQubicMiningStorage.addOracleQuery(tx, task.jobId);
 
                     if (isMainMode()) // only main node should send oracle queries
                     {
@@ -3158,11 +3158,20 @@ static void processTick(unsigned long long processorNumber)
         PROFILE_SCOPE_END();
     }
 
-    // Resend oracle queries for share validation if they were scheduled for but not included in this tick.
+    // Resend own oracle queries for share validation if they were scheduled for but not included in this tick.
     int currentQueryIndex = customQubicMiningStorage.getNextScheduledQueryIndexForTick(CustomMiningType::DOGE, /*currentQueryIndex=*/-1, system.tick);
     while (currentQueryIndex >= 0)
     {
         CustomQubicMiningStorage::OracleQueryInfo queryInfo = customQubicMiningStorage.getOracleQueryInfo(CustomMiningType::DOGE, currentQueryIndex);
+        
+        // Check if task is still active before rescheduling (revenue points can only be counted for active tasks).
+        if (!customQubicMiningStorage.containsTask(CustomMiningType::DOGE, queryInfo.taskId))
+        {
+            customQubicMiningStorage.removeOracleQuery(CustomMiningType::DOGE, currentQueryIndex);
+            currentQueryIndex = customQubicMiningStorage.getNextScheduledQueryIndexForTick(CustomMiningType::DOGE, currentQueryIndex, system.tick);
+            continue;
+        }
+
         for (unsigned int i = 0; i < computorSeedsCount; ++i)
         {
             if (computorPublicKeys[i] == queryInfo.sourcePublicKey)

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1356,10 +1356,8 @@ static void processBroadcastCustomMiningTask(RequestResponseHeader* header)
     if (verify(dogeDispatcherPubkey, digest.m256i_u8, payload + (messageSize - SIGNATURE_SIZE)))
     {
         enqueueResponse(NULL, header);
-#if BASIC_DOGE_ORACLE_QUERIES
         customQubicMiningStorage.addTask(reinterpret_cast<const CustomQubicMiningTask*>(payload), messageSize - SIGNATURE_SIZE);
         ATOMIC_INC64(gDogeMiningStats.phaseV2.tasks);
-#endif
     }
 }
 
@@ -1390,7 +1388,6 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
         // Broadcast the solution to peers.
         enqueueResponse(NULL, header);
 
-#if BASIC_DOGE_ORACLE_QUERIES
         if (sol->customMiningType == CustomMiningType::DOGE)
         {
             if (messageSize - SIGNATURE_SIZE < sizeof(CustomQubicMiningSolution) + sizeof(QubicDogeMiningSolution))
@@ -1445,9 +1442,7 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
                     queryData->numMerkleBranches = task.numMerkleBranches;
                     copyMem(queryData->additionalData, task.additionalData, OI::DogeShareValidation::OracleQuery::additionalDataSize);
 
-#if RETRY_DOGE_ORACLE_QUERIES
                     customQubicMiningStorage.addOracleQuery(tx);
-#endif
 
                     if (isMainMode()) // only main node should send oracle queries
                     {
@@ -1460,7 +1455,6 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
                 }
             }
         }
-#endif
     }
 }
 
@@ -2715,7 +2709,6 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
                     int64_t queryId = oracleEngine.startUserQuery(queryTx, transactionIndex, forceZeroFee);
                     const bool error = queryId < 0;
 
-#if RETRY_DOGE_ORACLE_QUERIES
                     if (queryTx->oracleInterfaceIndex == OI::DogeShareValidation::oracleInterfaceIndex)
                     {
                         if (error)
@@ -2728,7 +2721,6 @@ static void processTickTransaction(const Transaction* transaction, unsigned int 
                             customQubicMiningStorage.markOracleQueryStarted((const OracleUserQueryTransactionPrefix*)transaction, queryId);
                         }
                     }
-#endif
 
                     if (error && transaction->amount)
                     {
@@ -3166,7 +3158,6 @@ static void processTick(unsigned long long processorNumber)
         PROFILE_SCOPE_END();
     }
 
-#if RETRY_DOGE_ORACLE_QUERIES
     // Resend oracle queries for share validation if they were scheduled for but not included in this tick.
     int currentQueryIndex = customQubicMiningStorage.getNextScheduledQueryIndexForTick(CustomMiningType::DOGE, /*currentQueryIndex=*/-1, system.tick);
     while (currentQueryIndex >= 0)
@@ -3210,7 +3201,6 @@ static void processTick(unsigned long long processorNumber)
         }
         currentQueryIndex = customQubicMiningStorage.getNextScheduledQueryIndexForTick(CustomMiningType::DOGE, currentQueryIndex, system.tick);
     }
-#endif
 
     // Generate subscription queries (may create queries that immediately timeout if the network was stuck)
     oracleEngine.generateSubscriptionQueries();
@@ -3260,10 +3250,8 @@ static void processTick(unsigned long long processorNumber)
                 if (finishedUserQuery->status == ORACLE_QUERY_STATUS_SUCCESS
                     && oracleEngine.getOracleReply(finishedUserQuery->queryId, &reply, sizeof(reply)))
                 {
-#if RETRY_DOGE_ORACLE_QUERIES
                     // Oracle query was successful, remove from storage.
                     customQubicMiningStorage.removeOracleQuery(finishedUserQuery->interfaceIndex, finishedUserQuery->queryId);
-#endif
 
                     // Oracle reply is available
                     if (reply.isValid)
@@ -3296,7 +3284,6 @@ static void processTick(unsigned long long processorNumber)
                         ATOMIC_INC64(gDogeMiningStats.phaseV2.invalid);
                     }
                 }
-#if RETRY_DOGE_ORACLE_QUERIES
                 else
                 {
                     // Oracle query failed -> resend user query tx if it is from own comp pool
@@ -3328,7 +3315,6 @@ static void processTick(unsigned long long processorNumber)
                         }
                     }
                 }
-#endif
             }
         }
         finishedUserQuery = oracleEngine.getFinishedUserQuery();


### PR DESCRIPTION
This PR improves the doge oracle query retry mechanisms to only reschedule doge oracle queries if the corresponding task is still active. Revenue points are only counted for active tasks so rescheduling does not make sense if the task is stale.

minor changes:
- remove toggles for basic doge oracle queries and retry mechanisms -> always on now
- add `_` prefix to non-public methods in the `CustomQubicMiningStorage` class to easily spot where locking is needed