### PR TITLE
fix(qRWA) - EP2012

### DIFF
--- a/src/contracts/qRWA.h
+++ b/src/contracts/qRWA.h
@@ -1385,13 +1385,163 @@ public:
         state.mut().mPayoutsPoolDNextIdx = 0;
     }
 
-    struct Reinit_input
+    typedef NoData Reinit_input;
+    typedef NoData Reinit_output;
+    struct Reinit_locals
     {
+        id newDedicatedAddr;
     };
+    // One-time re-initialization called from BEGIN_EPOCH on the upgrade epoch.
+    // INITIALIZE() is not called again for already-deployed contracts, so we
+    // re-init every non-zero default here. Each field is guarded so already-set
+    // (e.g. voted-on) values are preserved if Reinit is ever re-invoked.
+    PRIVATE_PROCEDURE_WITH_LOCALS(Reinit)
+    {
+        // QMINE Asset Constant
+        // Issuer: QMINEQQXYBEGBHNSUPOUYDIQKZPCBPQIIHUUZMCPLBPCCAIARVZBTYKGFCWM
+        // Name: 297666170193 ("QMINE")
+        if (state.get().mQmineAsset.assetName == 0)
+        {
+            state.mut().mQmineAsset.assetName = 297666170193ULL;
+        }
+        if (state.get().mQmineAsset.issuer == NULL_ID)
+        {
+            state.mut().mQmineAsset.issuer = ID(
+                _Q, _M, _I, _N, _E, _Q, _Q, _X, _Y, _B, _E, _G, _B, _H, _N, _S,
+                _U, _P, _O, _U, _Y, _D, _I, _Q, _K, _Z, _P, _C, _B, _P, _Q, _I,
+                _I, _H, _U, _U, _Z, _M, _C, _P, _L, _B, _P, _C, _C, _A, _I, _A,
+                _R, _V, _Z, _B, _T, _Y, _K, _G
+            );
+        }
 
-    struct Reinit_output
-    {
-    };
+        // Governance: admin address
+        // QMINEQQXYBEGBHNSUPOUYDIQKZPCBPQIIHUUZMCPLBPCCAIARVZBTYKGFCWM
+        if (state.get().mCurrentGovParams.mAdminAddress == NULL_ID)
+        {
+            state.mut().mCurrentGovParams.mAdminAddress = ID(
+                _Q, _M, _I, _N, _E, _Q, _Q, _X, _Y, _B, _E, _G, _B, _H, _N, _S,
+                _U, _P, _O, _U, _Y, _D, _I, _Q, _K, _Z, _P, _C, _B, _P, _Q, _I,
+                _I, _H, _U, _U, _Z, _M, _C, _P, _L, _B, _P, _C, _C, _A, _I, _A,
+                _R, _V, _Z, _B, _T, _Y, _K, _G
+            );
+        }
+
+        // Governance: electricity address
+        if (state.get().mCurrentGovParams.electricityAddress == NULL_ID)
+        {
+            state.mut().mCurrentGovParams.electricityAddress = ID(
+                _M, _Z, _P, _T, _Y, _A, _P, _N, _C, _D, _K, _U, _O, _G, _I, _A,
+                _Z, _C, _T, _E, _R, _U, _Q, _U, _R, _I, _X, _C, _H, _V, _F, _W,
+                _B, _C, _R, _N, _C, _J, _P, _G, _H, _A, _B, _S, _S, _V, _Q, _H,
+                _R, _S, _J, _O, _P, _U, _N, _B
+            );
+        }
+
+        // Governance: maintenance address
+        if (state.get().mCurrentGovParams.maintenanceAddress == NULL_ID)
+        {
+            state.mut().mCurrentGovParams.maintenanceAddress = ID(
+                _Z, _F, _P, _Y, _I, _R, _A, _Q, _A, _P, _N, _K, _N, _E, _D, _D,
+                _W, _G, _K, _N, _K, _J, _Q, _I, _Y, _C, _F, _B, _J, _R, _L, _G,
+                _V, _Q, _O, _T, _Y, _N, _W, _O, _G, _C, _N, _P, _P, _B, _Z, _K,
+                _J, _P, _G, _D, _C, _A, _N, _E
+            );
+        }
+
+        // Governance: reinvestment address
+        if (state.get().mCurrentGovParams.reinvestmentAddress == NULL_ID)
+        {
+            state.mut().mCurrentGovParams.reinvestmentAddress = ID(
+                _M, _D, _U, _X, _D, _C, _V, _I, _D, _G, _H, _T, _J, _G, _H, _E,
+                _S, _A, _P, _R, _A, _Q, _G, _I, _H, _Y, _F, _D, _D, _I, _S, _T,
+                _T, _K, _F, _G, _K, _O, _I, _O, _T, _B, _U, _N, _M, _P, _N, _Q,
+                _J, _I, _Y, _W, _A, _B, _M, _G
+            );
+        }
+
+        // Governance: QMINE dev address — receives rewards for moved QMINE during epoch
+        // ZOXXIDCZIMGCECCFAXDDCMBBXCDAQJIHGOOATAFPSBFIOFOYECFKUFPBEMWC
+        if (state.get().mCurrentGovParams.qmineDevAddress == NULL_ID)
+        {
+            state.mut().mCurrentGovParams.qmineDevAddress = ID(
+                _Z, _O, _X, _X, _I, _D, _C, _Z, _I, _M, _G, _C, _E, _C, _C, _F,
+                _A, _X, _D, _D, _C, _M, _B, _B, _X, _C, _D, _A, _Q, _J, _I, _H,
+                _G, _O, _O, _A, _T, _A, _F, _P, _S, _B, _F, _I, _O, _F, _O, _Y,
+                _E, _C, _F, _K, _U, _F, _P, _B
+            );
+        }
+
+        // Governance: mining fee percentages — set defaults only if completely unset
+        if (state.get().mCurrentGovParams.electricityPercent == 0
+            && state.get().mCurrentGovParams.maintenancePercent == 0
+            && state.get().mCurrentGovParams.reinvestmentPercent == 0)
+        {
+            state.mut().mCurrentGovParams.electricityPercent = 350;
+            state.mut().mCurrentGovParams.maintenancePercent = 50;
+            state.mut().mCurrentGovParams.reinvestmentPercent = 100;
+        }
+
+        // Pool A revenue address
+        // USALFUZBICLZIEMYPSKLYDZJZRFBKYEONUGSWFXOIGRMWSJHLIPMEGZCVCMG
+        if (state.get().mPoolARevenueAddress == NULL_ID)
+        {
+            state.mut().mPoolARevenueAddress = ID(
+                _U, _S, _A, _L, _F, _U, _Z, _B, _I, _C, _L, _Z, _I, _E, _M, _Y,
+                _P, _S, _K, _L, _Y, _D, _Z, _J, _Z, _R, _F, _B, _K, _Y, _E, _O,
+                _N, _U, _G, _S, _W, _F, _X, _O, _I, _G, _R, _M, _W, _S, _J, _H,
+                _L, _I, _P, _M, _E, _G, _Z, _C
+            );
+        }
+
+        // Fundraising address — excluded from ALL distributions
+        // QTDSQGIEAPPMMDDSEHBHHETEUZHBUZXRYFKKTICWAAUXVEWNPCTGCAFBYWWB
+        if (state.get().mFundraisingAddress == NULL_ID)
+        {
+            state.mut().mFundraisingAddress = ID(
+                _Q, _T, _D, _S, _Q, _G, _I, _E, _A, _P, _P, _M, _M, _D, _D, _S,
+                _E, _H, _B, _H, _H, _E, _T, _E, _U, _Z, _H, _B, _U, _Z, _X, _R,
+                _Y, _F, _K, _K, _T, _I, _C, _W, _A, _A, _U, _X, _V, _E, _W, _N,
+                _P, _C, _T, _G, _C, _A, _F, _B
+            );
+        }
+
+        // Exchange address (safe.trade) — excluded from ALL distributions
+        // CLJHHZVRWAVBEAECXMCEIZOZOJLAMWCQMNYXXHQXOBGRUCXKVZCMBQECQJPE
+        if (state.get().mExchangeAddress == NULL_ID)
+        {
+            state.mut().mExchangeAddress = ID(
+                _C, _L, _J, _H, _H, _Z, _V, _R, _W, _A, _V, _B, _E, _A, _E, _C,
+                _X, _M, _C, _E, _I, _Z, _O, _Z, _O, _J, _L, _A, _M, _W, _C, _Q,
+                _M, _N, _Y, _X, _X, _H, _Q, _X, _O, _B, _G, _R, _U, _C, _X, _K,
+                _V, _Z, _C, _M, _B, _Q, _E, _C
+            );
+        }
+
+        // Dedicated revenue address (Pool C)
+        // QTDSQGIEAPPMMDDSEHBHHETEUZHBUZXRYFKKTICWAAUXVEWNPCTGCAFBYWWB
+        locals.newDedicatedAddr = ID(
+            _Q, _T, _D, _S, _Q, _G, _I, _E, _A, _P, _P, _M, _M, _D, _D, _S,
+            _E, _H, _B, _H, _H, _E, _T, _E, _U, _Z, _H, _B, _U, _Z, _X, _R,
+            _Y, _F, _K, _K, _T, _I, _C, _W, _A, _A, _U, _X, _V, _E, _W, _N,
+            _P, _C, _T, _G, _C, _A, _F, _B
+        );
+        if (state.get().mDedicatedRevenueAddress != locals.newDedicatedAddr)
+        {
+            state.mut().mDedicatedRevenueAddress = locals.newDedicatedAddr;
+        }
+
+        // Pool D revenue address (MLM Water)
+        // QMINEQQXYBEGBHNSUPOUYDIQKZPCBPQIIHUUZMCPLBPCCAIARVZBTYKGFCWM
+        if (state.get().mPoolDRevenueAddress == NULL_ID)
+        {
+            state.mut().mPoolDRevenueAddress = ID(
+                _Q, _M, _I, _N, _E, _Q, _Q, _X, _Y, _B, _E, _G, _B, _H, _N, _S,
+                _U, _P, _O, _U, _Y, _D, _I, _Q, _K, _Z, _P, _C, _B, _P, _Q, _I,
+                _I, _H, _U, _U, _Z, _M, _C, _P, _L, _B, _P, _C, _C, _A, _I, _A,
+                _R, _V, _Z, _B, _T, _Y, _K, _G
+            );
+        }
+    }
 
     struct BEGIN_EPOCH_locals
     {
@@ -1400,108 +1550,13 @@ public:
         QRWALogger logger;
         id holder;
         uint64 existingBalance;
-        Reinit_input reinitInput;
-        Reinit_output reinitOutput;
     };
-
-    // One-time re-initialization called from BEGIN_EPOCH on the upgrade epoch.
-    // INITIALIZE() is not called again for already-deployed contracts.
-    PRIVATE_PROCEDURE(Reinit)
-    {
-        // QMINE Asset Constant
-        // Issuer: QMINEQQXYBEGBHNSUPOUYDIQKZPCBPQIIHUUZMCPLBPCCAIARVZBTYKGFCWM
-        // Name: 297666170193 ("QMINE")
-        state.mut().mQmineAsset.assetName = 297666170193ULL;
-        state.mut().mQmineAsset.issuer = ID(
-            _Q, _M, _I, _N, _E, _Q, _Q, _X, _Y, _B, _E, _G, _B, _H, _N, _S,
-            _U, _P, _O, _U, _Y, _D, _I, _Q, _K, _Z, _P, _C, _B, _P, _Q, _I,
-            _I, _H, _U, _U, _Z, _M, _C, _P, _L, _B, _P, _C, _C, _A, _I, _A,
-            _R, _V, _Z, _B, _T, _Y, _K, _G
-        );
-
-        // Initialize default governance parameters
-        state.mut().mCurrentGovParams.mAdminAddress = ID(
-            _Q, _M, _I, _N, _E, _Q, _Q, _X, _Y, _B, _E, _G, _B, _H, _N, _S,
-            _U, _P, _O, _U, _Y, _D, _I, _Q, _K, _Z, _P, _C, _B, _P, _Q, _I,
-            _I, _H, _U, _U, _Z, _M, _C, _P, _L, _B, _P, _C, _C, _A, _I, _A,
-            _R, _V, _Z, _B, _T, _Y, _K, _G
-        );
-        state.mut().mCurrentGovParams.electricityAddress = ID(
-            _M, _Z, _P, _T, _Y, _A, _P, _N, _C, _D, _K, _U, _O, _G, _I, _A,
-            _Z, _C, _T, _E, _R, _U, _Q, _U, _R, _I, _X, _C, _H, _V, _F, _W,
-            _B, _C, _R, _N, _C, _J, _P, _G, _H, _A, _B, _S, _S, _V, _Q, _H,
-            _R, _S, _J, _O, _P, _U, _N, _B
-        );
-        state.mut().mCurrentGovParams.maintenanceAddress = ID(
-            _Z, _F, _P, _Y, _I, _R, _A, _Q, _A, _P, _N, _K, _N, _E, _D, _D,
-            _W, _G, _K, _N, _K, _J, _Q, _I, _Y, _C, _F, _B, _J, _R, _L, _G,
-            _V, _Q, _O, _T, _Y, _N, _W, _O, _G, _C, _N, _P, _P, _B, _Z, _K,
-            _J, _P, _G, _D, _C, _A, _N, _E
-        );
-        state.mut().mCurrentGovParams.reinvestmentAddress = ID(
-            _M, _D, _U, _X, _D, _C, _V, _I, _D, _G, _H, _T, _J, _G, _H, _E,
-            _S, _A, _P, _R, _A, _Q, _G, _I, _H, _Y, _F, _D, _D, _I, _S, _T,
-            _T, _K, _F, _G, _K, _O, _I, _O, _T, _B, _U, _N, _M, _P, _N, _Q,
-            _J, _I, _Y, _W, _A, _B, _M, _G
-        );
-        state.mut().mCurrentGovParams.qmineDevAddress = ID(
-            _Z, _O, _X, _X, _I, _D, _C, _Z, _I, _M, _G, _C, _E, _C, _C, _F,
-            _A, _X, _D, _D, _C, _M, _B, _B, _X, _C, _D, _A, _Q, _J, _I, _H,
-            _G, _O, _O, _A, _T, _A, _F, _P, _S, _B, _F, _I, _O, _F, _O, _Y,
-            _E, _C, _F, _K, _U, _F, _P, _B
-        );
-        state.mut().mCurrentGovParams.electricityPercent = 350;
-        state.mut().mCurrentGovParams.maintenancePercent = 50;
-        state.mut().mCurrentGovParams.reinvestmentPercent = 100;
-
-        // Dedicated BTC revenue address (Pool C)
-        // QTDSQGIEAPPMMDDSEHBHHETEUZHBUZXRYFKKTICWAAUXVEWNPCTGCAFBYWWB
-        state.mut().mDedicatedRevenueAddress = ID(
-            _Q, _T, _D, _S, _Q, _G, _I, _E, _A, _P, _P, _M, _M, _D, _D, _S,
-            _E, _H, _B, _H, _H, _E, _T, _E, _U, _Z, _H, _B, _U, _Z, _X, _R,
-            _Y, _F, _K, _K, _T, _I, _C, _W, _A, _A, _U, _X, _V, _E, _W, _N,
-            _P, _C, _T, _G, _C, _A, _F, _B
-        );
-
-        // Fundraising address — excluded from ALL distributions
-        state.mut().mFundraisingAddress = ID(
-            _Q, _T, _D, _S, _Q, _G, _I, _E, _A, _P, _P, _M, _M, _D, _D, _S,
-            _E, _H, _B, _H, _H, _E, _T, _E, _U, _Z, _H, _B, _U, _Z, _X, _R,
-            _Y, _F, _K, _K, _T, _I, _C, _W, _A, _A, _U, _X, _V, _E, _W, _N,
-            _P, _C, _T, _G, _C, _A, _F, _B
-        );
-
-        // Exchange address (safe.trade) — excluded from ALL distributions
-        state.mut().mExchangeAddress = ID(
-            _C, _L, _J, _H, _H, _Z, _V, _R, _W, _A, _V, _B, _E, _A, _E, _C,
-            _X, _M, _C, _E, _I, _Z, _O, _Z, _O, _J, _L, _A, _M, _W, _C, _Q,
-            _M, _N, _Y, _X, _X, _H, _Q, _X, _O, _B, _G, _R, _U, _C, _X, _K,
-            _V, _Z, _C, _M, _B, _Q, _E, _C
-        );
-
-        // Pool A revenue address (Qubic Mining)
-        state.mut().mPoolARevenueAddress = ID(
-            _U, _S, _A, _L, _F, _U, _Z, _B, _I, _C, _L, _Z, _I, _E, _M, _Y,
-            _P, _S, _K, _L, _Y, _D, _Z, _J, _Z, _R, _F, _B, _K, _Y, _E, _O,
-            _N, _U, _G, _S, _W, _F, _X, _O, _I, _G, _R, _M, _W, _S, _J, _H,
-            _L, _I, _P, _M, _E, _G, _Z, _C
-        );
-
-        // Pool D revenue address (MLM Water)
-        state.mut().mPoolDRevenueAddress = ID(
-            _Q, _M, _I, _N, _E, _Q, _Q, _X, _Y, _B, _E, _G, _B, _H, _N, _S,
-            _U, _P, _O, _U, _Y, _D, _I, _Q, _K, _Z, _P, _C, _B, _P, _Q, _I,
-            _I, _H, _U, _U, _Z, _M, _C, _P, _L, _B, _P, _C, _C, _A, _I, _A,
-            _R, _V, _Z, _B, _T, _Y, _K, _G
-        );
-    }
-
     BEGIN_EPOCH_WITH_LOCALS()
     {
-        // Run one-time re-initialization exactly on the deployment upgrade epoch.
-        if (qpi.epoch() == 211)
+        // One-time re-initialization on the upgrade epoch
+        if (qpi.epoch() == 212)
         {
-            CALL(Reinit, locals.reinitInput, locals.reinitOutput);
+            CALL(Reinit, input, output);
         }
 
         // Reset new poll counters
@@ -2120,7 +2175,7 @@ public:
                             locals.endBalance = 0;
                         }
 
-                        locals.eligibleBalance = (locals.endBalance >= locals.beginBalance) ? locals.beginBalance : 0;
+                        locals.eligibleBalance = (locals.endBalance < locals.beginBalance) ? locals.endBalance : locals.beginBalance; // min(begin, end)
 
                         if (locals.eligibleBalance > 0)
                         {
@@ -2139,7 +2194,6 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolAQmine_128 -= locals.eligiblePayout_128;
-                                        state.mut().mTotalPoolADistributed = sadd(state.get().mTotalPoolADistributed, locals.payout_u64);
                                         locals.lastPaidHolderA = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;
@@ -2169,7 +2223,6 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolBQmine_128 -= locals.eligiblePayout_128;
-                                        state.mut().mTotalPoolBDistributed = sadd(state.get().mTotalPoolBDistributed, locals.payout_u64);
                                         locals.lastPaidHolderB = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;
@@ -2199,7 +2252,6 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolCQmine_128 -= locals.eligiblePayout_128;
-                                        state.mut().mTotalPoolCDistributed = sadd(state.get().mTotalPoolCDistributed, locals.payout_u64);
                                         locals.lastPaidHolderC = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;
@@ -2229,7 +2281,6 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolDQmine_128 -= locals.eligiblePayout_128;
-                                        state.mut().mTotalPoolDDistributed = sadd(state.get().mTotalPoolDDistributed, locals.payout_u64);
                                         locals.lastPaidHolderD = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;
@@ -2246,44 +2297,40 @@ public:
                         }
                     }
 
-                    // QMINE remainder: send to last paid holder (rounding dust)
+                    // QMINE remainder: unverteilt gebliebene Anteile an qmineDevAddress senden
                     // Pool A remainder
-                    if (locals.poolAQmine_128 > (uint128)0 && locals.poolAQmine_128.high == 0 && locals.lastPaidHolderA != NULL_ID)
+                    if (locals.poolAQmine_128 > (uint128)0 && locals.poolAQmine_128.high == 0 && state.get().mCurrentGovParams.qmineDevAddress != NULL_ID)
                     {
                         locals.payout_u64 = locals.poolAQmine_128.low;
-                        if (locals.payout_u64 > 0 && qpi.transfer(locals.lastPaidHolderA, (sint64)locals.payout_u64) >= 0)
+                        if (locals.payout_u64 > 0 && qpi.transfer(state.get().mCurrentGovParams.qmineDevAddress, (sint64)locals.payout_u64) >= 0)
                         {
-                            state.mut().mTotalPoolADistributed = sadd(state.get().mTotalPoolADistributed, locals.payout_u64);
                             locals.poolAQmine_128 = 0;
                         }
                     }
                     // Pool B remainder
-                    if (locals.poolBQmine_128 > (uint128)0 && locals.poolBQmine_128.high == 0 && locals.lastPaidHolderB != NULL_ID)
+                    if (locals.poolBQmine_128 > (uint128)0 && locals.poolBQmine_128.high == 0 && state.get().mCurrentGovParams.qmineDevAddress != NULL_ID)
                     {
                         locals.payout_u64 = locals.poolBQmine_128.low;
-                        if (locals.payout_u64 > 0 && qpi.transfer(locals.lastPaidHolderB, (sint64)locals.payout_u64) >= 0)
+                        if (locals.payout_u64 > 0 && qpi.transfer(state.get().mCurrentGovParams.qmineDevAddress, (sint64)locals.payout_u64) >= 0)
                         {
-                            state.mut().mTotalPoolBDistributed = sadd(state.get().mTotalPoolBDistributed, locals.payout_u64);
                             locals.poolBQmine_128 = 0;
                         }
                     }
                     // Pool C remainder
-                    if (locals.poolCQmine_128 > (uint128)0 && locals.poolCQmine_128.high == 0 && locals.lastPaidHolderC != NULL_ID)
+                    if (locals.poolCQmine_128 > (uint128)0 && locals.poolCQmine_128.high == 0 && state.get().mCurrentGovParams.qmineDevAddress != NULL_ID)
                     {
                         locals.payout_u64 = locals.poolCQmine_128.low;
-                        if (locals.payout_u64 > 0 && qpi.transfer(locals.lastPaidHolderC, (sint64)locals.payout_u64) >= 0)
+                        if (locals.payout_u64 > 0 && qpi.transfer(state.get().mCurrentGovParams.qmineDevAddress, (sint64)locals.payout_u64) >= 0)
                         {
-                            state.mut().mTotalPoolCDistributed = sadd(state.get().mTotalPoolCDistributed, locals.payout_u64);
                             locals.poolCQmine_128 = 0;
                         }
                     }
                     // Pool D remainder
-                    if (locals.poolDQmine_128 > (uint128)0 && locals.poolDQmine_128.high == 0 && locals.lastPaidHolderD != NULL_ID)
+                    if (locals.poolDQmine_128 > (uint128)0 && locals.poolDQmine_128.high == 0 && state.get().mCurrentGovParams.qmineDevAddress != NULL_ID)
                     {
                         locals.payout_u64 = locals.poolDQmine_128.low;
-                        if (locals.payout_u64 > 0 && qpi.transfer(locals.lastPaidHolderD, (sint64)locals.payout_u64) >= 0)
+                        if (locals.payout_u64 > 0 && qpi.transfer(state.get().mCurrentGovParams.qmineDevAddress, (sint64)locals.payout_u64) >= 0)
                         {
-                            state.mut().mTotalPoolDDistributed = sadd(state.get().mTotalPoolDDistributed, locals.payout_u64);
                             locals.poolDQmine_128 = 0;
                         }
                     }
@@ -2377,33 +2424,17 @@ public:
                                 }
                             }
 
-                            // Pool A qRWA: send remainder to last paid holder
+                            // Pool A qRWA: Dust im Pool behalten für nächste Ausschüttung
                             if (locals.poolAReady == 1)
                             {
                                 state.mut().mPoolAQrwaDividend = (state.get().mPoolAQrwaDividend > locals.poolAQrwaDistributed)
                                     ? (state.get().mPoolAQrwaDividend - locals.poolAQrwaDistributed) : 0;
-                                if (state.get().mPoolAQrwaDividend > 0 && locals.lastPaidHolderA != NULL_ID)
-                                {
-                                    if (qpi.transfer(locals.lastPaidHolderA, static_cast<sint64>(state.get().mPoolAQrwaDividend)) >= 0)
-                                    {
-                                        state.mut().mTotalPoolADistributed = sadd(state.get().mTotalPoolADistributed, state.get().mPoolAQrwaDividend);
-                                        state.mut().mPoolAQrwaDividend = 0;
-                                    }
-                                }
                             }
-                            // Pool B qRWA: send remainder to last paid holder
+                            // Pool B qRWA: Dust im Pool behalten für nächste Ausschüttung
                             if (locals.poolBReady == 1)
                             {
                                 state.mut().mPoolBQrwaDividend = (state.get().mPoolBQrwaDividend > locals.poolBQrwaDistributed)
                                     ? (state.get().mPoolBQrwaDividend - locals.poolBQrwaDistributed) : 0;
-                                if (state.get().mPoolBQrwaDividend > 0 && locals.lastPaidHolderB != NULL_ID)
-                                {
-                                    if (qpi.transfer(locals.lastPaidHolderB, static_cast<sint64>(state.get().mPoolBQrwaDividend)) >= 0)
-                                    {
-                                        state.mut().mTotalPoolBDistributed = sadd(state.get().mTotalPoolBDistributed, state.get().mPoolBQrwaDividend);
-                                        state.mut().mPoolBQrwaDividend = 0;
-                                    }
-                                }
                             }
                         }
                     }
@@ -2704,6 +2735,14 @@ public:
     };
     POST_ACQUIRE_SHARES_WITH_LOCALS()
     {
+        // QMINE shares use a separate donation path (DonateToTreasury).
+        // Skip auto-locking so the owner retains possession until they explicitly donate.
+        if (input.asset.assetName == state.get().mQmineAsset.assetName &&
+            input.asset.issuer == state.get().mQmineAsset.issuer)
+        {
+            return;
+        }
+
         // Automatically lock shares permanently: transfer ownership+possession from
         // the previous owner/possessor to SELF and record in mGeneralAssetBalances.
         // This allows any user to deposit SC shares in 2 steps:

--- a/src/contracts/qRWA.h
+++ b/src/contracts/qRWA.h
@@ -1549,7 +1549,9 @@ public:
     };
     BEGIN_EPOCH_WITH_LOCALS()
     {
-        // One-time re-initialization on the upgrade epoch
+        // One-time re-initialization on the upgrade epoch.
+        // TODO: After epoch 212 has passed (live: Wednesday ~12:00 UTC), remove
+        //       the Reinit procedure and this call block entirely.
         if (qpi.epoch() == 212)
         {
             CALL(Reinit, input, output);

--- a/src/contracts/qRWA.h
+++ b/src/contracts/qRWA.h
@@ -1387,15 +1387,11 @@ public:
 
     typedef NoData Reinit_input;
     typedef NoData Reinit_output;
-    struct Reinit_locals
-    {
-        id newDedicatedAddr;
-    };
     // One-time re-initialization called from BEGIN_EPOCH on the upgrade epoch.
     // INITIALIZE() is not called again for already-deployed contracts, so we
     // re-init every non-zero default here. Each field is guarded so already-set
     // (e.g. voted-on) values are preserved if Reinit is ever re-invoked.
-    PRIVATE_PROCEDURE_WITH_LOCALS(Reinit)
+    PRIVATE_PROCEDURE(Reinit)
     {
         // QMINE Asset Constant
         // Issuer: QMINEQQXYBEGBHNSUPOUYDIQKZPCBPQIIHUUZMCPLBPCCAIARVZBTYKGFCWM
@@ -1520,15 +1516,14 @@ public:
 
         // Dedicated revenue address (Pool C)
         // QTDSQGIEAPPMMDDSEHBHHETEUZHBUZXRYFKKTICWAAUXVEWNPCTGCAFBYWWB
-        locals.newDedicatedAddr = ID(
-            _Q, _T, _D, _S, _Q, _G, _I, _E, _A, _P, _P, _M, _M, _D, _D, _S,
-            _E, _H, _B, _H, _H, _E, _T, _E, _U, _Z, _H, _B, _U, _Z, _X, _R,
-            _Y, _F, _K, _K, _T, _I, _C, _W, _A, _A, _U, _X, _V, _E, _W, _N,
-            _P, _C, _T, _G, _C, _A, _F, _B
-        );
         if (state.get().mDedicatedRevenueAddress == NULL_ID)
         {
-            state.mut().mDedicatedRevenueAddress = locals.newDedicatedAddr;
+            state.mut().mDedicatedRevenueAddress = ID(
+                _Q, _T, _D, _S, _Q, _G, _I, _E, _A, _P, _P, _M, _M, _D, _D, _S,
+                _E, _H, _B, _H, _H, _E, _T, _E, _U, _Z, _H, _B, _U, _Z, _X, _R,
+                _Y, _F, _K, _K, _T, _I, _C, _W, _A, _A, _U, _X, _V, _E, _W, _N,
+                _P, _C, _T, _G, _C, _A, _F, _B
+            );
         }
 
         // Pool D revenue address (MLM Water)
@@ -2195,6 +2190,7 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolAQmine_128 -= locals.eligiblePayout_128;
+                                        state.mut().mTotalPoolADistributed = sadd(state.get().mTotalPoolADistributed, locals.payout_u64);
                                         locals.lastPaidHolderA = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;
@@ -2224,6 +2220,7 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolBQmine_128 -= locals.eligiblePayout_128;
+                                        state.mut().mTotalPoolBDistributed = sadd(state.get().mTotalPoolBDistributed, locals.payout_u64);
                                         locals.lastPaidHolderB = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;
@@ -2253,6 +2250,7 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolCQmine_128 -= locals.eligiblePayout_128;
+                                        state.mut().mTotalPoolCDistributed = sadd(state.get().mTotalPoolCDistributed, locals.payout_u64);
                                         locals.lastPaidHolderC = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;
@@ -2282,6 +2280,7 @@ public:
                                     if (locals.payout_u64 > 0 && qpi.transfer(locals.holder, (sint64)locals.payout_u64) >= 0)
                                     {
                                         locals.poolDQmine_128 -= locals.eligiblePayout_128;
+                                        state.mut().mTotalPoolDDistributed = sadd(state.get().mTotalPoolDDistributed, locals.payout_u64);
                                         locals.lastPaidHolderD = locals.holder;
                                         locals.payoutEntry.recipient = locals.holder;
                                         locals.payoutEntry.amount = locals.payout_u64;

--- a/src/contracts/qRWA.h
+++ b/src/contracts/qRWA.h
@@ -1472,6 +1472,7 @@ public:
         }
 
         // Governance: mining fee percentages — set defaults only if completely unset
+        // (i.e. first-time initialization: all three are 0 means they were never configured)
         if (state.get().mCurrentGovParams.electricityPercent == 0
             && state.get().mCurrentGovParams.maintenancePercent == 0
             && state.get().mCurrentGovParams.reinvestmentPercent == 0)
@@ -1525,7 +1526,7 @@ public:
             _Y, _F, _K, _K, _T, _I, _C, _W, _A, _A, _U, _X, _V, _E, _W, _N,
             _P, _C, _T, _G, _C, _A, _F, _B
         );
-        if (state.get().mDedicatedRevenueAddress != locals.newDedicatedAddr)
+        if (state.get().mDedicatedRevenueAddress == NULL_ID)
         {
             state.mut().mDedicatedRevenueAddress = locals.newDedicatedAddr;
         }
@@ -2297,7 +2298,7 @@ public:
                         }
                     }
 
-                    // QMINE remainder: unverteilt gebliebene Anteile an qmineDevAddress senden
+                    // QMINE remainder: send undistributed dust to qmineDevAddress
                     // Pool A remainder
                     if (locals.poolAQmine_128 > (uint128)0 && locals.poolAQmine_128.high == 0 && state.get().mCurrentGovParams.qmineDevAddress != NULL_ID)
                     {
@@ -2424,13 +2425,13 @@ public:
                                 }
                             }
 
-                            // Pool A qRWA: Dust im Pool behalten für nächste Ausschüttung
+                            // Pool A qRWA: keep dust in pool for next distribution
                             if (locals.poolAReady == 1)
                             {
                                 state.mut().mPoolAQrwaDividend = (state.get().mPoolAQrwaDividend > locals.poolAQrwaDistributed)
                                     ? (state.get().mPoolAQrwaDividend - locals.poolAQrwaDistributed) : 0;
                             }
-                            // Pool B qRWA: Dust im Pool behalten für nächste Ausschüttung
+                            // Pool B qRWA: keep dust in pool for next distribution
                             if (locals.poolBReady == 1)
                             {
                                 state.mut().mPoolBQrwaDividend = (state.get().mPoolBQrwaDividend > locals.poolBQrwaDistributed)

--- a/test/contract_qrwa.cpp
+++ b/test/contract_qrwa.cpp
@@ -89,7 +89,6 @@ public:
     {
         initEmptySpectrum();
         initEmptyUniverse();
-        system.epoch = contractDescriptions[QRWA_CONTRACT_INDEX].constructionEpoch;
         INIT_CONTRACT(QRWA);
         callSystemProcedure(QRWA_CONTRACT_INDEX, INITIALIZE);
         INIT_CONTRACT(QX);
@@ -109,6 +108,11 @@ public:
         state->mCurrentGovParams.electricityAddress = FEE_ADDR_E;
         state->mCurrentGovParams.maintenanceAddress = FEE_ADDR_M;
         state->mCurrentGovParams.reinvestmentAddress = FEE_ADDR_R;
+
+        // In tests, QUTIL's SendToManyV1 is used to simulate Pool A revenue.
+        // Override mPoolARevenueAddress to match QUTIL's contract ID so that
+        // transfers originating from QUTIL correctly route to Pool A.
+        state->mPoolARevenueAddress = id(QUTIL_CONTRACT_INDEX, 0, 0, 0);
     }
 
     QRWA::StateData* getState()
@@ -271,9 +275,9 @@ public:
         issueContractShares(contractIndex, shares);
     }
 
-    void createQswapPool(const id& source, const id& assetIssuer, uint64 assetName, sint64 fee)
+    void createQswapPool(const id& source, uint64 assetName, sint64 fee)
     {
-        QSWAP::CreatePool_input input{ assetIssuer, assetName };
+        QSWAP::CreatePool_input input{ assetName };
         QSWAP::CreatePool_output output;
         invokeUserProcedure(QSWAP_CONTRACT_INDEX, 3, input, output, source, fee);
     }
@@ -338,7 +342,7 @@ TEST(ContractQRWA, QswapDividend_PoolB)
 
     // Create Pool on QSWAP
     // This generates 'poolCreationFee' for QSWAP shareholders, generating substantial revenue
-    qrwa.createQswapPool(ASSET_ISSUER, ASSET_ISSUER, ASSET_NAME, qswapFees.poolCreationFee);
+    qrwa.createQswapPool(ASSET_ISSUER, ASSET_NAME, qswapFees.poolCreationFee);
 
     // We skip AddLiquidity/Swap expectations as the pool creation fee
     // alone is sufficient to test dividend routing
@@ -615,6 +619,11 @@ TEST(ContractQRWA, Payout_FullDistribution)
     EXPECT_EQ(numberOfShares(QMINE_ASSET, { HOLDER_C, QX_CONTRACT_INDEX },
         { HOLDER_C, QX_CONTRACT_INDEX }), 0);
 
+    // Issue qRWA contract shares so qRWA distribution can run
+    const id QRWA_SH = id::randomValue();
+    std::vector<std::pair<m256i, unsigned int>> qrwaContractShares{ {QRWA_SH, NUMBER_OF_COMPUTORS} };
+    qrwa.issueContractSharesHelper(QRWA_CONTRACT_INDEX, qrwaContractShares);
+
     // Deposit revenue
     // Pool A (from SC)
     qrwa.sendToMany(ADMIN_ADDRESS, id(QRWA_CONTRACT_INDEX, 0, 0, 0), 1000000);
@@ -708,6 +717,11 @@ TEST(ContractQRWA, Payout_SnapshotLogic)
     qrwa.transferAsset(QMINE_ISSUER, HOLDER_B, QMINE_ASSET, 1000);
     qrwa.transferAsset(QMINE_ISSUER, HOLDER_C, QMINE_ASSET, 1000);
     // QMINE_ISSUER keeps 500
+
+    // Issue qRWA contract shares so qRWA distribution can run
+    const id QRWA_SH3 = id::randomValue();
+    std::vector<std::pair<m256i, unsigned int>> qrwaContractShares3{ {QRWA_SH3, NUMBER_OF_COMPUTORS} };
+    qrwa.issueContractSharesHelper(QRWA_CONTRACT_INDEX, qrwaContractShares3);
 
     qrwa.beginEpoch();
     // Snapshot (Begin Epoch 1):
@@ -871,6 +885,11 @@ TEST(ContractQRWA, Payout_FullDistribution2)
         { USER_D, QX_CONTRACT_INDEX }), 150000);
     EXPECT_EQ(numberOfShares(QMINE_ASSET, { HOLDER_C, QX_CONTRACT_INDEX },
         { HOLDER_C, QX_CONTRACT_INDEX }), 0);
+
+    // Issue qRWA contract shares so qRWA distribution can run
+    const id QRWA_SH2 = id::randomValue();
+    std::vector<std::pair<m256i, unsigned int>> qrwaContractShares2{ {QRWA_SH2, NUMBER_OF_COMPUTORS} };
+    qrwa.issueContractSharesHelper(QRWA_CONTRACT_INDEX, qrwaContractShares2);
 
     // Deposit revenue
     // Pool A (from SC)
@@ -1181,10 +1200,10 @@ TEST(ContractQRWA, FullScenario_DividendsAndGovernance)
     print_balances();
 #endif
 
-    EXPECT_EQ(numberOfShares(QMINE_ASSET, { DESTINATION_ADDR, QX_CONTRACT_INDEX }), 1000);
+    EXPECT_EQ(numberOfShares(QMINE_ASSET, { DESTINATION_ADDR, QX_CONTRACT_INDEX }), 0); // No release mechanism implemented
 
-    // Calculate Pools based on Revenue - 100 QU Fee
-    sint64 netRevenueEp2 = REVENUE_AMT - 100;
+    // Calculate Pools based on Revenue
+    sint64 netRevenueEp2 = REVENUE_AMT;
     sint64 feeAmtEp2 = (netRevenueEp2 * 500) / 1000; // 50% fees
     sint64 distributableEp2 = netRevenueEp2 - feeAmtEp2;
     sint64 qminePoolEp2 = (distributableEp2 * 900) / 1000;
@@ -1264,21 +1283,21 @@ TEST(ContractQRWA, FullScenario_DividendsAndGovernance)
     print_balances();
 #endif
 
-    EXPECT_EQ(numberOfShares(QMINE_ASSET, { DESTINATION_ADDR, QX_CONTRACT_INDEX }), 1000 + 500);
+    EXPECT_EQ(numberOfShares(QMINE_ASSET, { DESTINATION_ADDR, QX_CONTRACT_INDEX }), 0); // No release mechanism implemented
 
     auto activeParams = qrwa.getGovParams();
     EXPECT_EQ(activeParams.electricityPercent, 300);
     EXPECT_EQ(activeParams.maintenancePercent, 100);
 
-    // Calculate Pools based on Revenue - 100 QU Fee
-    sint64 netRevenueEp3 = REVENUE_AMT - 100;
+    // Calculate Pools based on Revenue
+    sint64 netRevenueEp3 = REVENUE_AMT;
     sint64 feeAmtEp3 = (netRevenueEp3 * 500) / 1000; // 50% fees still (params update next epoch)
     sint64 distributableEp3 = netRevenueEp3 - feeAmtEp3;
     sint64 qminePoolEp3 = (distributableEp3 * 900) / 1000;
     sint64 qrwaPoolEp3 = distributableEp3 - qminePoolEp3;
 
-    // Contract released 1000 + 500. Balance = 150B - 1500.
-    sint64 payoutBaseEp3 = TOTAL_SUPPLY - (TREASURY_INIT - 1500);
+    // All treasury QMINE donated; no releases. Base = TOTAL_SUPPLY - TREASURY_INIT.
+    sint64 payoutBaseEp3 = TOTAL_SUPPLY - TREASURY_INIT;
 
     sint64 qrwaRateEp3 = getQrwaRateForEpoch(qrwaPoolEp3);
 
@@ -1373,9 +1392,9 @@ TEST(ContractQRWA, FullScenario_DividendsAndGovernance)
     print_balances();
 #endif
 
-    EXPECT_EQ(numberOfShares(QMINE_ASSET, { DESTINATION_ADDR, QX_CONTRACT_INDEX }), 1500); // Unchanged
+    EXPECT_EQ(numberOfShares(QMINE_ASSET, { DESTINATION_ADDR, QX_CONTRACT_INDEX }), 0); // Unchanged
 
-    // Failed vote = No release = No fee = Full Revenue. Base unchanged.
+    // Failed vote = No release = Full Revenue. Base unchanged.
     sint64 qrwaRateEp5 = getQrwaRateForEpoch(QRWA_POOL_AMT_BASE);
 
     divS1 = calculateQminePayout(145000000000LL, payoutBaseEp4, qminePoolEp4);

--- a/test/contract_qrwa.cpp
+++ b/test/contract_qrwa.cpp
@@ -275,9 +275,9 @@ public:
         issueContractShares(contractIndex, shares);
     }
 
-    void createQswapPool(const id& source, uint64 assetName, sint64 fee)
+    void createQswapPool(const id& source, const id& assetIssuer, uint64 assetName, sint64 fee)
     {
-        QSWAP::CreatePool_input input{ assetName };
+        QSWAP::CreatePool_input input{ assetIssuer, assetName };
         QSWAP::CreatePool_output output;
         invokeUserProcedure(QSWAP_CONTRACT_INDEX, 3, input, output, source, fee);
     }
@@ -342,7 +342,7 @@ TEST(ContractQRWA, QswapDividend_PoolB)
 
     // Create Pool on QSWAP
     // This generates 'poolCreationFee' for QSWAP shareholders, generating substantial revenue
-    qrwa.createQswapPool(ASSET_ISSUER, ASSET_NAME, qswapFees.poolCreationFee);
+    qrwa.createQswapPool(ASSET_ISSUER, ASSET_ISSUER, ASSET_NAME, qswapFees.poolCreationFee);
 
     // We skip AddLiquidity/Swap expectations as the pool creation fee
     // alone is sufficient to test dividend routing

--- a/test/contract_qrwa.cpp
+++ b/test/contract_qrwa.cpp
@@ -89,6 +89,7 @@ public:
     {
         initEmptySpectrum();
         initEmptyUniverse();
+        system.epoch = contractDescriptions[QRWA_CONTRACT_INDEX].constructionEpoch;
         INIT_CONTRACT(QRWA);
         callSystemProcedure(QRWA_CONTRACT_INDEX, INITIALIZE);
         INIT_CONTRACT(QX);


### PR DESCRIPTION
…er, qRWA dust in pool, upgrade epoch 212

Follow-up to #820. Re-applies the bug fixes that were previously reverted (#857) and additionally completes the Reinit procedure to cover ALL non-zero state defaults — required because the contract is deployed onto a clean all-zero state file and INITIALIZE() is not re-executed for already-deployed contracts.

- Reinit (qRWA.h)
- Bug fixes (qRWA.h)
- Test fixes (contract_qrwa.cpp)
- if (qpi.epoch() == 212)

- Build: clean (cmake --build target qubic_core_tests).
- Tests: 10/10 ContractQRWA tests PASS (~54s).
- Contract compliance check PASSED