### PR TITLE
Adds an input limit check to public procedures

### DIFF
--- a/src/contracts/qpi.h
+++ b/src/contracts/qpi.h
@@ -2999,6 +2999,7 @@ namespace QPI
 	#define PUBLIC_PROCEDURE_WITH_LOCALS(procedure) \
 		public: \
 			enum { __is_function_##procedure = false, __id_##procedure = (CONTRACT_INDEX << 22) | __LINE__ }; \
+			static_assert(sizeof(procedure##_input) <= MAX_INPUT_SIZE, #procedure "_input size too large"); \
 			inline static void procedure(const QPI::QpiContextProcedureCall& qpi, QPI::ContractState<CONTRACT_STATE_TYPE::StateData, CONTRACT_INDEX>& state, procedure##_input& input, procedure##_output& output, procedure##_locals& locals) { ::__FunctionOrProcedureBeginEndGuard<(CONTRACT_INDEX << 22) | __LINE__> __prologueEpilogueCaller; __impl_##procedure(qpi, state, input, output, locals); } \
 			static void __impl_##procedure(const QPI::QpiContextProcedureCall& qpi, QPI::ContractState<CONTRACT_STATE_TYPE::StateData, CONTRACT_INDEX>& state, procedure##_input& input, procedure##_output& output, procedure##_locals& locals)
 


### PR DESCRIPTION
Transactions check the limit of `_input` structures against `MAX_INPUT_SIZE`, which is `1024`
`transactions.h`
```C++
    // Check if transaction is valid
    bool checkValidity() const
    {
        return amount >= 0 && amount <= MAX_AMOUNT && inputSize <= MAX_INPUT_SIZE;
    }
```
The following check is used in `#define REGISTER_USER_PROCEDURE`:
`static_assert(sizeof(userProcedure##_input) <= 65535, #userProcedure "_input size too large"); `
I decided not to change it, but to add my own in `#define PUBLIC_PROCEDURE_WITH_LOCALS` so as not to affect private procedures, since there is no need to