### PR TITLE
fix(qRWA): update test assertions for totalPoolADistributed to include QMINE payouts

### DIFF
--- a/test/contract_qrwa.cpp
+++ b/test/contract_qrwa.cpp
@@ -662,7 +662,11 @@ TEST(ContractQRWA, Payout_FullDistribution)
     // qRWA Payout (50,000 QUs)
     uint64 qrwaPerShare = 50000 / NUMBER_OF_COMPUTORS; // 73
     auto distTotals = qrwa.getTotalDistributed();
-    EXPECT_EQ(distTotals.totalPoolADistributed, qrwaPerShare * NUMBER_OF_COMPUTORS); // 73 * 676 = 49328
+    // totalPoolADistributed includes both qRWA holder payouts and QMINE holder payouts
+    // qRWA: 73 * 676 = 49,348
+    // QMINE eligible paid: H1=67,500 + H2=135,000 + Issuer=180,000 = 382,500
+    uint64 qmineEligiblePaidA = 67500 + 135000 + 180000;
+    EXPECT_EQ(distTotals.totalPoolADistributed, qrwaPerShare * NUMBER_OF_COMPUTORS + qmineEligiblePaidA);
 
     // QMINE Payout (450,000 QUs)
     // mPayoutTotalQmineBegin = 1,000,000
@@ -929,7 +933,11 @@ TEST(ContractQRWA, Payout_FullDistribution2)
     // qRWA Payout (150,000 QUs)
     uint64 qrwaPerShare = 150000 / NUMBER_OF_COMPUTORS; // 150000 / 676 = 221
     auto distTotals = qrwa.getTotalDistributed();
-    EXPECT_EQ(distTotals.totalPoolADistributed, qrwaPerShare * NUMBER_OF_COMPUTORS); // 221 * 676 = 149416
+    // totalPoolADistributed includes both qRWA holder payouts and QMINE holder payouts
+    // qRWA: 221 * 676 = 149,396
+    // QMINE eligible paid: H1=202,500 + H2=405,000 + Issuer=540,000 = 1,147,500
+    uint64 qmineEligiblePaidA = 202500 + 405000 + 540000;
+    EXPECT_EQ(distTotals.totalPoolADistributed, qrwaPerShare * NUMBER_OF_COMPUTORS + qmineEligiblePaidA);
 
     // QMINE Payout (1,350,000 QUs)
     // mPayoutTotalQmineBegin = 1,000,000 (A:200k, B:300k, C:100k, Issuer:400k)


### PR DESCRIPTION
## Context

After PR #863 was merged, the CI reported 2 failing tests:
- `ContractQRWA.Payout_FullDistribution`
- `ContractQRWA.Payout_FullDistribution2`

## Root Cause

PR #863 added `mTotalPool{A,B,C,D}Distributed += payout` tracking to the **QMINE holder payout loops** (previously only tracked in the qRWA-holder loops). This was the correct fix per review comments.

However, the test assertions still only expected the **qRWA-holder portion**:
```cpp
EXPECT_EQ(distTotals.totalPoolADistributed, qrwaPerShare * NUMBER_OF_COMPUTORS); // only qRWA
```

## Fix

Updated both test assertions to include the QMINE-holder payout amounts:

| Test | qRWA portion | QMINE eligible paid | Total expected |
|---|---|---|---|
| `Payout_FullDistribution` | 73 × 676 = 49,348 | H1+H2+Issuer = 382,500 | **431,848** |
| `Payout_FullDistribution2` | 221 × 676 = 149,396 | H1+H2+Issuer = 1,147,500 | **1,296,896** |

These values match exactly what the failing CI reported as actual values, confirming the contract behaviour is correct and only the test expectations needed updating.

## Changes
- `test/contract_qrwa.cpp`: Updated 2 `EXPECT_EQ` assertions