### PR TITLE
Add Qassandra prediction market scaffold

### DIFF
--- a/src/contract_core/contract_def.h
+++ b/src/contract_core/contract_def.h
@@ -18,6 +18,9 @@
 // make interfaces to oracles available for all contracts
 #include "oracle_core/oracle_interfaces_def.h"
 
+// make inert Qassandra prediction-market scaffold types available for contracts
+#include "contracts/Qassandra.h"
+
 #define QX_CONTRACT_INDEX 1
 #define CONTRACT_INDEX QX_CONTRACT_INDEX
 #define CONTRACT_STATE_TYPE QX

--- a/src/contracts/Qassandra.h
+++ b/src/contracts/Qassandra.h
@@ -1,3 +1,5 @@
+#pragma once
+
 using namespace QPI;
 
 // Inert scaffold for future Qassandra oracle-settled prediction markets.
@@ -52,7 +54,7 @@ struct QassandraMarketId
 
 struct QassandraOracleSettlement
 {
-	sint64 thresholdValue;
+	uint64 thresholdValue;
 	uint8 comparisonDirection;
 };
 
@@ -69,7 +71,7 @@ struct QassandraMarketDescriptor
 	uint64 settlementTime;
 	id oracleQueryId;
 	uint8 settlementStatus;
-	bool canAgentRead;
+	uint8 canAgentRead;
 };
 
 inline static bool qassandraIsValidPriceReply(const OI::Price::OracleReply& reply)
@@ -77,9 +79,9 @@ inline static bool qassandraIsValidPriceReply(const OI::Price::OracleReply& repl
 	return reply.numerator > 0 && reply.denominator > 0;
 }
 
-inline static bool qassandraCompareScaledPrice(const OI::Price::OracleReply& reply, sint64 thresholdValue, uint8 comparisonDirection)
+inline static bool qassandraCompareScaledPrice(const OI::Price::OracleReply& reply, uint64 thresholdValue, uint8 comparisonDirection)
 {
-	if (!qassandraIsValidPriceReply(reply) || thresholdValue < 0)
+	if (!qassandraIsValidPriceReply(reply))
 	{
 		return false;
 	}
@@ -103,5 +105,6 @@ inline static bool qassandraCompareScaledPrice(const OI::Price::OracleReply& rep
 	{
 		return left <= right;
 	}
+	// Unknown comparison directions fail closed.
 	return false;
 }

--- a/src/contracts/Qassandra.h
+++ b/src/contracts/Qassandra.h
@@ -15,6 +15,12 @@ enum QassandraMarketStatus : uint8
 	QASSANDRA_MARKET_STATUS_CANCELLED = 4,
 };
 
+enum QassandraMarketType : uint8
+{
+	QASSANDRA_MARKET_TYPE_UNKNOWN = 0,
+	QASSANDRA_MARKET_TYPE_BINARY_PRICE = 1,
+};
+
 enum QassandraOutcome : uint8
 {
 	QASSANDRA_OUTCOME_UNKNOWN = 0,
@@ -28,6 +34,14 @@ enum QassandraComparisonDirection : uint8
 	QASSANDRA_COMPARE_GTE = 1,
 	QASSANDRA_COMPARE_LT = 2,
 	QASSANDRA_COMPARE_LTE = 3,
+};
+
+enum QassandraOracleSettlementStatus : uint8
+{
+	QASSANDRA_ORACLE_SETTLEMENT_STATUS_UNKNOWN = 0,
+	QASSANDRA_ORACLE_SETTLEMENT_STATUS_PENDING = 1,
+	QASSANDRA_ORACLE_SETTLEMENT_STATUS_READY = 2,
+	QASSANDRA_ORACLE_SETTLEMENT_STATUS_FINAL = 3,
 };
 
 struct QassandraMarketId
@@ -47,9 +61,15 @@ struct QassandraOracleSettlement
 struct QassandraMarketDescriptor
 {
 	QassandraMarketId marketId;
+	uint8 marketType;
 	id baseAsset;
 	id quoteAsset;
 	QassandraOracleSettlement settlement;
+	uint64 settlementTick;
+	uint64 settlementTime;
+	id oracleQueryId;
+	uint8 settlementStatus;
+	bool canAgentRead;
 };
 
 inline static bool qassandraIsValidPriceReply(const OI::Price::OracleReply& reply)

--- a/src/contracts/Qassandra.h
+++ b/src/contracts/Qassandra.h
@@ -109,57 +109,6 @@ inline static bool qassandraCompareScaledPrice(const OI::Price::OracleReply& rep
 	return false;
 }
 
-struct Qassandra : public ContractBase
-{
-	struct StateData
-	{
-	};
-
-	REGISTER_USER_FUNCTIONS_AND_PROCEDURES()
-	{
-	}
-
-	INITIALIZE()
-	{
-	}
-
-	BEGIN_EPOCH()
-	{
-	}
-
-	END_EPOCH()
-	{
-	}
-
-	BEGIN_TICK()
-	{
-	}
-
-	END_TICK()
-	{
-	}
-
-	PRE_ACQUIRE_SHARES()
-	{
-	}
-
-	POST_ACQUIRE_SHARES()
-	{
-	}
-
-	PRE_RELEASE_SHARES()
-	{
-	}
-
-	POST_RELEASE_SHARES()
-	{
-	}
-
-	POST_INCOMING_TRANSFER()
-	{
-	}
-
-	EXPAND()
-	{
-	}
-};
+// Qassandra contract lifecycle hooks are intentionally omitted in this scaffold.
+// Later commits can add the ContractBase implementation after the contract index,
+// state type, and runtime registration path are fully wired.

--- a/src/contracts/Qassandra.h
+++ b/src/contracts/Qassandra.h
@@ -1,0 +1,87 @@
+using namespace QPI;
+
+// Inert scaffold for future Qassandra oracle-settled prediction markets.
+// This header defines contract-safe identifiers, status/outcome values, and
+// deterministic settlement comparison helpers without adding storage or runtime hooks.
+
+constexpr uint64 QASSANDRA_QUBIC_USD_PRICE_SCALE = 100000000ULL;
+
+enum QassandraMarketStatus : uint8
+{
+	QASSANDRA_MARKET_STATUS_DRAFT = 0,
+	QASSANDRA_MARKET_STATUS_OPEN = 1,
+	QASSANDRA_MARKET_STATUS_LOCKED = 2,
+	QASSANDRA_MARKET_STATUS_SETTLED = 3,
+	QASSANDRA_MARKET_STATUS_CANCELLED = 4,
+};
+
+enum QassandraOutcome : uint8
+{
+	QASSANDRA_OUTCOME_UNKNOWN = 0,
+	QASSANDRA_OUTCOME_NO = 1,
+	QASSANDRA_OUTCOME_YES = 2,
+};
+
+enum QassandraComparisonDirection : uint8
+{
+	QASSANDRA_COMPARE_GT = 0,
+	QASSANDRA_COMPARE_GTE = 1,
+	QASSANDRA_COMPARE_LT = 2,
+	QASSANDRA_COMPARE_LTE = 3,
+};
+
+struct QassandraMarketId
+{
+	id eventId;
+	uint64 nonce;
+};
+
+struct QassandraOracleSettlement
+{
+	sint64 thresholdValue;
+	uint8 comparisonDirection;
+};
+
+// Agent-readable market metadata and deterministic settlement surfaces are planned
+// for later Qassandra layers; no wallet, API, or off-chain orchestration is added here.
+struct QassandraMarketDescriptor
+{
+	QassandraMarketId marketId;
+	id baseAsset;
+	id quoteAsset;
+	QassandraOracleSettlement settlement;
+};
+
+inline static bool qassandraIsValidPriceReply(const OI::Price::OracleReply& reply)
+{
+	return reply.numerator > 0 && reply.denominator > 0;
+}
+
+inline static bool qassandraCompareScaledPrice(const OI::Price::OracleReply& reply, sint64 thresholdValue, uint8 comparisonDirection)
+{
+	if (!qassandraIsValidPriceReply(reply) || thresholdValue < 0)
+	{
+		return false;
+	}
+
+	const uint128 left = uint128(reply.numerator) * uint128(QASSANDRA_QUBIC_USD_PRICE_SCALE);
+	const uint128 right = uint128(thresholdValue) * uint128(reply.denominator);
+
+	if (comparisonDirection == QASSANDRA_COMPARE_GT)
+	{
+		return left > right;
+	}
+	if (comparisonDirection == QASSANDRA_COMPARE_GTE)
+	{
+		return left >= right;
+	}
+	if (comparisonDirection == QASSANDRA_COMPARE_LT)
+	{
+		return left < right;
+	}
+	if (comparisonDirection == QASSANDRA_COMPARE_LTE)
+	{
+		return left <= right;
+	}
+	return false;
+}

--- a/src/contracts/Qassandra.h
+++ b/src/contracts/Qassandra.h
@@ -108,3 +108,58 @@ inline static bool qassandraCompareScaledPrice(const OI::Price::OracleReply& rep
 	// Unknown comparison directions fail closed.
 	return false;
 }
+
+struct Qassandra : public ContractBase
+{
+	struct StateData
+	{
+	};
+
+	REGISTER_USER_FUNCTIONS_AND_PROCEDURES()
+	{
+	}
+
+	INITIALIZE()
+	{
+	}
+
+	BEGIN_EPOCH()
+	{
+	}
+
+	END_EPOCH()
+	{
+	}
+
+	BEGIN_TICK()
+	{
+	}
+
+	END_TICK()
+	{
+	}
+
+	PRE_ACQUIRE_SHARES()
+	{
+	}
+
+	POST_ACQUIRE_SHARES()
+	{
+	}
+
+	PRE_RELEASE_SHARES()
+	{
+	}
+
+	POST_RELEASE_SHARES()
+	{
+	}
+
+	POST_INCOMING_TRANSFER()
+	{
+	}
+
+	EXPAND()
+	{
+	}
+};


### PR DESCRIPTION
## Summary

This PR adds the first minimal Qassandra scaffold to `core` as Qubic-native prediction market infrastructure.

Qassandra is being designed as an oracle-first forecasting layer for both human users and autonomous agents. The initial focus is QUBIC/USD forecasting, but the structure is intentionally typed, deterministic, and modular so it can later support stablecoin rails, bridges, external oracle providers, UI/API layers, broader market categories, and direct agent integrations.

This PR adds only inert primitives and helper logic. It does not register a contract, add procedures, introduce storage, touch runtime behavior, or wire in settlement flows.

---

## Why this matters

Most prediction markets are built around human-facing UI flows first, then later expose APIs for automation.

Qassandra takes the opposite path.

It starts from deterministic, contract-safe primitives that can become readable and usable by both humans and agents from the beginning. Markets should not only be displayed to users; they should be structured so software agents can discover them, reason about them, price them, execute against them, and eventually settle through Qubic-native oracle logic.

This matters because future demand will not only come from people clicking buttons. It will come from AI agents needing reliable forecast markets for price signals, risk checks, hedging, routing decisions, automated treasury actions, and machine-to-machine coordination.

Qassandra should be built for that future at the base layer.

---

## Design intent

This scaffold is designed to be:

- **Qubic-native**: aligned with deterministic smart contract execution instead of external market infrastructure.
- **Oracle-first**: built around verifiable price/outcome settlement rather than UI-first speculation.
- **Agent-readable**: typed market descriptors and outcomes can later be exposed cleanly to autonomous systems.
- **Deterministic**: scaled integer comparison avoids floating-point behavior.
- **Modular**: future commits can add storage, market lifecycle, settlement, stablecoin rails, bridges, APIs, and agent interfaces without redesigning the base types.
- **Minimal**: no runtime behavior is changed in this PR.

---

## Added

This PR introduces:

- `QASSANDRA_QUBIC_USD_PRICE_SCALE`
- `QassandraMarketStatus`
- `QassandraOutcome`
- `QassandraComparisonDirection`
- `QassandraMarketId`
- `QassandraOracleSettlement`
- `QassandraMarketDescriptor`
- `qassandraIsValidPriceReply`
- `qassandraCompareScaledPrice`

---

## Oracle price comparison behavior

The helper logic supports deterministic comparison of scaled oracle price replies against market thresholds.

This is intended for future QUBIC/USD forecast markets where an oracle reply can provide a rational price through numerator/denominator fields while the market stores a scaled threshold.

This keeps future settlement logic compatible with deterministic execution and avoids floating-point ambiguity.

---

## Agentic roadmap alignment

This PR does not add agent functionality yet, but it creates the structure needed for it.

Future Qassandra layers can expose markets in formats that are easy for agents to parse, query, and act on. That includes:

- market descriptors
- market status
- comparison direction
- threshold values
- oracle settlement metadata
- outcome states
- deterministic validation helpers

Longer term, Qassandra can support agent interaction through APIs, indexers, wallet-controlled agents, strategy bots, bridge-aware execution, and eventual direct integration paths with Qubic AI infrastructure such as Aigarth and Neuraxon once those rails mature.

The goal is not just a prediction market frontend.

The goal is forecasting infrastructure that autonomous agents can use as a native market signal layer.

---

## Scope intentionally excluded

This PR does **not** add:

- market creation procedures
- user orders
- positions/shares
- escrow/accounting logic
- oracle query submission
- oracle subscriptions
- settlement execution
- stablecoin logic
- bridge logic
- frontend/API behavior
- persistent Qassandra state
- new contract registration
- agent execution logic

Those should come in separate PRs with clean review boundaries.

---

## Validation

Completed:

- Confirmed no pre-existing `Qassandra` symbols before adding.
- Added focused Qassandra symbols only.
- Ran focused symbol search after implementation.
- Ran `git diff --check`.
- Ran a narrow syntax probe against `contract_def.h`.

The narrow syntax probe confirmed the Qassandra-specific issue was fixed. Remaining local probe failures are from existing macOS/clang platform issues, including MSVC-style integer suffixes and intrinsic helpers, not from the Qassandra scaffold itself.

Full build was not run because the local workspace does not have an existing build directory, the documented test CMake path fetches GoogleTest, and EFI/full build setup is platform-sensitive in this environment.

---

## Risk profile

Low.

This PR adds inert types, constants, and helper functions only. It does not alter existing contract behavior, does not execute at runtime, does not change consensus behavior, and does not introduce storage layout changes.

Future PRs can build from this scaffold incrementally across storage, procedures, oracle queries, settlement, market lifecycle, stablecoin rails, and agent-facing interfaces.