### PR TITLE
Oracle interface and contract compliance with updated verifier

### DIFF
--- a/doc/contracts.md
+++ b/doc/contracts.md
@@ -512,6 +512,8 @@ The following container types are available in the QPI:
 - `LinkedList<T, L>`: Doubly-linked list of elements of type `T` with fixed capacity `L` (`L` must be 2^N).
   Provides O(1) insertion at head/tail, O(1) insertion before/after a given index, O(1) removal by index, and bidirectional traversal.
   Removed nodes are immediately recycled via a free list (no deferred cleanup needed).
+- `SlowAnySizeArray<T, L>`: Array of `L` elements of type `T` that is slower than the normal `Array` but may have any capacity `L`.
+  This should be only used when a specific `L` != 2^N is needed for a good reason, e.g., in input/output.
 
 Please note that removing items from `Collection`, `HashMap`, and `HashSet` does not immediately free the hash map slots used for the removed items.
 This may negatively impact the lookup speed, which depends on the maximum population seen since the last cleanup.

--- a/doc/contracts_oracles.md
+++ b/doc/contracts_oracles.md
@@ -191,8 +191,15 @@ static sint64 getSubscriptionFee(const OracleQuery& query, uint32 notifyPeriodIn
 
 Additionally, the interface struct may contain other structs or convenience features for contracts using the oracle interface.
 
-All code in the interface header file must respect the same [C++ language feature restrictions as contracts](#restrictions-of-c-language-features).
+All code in the interface header file must respect the same [C++ language feature restrictions as contracts](#restrictions-of-c-language-features) (except for a few differences listed below).
 These are checked with the [Qubic Contract Verification Tool](https://github.com/Franziska-Mueller/qubic-contract-verify).
+
+The C++ language feature restrictions of oracle interfaces differ in the following points from those of contracts:
+
+- Only one struct is permitted on global scope that should have the same name as the file (e.g. `struct Price` in `Price.h`).
+  Global constants or other global definitions/declarations are forbidden.
+- The restrictions of the contract input / output types apply to all structs in oracle interfaces, that is, all structs are considered to be input / output.
+- Functions defined in oracle interfaces may use a few local integer variables. The rationale is to keep the interfaces simple (no passing of storage for local variables as arguments). The number is restricted to 10 integers, which should fit in the registers of the Intel/AMD x64.
 
 A new oracle interface has to be added file `src/oracle_core/oracle_interfaces_def.h`.
 Search for "add new interface above this line" in this file to see, where to add references to new interface to make it available to contracts and the oracle engine.

--- a/src/contracts/ComputorControlledFund.h
+++ b/src/contracts/ComputorControlledFund.h
@@ -23,7 +23,7 @@ struct CCF : public ContractBase
 
 	struct Success_output
 	{
-		bool okay;
+		bit okay;
 	};
 
 	struct LatestTransfersEntry
@@ -32,7 +32,7 @@ struct CCF : public ContractBase
 		Array<uint8, 256> url;
 		sint64 amount;
 		uint32 tick;
-		bool success;
+		bit success;
 	};
 
 	typedef Array<LatestTransfersEntry, 128> LatestTransfersT;
@@ -79,7 +79,7 @@ struct CCF : public ContractBase
 		sint64 amount;
 		uint32 tick;
 		sint32 periodIndex;				// Which period this payment is for (0-based)
-		bool success;
+		bit success;
 		Array<uint8, 1> _padding0;
 		Array<uint8, 2> _padding1;
 	};

--- a/src/contracts/GeneralQuorumProposal.h
+++ b/src/contracts/GeneralQuorumProposal.h
@@ -21,7 +21,7 @@ struct GQMPROP : public ContractBase
 
 	struct Success_output
 	{
-		bool okay;
+		bit okay;
 	};
 
 	struct RevenueDonationEntry
@@ -175,7 +175,7 @@ public:
 	struct SetProposal_output
 	{
 		uint16 proposalIndex;
-		bool okay;
+		bit okay;
 	};
 	struct SetProposal_locals
 	{

--- a/src/contracts/Qswap.h
+++ b/src/contracts/Qswap.h
@@ -144,7 +144,7 @@ public:
 	};
 	struct SetInvestRewardsInfo_output
 	{
-		bool success;
+		bit success;
 	};
 
 	struct GetPoolBasicState_input
@@ -233,7 +233,7 @@ public:
 	};
 	struct CreatePool_output
 	{
-		bool success;
+		bit success;
 	};
 
 	struct TransferShareOwnershipAndPossession_input

--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -1069,6 +1069,57 @@ namespace QPI
 	template <typename T, uint64 L>
 	bool isArraySortedWithoutDuplicates(const Array<T, L>& Array, uint64 beginIdx = 0, uint64 endIdx = L);
 
+	// Array of L elements of type T that is slower than normal Array but may have any capacity L.
+	// This should be only used when a specific L != 2^N is needed for a good reason, e.g., in input/output.
+	template <typename T, uint64 L>
+	struct SlowAnySizeArray
+	{
+	private:
+		static_assert(L, "The capacity of the array must be != 0.");
+
+		T _values[L];
+
+	public:
+		// Return number of elements in array
+		static inline constexpr uint64 capacity()
+		{
+			return L;
+		}
+
+		// Get element of array
+		inline const T& get(uint64 index) const
+		{
+			return _values[index % L];
+		}
+
+		// Set element of array
+		inline void set(uint64 index, const T& value)
+		{
+			_values[index % L] = value;
+		}
+
+		// Set all elements to passed value
+		inline void setAll(const T& value)
+		{
+			for (uint64 i = 0; i < L; ++i)
+				_values[i] = value;
+		}
+
+		// Implement assignment operator to prevent generating call to unavailable memcpy()
+		inline SlowAnySizeArray<T, L>& operator=(const SlowAnySizeArray<T, L>& other)
+		{
+			copyMemory(*this, other);
+			return *this;
+		}
+
+		// Implement copy constructor to prevent generating call to unavailable memcpy()
+		inline SlowAnySizeArray(const SlowAnySizeArray<T, L>& other)
+		{
+			copyMemory(*this, other);
+		}
+
+		SlowAnySizeArray() = default;
+	};
 
 	// Hash function class to be used with the hash map.
 	template <typename KeyT> class HashFunction 

--- a/src/oracle_interfaces/DogeShareValidation.h
+++ b/src/oracle_interfaces/DogeShareValidation.h
@@ -32,7 +32,7 @@ struct DogeShareValidation
         static constexpr uint64 additionalDataSize = MAX_ORACLE_QUERY_SIZE
             - (sizeof(uint64) + 32 + 4 + 4 + 8 + 4 + 4 + 32 + 4 * sizeof(uint32)); // size of all previous struct members
 
-        uint8 additionalData[additionalDataSize];
+        SlowAnySizeArray<uint8, additionalDataSize> additionalData;
         // Layout for additional data:
         // - extraNonce1
         // - coinbase1
@@ -42,7 +42,7 @@ struct DogeShareValidation
         // Note: The size of the components contained in the additional data varies, hence the total occupied bytes in the array is not fixed.
     };
 
-    static_assert(sizeof(OracleQuery) == MAX_ORACLE_QUERY_SIZE, "DogeShareValidation::OracleQuery has wrong size");
+    static_assert(sizeof(OracleQuery) == MAX_ORACLE_QUERY_SIZE); // DogeShareValidation::OracleQuery has wrong size!?
 
     /// Oracle reply data / output of the oracle machine
     struct OracleReply

--- a/src/oracle_interfaces/Price.h
+++ b/src/oracle_interfaces/Price.h
@@ -89,12 +89,12 @@ struct Price
 		// - Select a power of two (1, 2, 4, 8, 16, ...) as notifyPeriodInMinutes to pay less per query.
 		// - With notifyPeriodInMinutes >= 317, it is always cheaper to use individual queries (10 QU per query)
 		//   instead of subscriptions.
-		uint16 period = notifyPeriodInMilliseconds / 60000;
+		uint16 period = (uint16)QPI::div(notifyPeriodInMilliseconds, 60000u);
 		sint64 fee = 10000;
 		while (period > 1)
 		{
-			fee = fee * 65 / 100;
-			period /= 2;
+			fee = QPI::div(fee * 65ll, 100ll);
+			period = period >> 1;
 		}
 		return fee;
 	}

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -1439,7 +1439,7 @@ static void processBroadcastCustomMiningSolution(RequestResponseHeader* header)
                     queryData->coinbase1NumBytes = task.coinbase1NumBytes;
                     queryData->coinbase2NumBytes = task.coinbase2NumBytes;
                     queryData->numMerkleBranches = task.numMerkleBranches;
-                    copyMem(queryData->additionalData, task.additionalData, OI::DogeShareValidation::OracleQuery::additionalDataSize);
+                    copyMemory(queryData->additionalData, task.additionalData);
 
                     customQubicMiningStorage.addOracleQuery(tx, task.jobId);
 

--- a/test/qpi.cpp
+++ b/test/qpi.cpp
@@ -136,7 +136,7 @@ TEST(TestCoreQPI, SafeMath)
 
 TEST(TestCoreQPI, Array)
 {
-    //QPI::array<int, 0> mustFail; // should raise compile error
+    //QPI::Array<int, 0> mustFail; // should raise compile error
 
     QPI::Array<QPI::uint8, 4> uint8_4;
     EXPECT_EQ(uint8_4.capacity(), 4);
@@ -175,7 +175,7 @@ TEST(TestCoreQPI, Array)
     //uint64_4.setMem(uint8_4); // should raise compile error
 
     QPI::Array<QPI::uint16, 2> uint16_2;
-    EXPECT_EQ(uint8_4.capacity(), 4);
+    EXPECT_EQ(uint16_2.capacity(), 2);
     //uint16_2.setMem(QPI::id(1, 2, 3, 4)); // should raise compile error
     uint16_2.setAll(12345);
     EXPECT_EQ((int)uint16_2.get(0), 12345);
@@ -187,6 +187,42 @@ TEST(TestCoreQPI, Array)
     uint16_2.setMem(uint8_4);
     for (int i = 0; i < uint16_2.capacity(); ++i)
         EXPECT_EQ((int)uint16_2.get(i), (int)(((2*i+2) << 8) | (2*i + 1)));
+}
+
+
+TEST(TestCoreQPI, SlowAnySizeArray)
+{
+    //QPI::SlowAnySizeArray<int, 0> mustFail; // should raise compile error
+
+    QPI::SlowAnySizeArray<QPI::uint8, 3> uint8_3;
+    EXPECT_EQ(uint8_3.capacity(), 3);
+    uint8_3.setAll(2);
+    EXPECT_EQ(uint8_3.get(0), 2);
+    EXPECT_EQ(uint8_3.get(1), 2);
+    EXPECT_EQ(uint8_3.get(2), 2);
+    EXPECT_EQ(uint8_3.get(3), 2); // same as get(0)
+    for (int i = 0; i < uint8_3.capacity(); ++i)
+        uint8_3.set(i, i + 1);
+    for (int i = 0; i < uint8_3.capacity(); ++i)
+        EXPECT_EQ(uint8_3.get(i), i + 1);
+    for (int i = 0; i < uint8_3.capacity(); ++i)
+        uint8_3.set(i + 10, i + 1);
+    for (int i = 0; i < uint8_3.capacity(); ++i)
+        EXPECT_EQ(uint8_3.get(i + 10), i + 1);
+
+
+    QPI::SlowAnySizeArray<QPI::uint16, 676> uint16_676;
+    uint16_676.setAll(12345);
+    for (int i = 0; i < uint16_676.capacity(); ++i)
+        EXPECT_EQ((int)uint16_676.get(i), 12345);
+    for (int i = 0; i < uint16_676.capacity(); ++i)
+        uint16_676.set(i, i + 987);
+    for (int i = 0; i < uint16_676.capacity(); ++i)
+        EXPECT_EQ((int)uint16_676.get(i), i + 987);
+    for (int i = 0; i < uint16_676.capacity(); ++i)
+        uint16_676.set(i + uint16_676.capacity(), i + 42);
+    for (int i = 0; i < uint16_676.capacity(); ++i)
+        EXPECT_EQ((int)uint16_676.get(i + uint16_676.capacity()), i + 42);
 }
 
 


### PR DESCRIPTION
This includes the following changes:

- Fix issues in oracle interfaces "DogeShareValidation" and "Price" to make them comply with the QPI language restriction and the [updated version of the contract verifier](https://github.com/Franziska-Mueller/qubic-contract-verify/pull/7)
- Add new QPI type `SlowAnySizeArray` required for the DogeShareValidation query
- Replace `bool` by `bit` in contract input / output struct, to follow a new rule to forbid bool in input / output due to the issue explained in #822 
- Update docs

Closes https://github.com/qubic/core/issues/678