### PR TITLE
Add minimum fee for oracle query and subscription

### DIFF
--- a/doc/contracts_oracles.md
+++ b/doc/contracts_oracles.md
@@ -139,7 +139,7 @@ See the comments in the source code in `src/oracle_interfaces/Price.h` for more 
 The source code of the official Qubic Core repository and release should usually tell the current oracle fees.
 However, the Quorum decides as usual in Qubic, because the computors running the Qubic Network may change the code, including the fee amounts.
 
-In order to prevent spam, there are minimum fees, which are 10 QUs per oracle query and 100 QUs per oracle subscriptions at the moment.
+In order to prevent spam, there are minimum fees, which are 10 QUs per oracle query and 100 QUs per oracle subscription at the moment.
 
 
 ### Adding new interfaces

--- a/doc/contracts_oracles.md
+++ b/doc/contracts_oracles.md
@@ -139,6 +139,8 @@ See the comments in the source code in `src/oracle_interfaces/Price.h` for more 
 The source code of the official Qubic Core repository and release should usually tell the current oracle fees.
 However, the Quorum decides as usual in Qubic, because the computors running the Qubic Network may change the code, including the fee amounts.
 
+In order to prevent spam, there are minimum fees, which are 10 QUs per oracle query and 100 QUs per oracle subscriptions at the moment.
+
 
 ### Adding new interfaces
 

--- a/src/contract_core/qpi_oracle_impl.h
+++ b/src/contract_core/qpi_oracle_impl.h
@@ -42,7 +42,7 @@ QPI::sint64 QPI::QpiContextProcedureCall::__qpiQueryOracle(
 	// get and destroy fee (not adding to contracts execution fee reserve)
 	sint64 fee = OracleInterface::getQueryFee(query);
 	int contractSpectrumIdx = ::spectrumIndex(this->_currentContractId);
-	if (fee >= 0 && contractSpectrumIdx >= 0 && decreaseEnergy(contractSpectrumIdx, fee))
+	if (fee >= MIN_ORACLE_QUERY_FEE && contractSpectrumIdx >= 0 && decreaseEnergy(contractSpectrumIdx, fee))
 	{
 		// log burning of QU
 		const QuTransfer quTransfer = { this->_currentContractId, m256i::zero(), fee };
@@ -125,7 +125,7 @@ inline QPI::sint32 QPI::QpiContextProcedureCall::__qpiSubscribeOracle(
 	// get and destroy fee (not adding to contracts execution fee reserve)
 	const sint64 fee = OracleInterface::getSubscriptionFee(query, notificationPeriodInMilliseconds);
 	const int contractSpectrumIdx = ::spectrumIndex(this->_currentContractId);
-	if (fee >= 0 && contractSpectrumIdx >= 0 && decreaseEnergy(contractSpectrumIdx, fee))
+	if (fee >= MIN_ORACLE_SUBSCRIPTION_FEE && contractSpectrumIdx >= 0 && decreaseEnergy(contractSpectrumIdx, fee))
 	{
 		// log burning of QU
 		const QuTransfer quTransfer = { this->_currentContractId, m256i::zero(), fee };

--- a/src/oracle_core/oracle_engine.h
+++ b/src/oracle_core/oracle_engine.h
@@ -34,6 +34,9 @@ constexpr uint32_t MAX_ORACLE_SUBSCRIBERS = MAX_ORACLE_SUBSCRIPTIONS * 16;
 
 constexpr uint32_t MAX_ORACLE_TIMEOUT_MILLISEC = 3600 * 1000;
 
+constexpr int64_t MIN_ORACLE_QUERY_FEE = 10;
+constexpr int64_t MIN_ORACLE_SUBSCRIPTION_FEE = 100;
+
 
 #pragma pack(push, 4)
 struct OracleQueryMetadata
@@ -633,7 +636,7 @@ public:
         // check fee
         const void* queryData = (tx + 1);
         const int64_t fee = (forceZeroFee) ? 0 : OI::getOracleQueryFeeFunc[tx->oracleInterfaceIndex](queryData);
-        if (tx->amount < fee)
+        if (!forceZeroFee && (tx->amount < fee || fee < MIN_ORACLE_QUERY_FEE))
         {
             // tx amount insufficient for fee -> return error (caller should refund in all error cases)
 #if !defined(NDEBUG) && !defined(NO_UEFI)


### PR DESCRIPTION
Add and check `MIN_ORACLE_QUERY_FEE = 10` and `MIN_ORACLE_SUBSCRIPTION_FEE = 100`. The goal is to prevent spam.