### PR TITLE
Revenue improvement.

### DIFF
--- a/src/contracts/math_lib.h
+++ b/src/contracts/math_lib.h
@@ -181,4 +181,110 @@ inline constexpr T greatestCommonDivisor(T a, T b)
 	return a;
 }
 
+// hard termination backstop for iroot
+static constexpr unsigned int IROOT_NEWTON_CAP = 100;
+
+// Number of significant bits of x (highest set bit + 1); bitLength(0) == 0.
+inline static unsigned int bitLength(unsigned long long x)
+{
+    if (x == 0)
+    {
+        return 0;
+    }
+    return 64U - static_cast<unsigned int>(__lzcnt64(x));
+}
+
+// Returns true if x^exp <= maxAllowed
+inline static bool powerLessOrEqual(unsigned long long x, unsigned int exp, unsigned long long maxAllowed)
+{
+    if (exp == 0)
+    {
+        return 1ULL <= maxAllowed;
+    }
+    if (x <= 1)
+    {
+        return x <= maxAllowed;
+    }
+
+    unsigned long long p = 1;
+    for (unsigned int i = 0; i < exp; i++)
+    {
+        if (p > maxAllowed / x)
+        {
+            // p * x would exceed maxAllowed
+            return false;
+        }
+        p *= x;
+    }
+    return true;
+}
+
+// One Newton step toward floor(n^(1/k)): exact integer floor of ((k-1)*x + n/x^(k-1)) / k,
+// formed so neither (k-1)*x nor x^(k-1) can overflow u64
+template<unsigned int k>
+inline static unsigned long long irootNewtonStep(unsigned long long n, unsigned long long x)
+{
+    unsigned long long xPowKm1 = 1;
+    bool overflowed = false;
+    for (unsigned int j = 0; j < k - 1; j++)
+    {
+        if (xPowKm1 > 0xFFFFFFFFFFFFFFFFULL / x)
+        {
+            // x^(k-1) > u64max => > n => divTerm = 0
+            overflowed = true;
+            break;
+        }
+        xPowKm1 *= x;
+    }
+    const unsigned long long divTerm = overflowed ? 0ULL : (n / xPowKm1);
+
+    if (divTerm >= x)
+    {
+        return x + (divTerm - x) / k;
+    }
+    return x - (x - divTerm + (k - 1)) / k;
+}
+
+// Floor of the integer k-th root: the largest r with r^k <= n
+template<unsigned int k>
+inline static unsigned long long irootK64(unsigned long long n)
+{
+    static_assert(k >= 1 && k <= 64, "irootK64 only supports k in [1, 64]");
+    if (k == 1)
+    {
+        return n;
+    }
+
+    if (n < 2)
+    {
+        // iroot(0) = 0, iroot(1) = 1
+        return n;
+    }
+
+    // Init value
+    const unsigned int seedShift = (bitLength(n) + k - 1) / k;   // ceil(bitLength(n)/k); <= 32 for k >= 2
+    unsigned long long x = 1ULL << seedShift;
+
+    // Condition-driven Newton
+    unsigned long long t = irootNewtonStep<k>(n, x);
+    unsigned int iter = 0;
+    while (t < x && iter < IROOT_NEWTON_CAP)
+    {
+        x = t;
+        t = irootNewtonStep<k>(n, x);
+        iter++;
+    }
+
+    // Exact floor correction
+    while (!powerLessOrEqual(x, k, n))
+    {
+        x--;
+    }
+    while (x < 0xFFFFFFFFFFFFFFFFULL && powerLessOrEqual(x + 1, k, n))
+    {
+        x++;
+    }
+    return x;
+}
+
 }

--- a/src/contracts/math_lib.h
+++ b/src/contracts/math_lib.h
@@ -181,6 +181,50 @@ inline constexpr T greatestCommonDivisor(T a, T b)
 	return a;
 }
 
+static unsigned long long ipow(unsigned long long v, unsigned int e)
+{
+    // Edge case: 0^0 = 1, while 0^e (where e > 0) = 0
+    if (v == 0)
+    {
+        return (e == 0) ? 1 : 0;
+    }
+    // Edge case: 1^e is always 1
+    if (v == 1)
+    {
+        return 1;
+    }
+
+    unsigned long long r = 1;
+    const unsigned long long max_val = 0xFFFFFFFFFFFFFFFFULL;
+
+    while (e > 0)
+    {
+        // If the current bit of the exponent is set, multiply r by v
+        if (e & 1)
+        {
+            if (r > max_val / v)
+            {
+                return max_val; // Saturate on overflow
+            }
+            r *= v;
+        }
+
+        // Advance to the next bit of the exponent
+        e >>= 1;
+
+        // If there are more bits left, square the base v
+        if (e > 0)
+        {
+            if (v > max_val / v)
+            {
+                return max_val;
+            }
+            v *= v;
+        }
+    }
+    return r;
+}
+
 // hard termination backstop for iroot
 static constexpr unsigned int IROOT_NEWTON_CAP = 100;
 

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -87,7 +87,6 @@ static unsigned short SPECTRUM_FILE_NAME[] = L"spectrum.???";
 static unsigned short UNIVERSE_FILE_NAME[] = L"universe.???";
 static unsigned short SCORE_CACHE_FILE_NAME[] = L"score.???";
 static unsigned short CONTRACT_FILE_NAME[] = L"contract????.???";
-static unsigned short CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME[] = L"custom_revenue.eoe";
 static unsigned short CONTRACT_EXEC_FEES_ACC_FILE_NAME[] = L"contract_exec_fees_acc.???";
 static unsigned short CONTRACT_EXEC_FEES_REC_FILE_NAME[] = L"contract_exec_fees_rec.???";
 static unsigned short REVENUE_DATA_END_OF_EPOCH_FILE_NAME[] = L"revenue_data.eoe";

--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -92,6 +92,8 @@ static unsigned short CONTRACT_EXEC_FEES_ACC_FILE_NAME[] = L"contract_exec_fees_
 static unsigned short CONTRACT_EXEC_FEES_REC_FILE_NAME[] = L"contract_exec_fees_rec.???";
 static unsigned short REVENUE_DATA_END_OF_EPOCH_FILE_NAME[] = L"revenue_data.eoe";
 static unsigned short REVENUE_DATA_SNAPSHOT_FILE_NAME[] = L"revenue_data.???";
+static unsigned short MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[] = L"revenue_data_multi.???";
+static unsigned short MULTIDIM_REVENUE_END_OF_EPOCH_FILE_NAME[] = L"revenue_data_multi.eoe";
 
 static constexpr unsigned long long HYPERIDENTITY_NUMBER_OF_INPUT_NEURONS = 512;     // K
 static constexpr unsigned long long HYPERIDENTITY_NUMBER_OF_OUTPUT_NEURONS = 512;    // L

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -3142,6 +3142,8 @@ static void processTick(unsigned long long processorNumber)
         unsigned int nProtocolTx = 0;
         unsigned int nContractTx = 0;
         unsigned int nOtherTx = 0;
+        setMem(gTxObservation, sizeof(gTxObservation), 0);
+
         const m256i& tickLeaderKey = broadcastedComputors.computors.publicKeys[system.tick % NUMBER_OF_COMPUTORS];
         for (unsigned int transactionIndex = 0; transactionIndex < NUMBER_OF_TRANSACTIONS_PER_TICK; transactionIndex++)
         {
@@ -3152,6 +3154,33 @@ static void processTick(unsigned long long processorNumber)
                     Transaction* transaction = ts.tickTransactions(tsCurrentTickTransactionOffsets[transactionIndex]);
                     logger.registerNewTx(transaction->tick, transactionIndex);
                     processTickTransaction(transaction, transactionIndex, processorNumber);
+
+                    // Multi-dim revenue: categorize this tx into the REVENUE_TX_DIM observation
+                    if (isZero(transaction->destinationPublicKey))
+                    {
+                        const int srcIdx = computorIndex(transaction->sourcePublicKey);
+                        if (srcIdx >= 0)
+                        {
+                            // [0,676) source-computor
+                            gTxObservation[srcIdx]++;
+                        }
+                        else
+                        {
+                            // non-computor service -> transfer
+                            gTxObservation[REVENUE_TX_DIM - 1]++;
+                        }
+                    }
+                    else if (isPublicKeyOfContract(transaction->destinationPublicKey))
+                    {
+                        const unsigned int cidx = (unsigned int)transaction->destinationPublicKey.u64._0;
+                        // [676, 676+contractCount)
+                        gTxObservation[NUMBER_OF_COMPUTORS + cidx]++;
+                    }
+                    else
+                    {
+                        // user-to-user txs, other txs
+                        gTxObservation[REVENUE_TX_DIM - 1]++;                    
+                    }
 
                     if (transaction->sourcePublicKey == tickLeaderKey)
                     {
@@ -3192,6 +3221,8 @@ static void processTick(unsigned long long processorNumber)
                 gEpochRevenueData.perTickProtocolTxCount[tickOffset] = (unsigned short)nProtocolTx;
                 gEpochRevenueData.perTickContractTxCount[tickOffset] = (unsigned short)nContractTx;
                 gEpochRevenueData.perTickOtherTxCount[tickOffset] = (unsigned short)nOtherTx;
+
+                revenueOnTick(tickOffset, gTxObservation);
             }
         }
         PROFILE_SCOPE_END();
@@ -3881,6 +3912,9 @@ static void beginEpoch()
 
     resetCustomMining();
     setMem(&gEpochRevenueData, sizeof(gEpochRevenueData), 0);
+    setMem(&gMultiDimRevenue, sizeof(gMultiDimRevenue), 0);
+    // interior ticks finalized in revenueOnTick() depend on initialTick being correct all epoch.
+    gMultiDimRevenue.initialTick = system.initialTick;
 
     // Reset resource testing digest at beginning of the epoch
     // there are many global variables that were init at declaration, may need to re-check all of them again
@@ -3950,21 +3984,6 @@ static void endEpoch()
             ts.tickData.releaseLock();
         }
 
-        // Save data of custom mining.
-        {
-            for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
-            {
-                gRevenueComponents.voteScore[i] = voteCounter.getVoteCount(i);
-                gRevenueComponents.txScore[i] = revenueScore[i];
-            }
-            setMem(gRevenueComponents.customMiningScore, sizeof(gRevenueComponents.customMiningScore), 0);
-            computeRevenue(
-                gRevenueComponents.txScore,
-                gRevenueComponents.voteScore,
-                gRevenueComponents.customMiningScore,
-                gRevenueComponents.revenue);
-        }
-
         // Collect mining scores for V2
         for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
         {
@@ -3982,6 +4001,25 @@ static void endEpoch()
             copyMemory(gEpochRevenueData.oracleScore, oracleRevPoints.computorRevPoints);
         }
         computeRevenueV2(gEpochRevenueData);
+
+        // Multi dimension revenue in shadow mode
+        gMultiDimRevenue.totalTicks = system.tick - system.initialTick;
+        computeMultiDimRevenue();
+
+        // Save data of custom mining.
+        {
+            for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+            {
+                gRevenueComponents.voteScore[i] = voteCounter.getVoteCount(i);
+                gRevenueComponents.txScore[i] = revenueScore[i];
+            }
+            setMem(gRevenueComponents.customMiningScore, sizeof(gRevenueComponents.customMiningScore), 0);
+            computeRevenue(
+                gRevenueComponents.txScore,
+                gRevenueComponents.voteScore,
+                gRevenueComponents.customMiningScore,
+                gRevenueComponents.revenue);
+        }
 
 
         // Get revenue donation data by calling contract GQMPROP::GetRevenueDonation()
@@ -4319,6 +4357,16 @@ static bool saveAllNodeStates()
         return false;
     }
 
+    MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME) / sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[0]) - 4] = system.epoch / 100 + L'0';
+    MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME) / sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[0]) - 3] = (system.epoch % 100) / 10 + L'0';
+    MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME) / sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[0]) - 2] = system.epoch % 10 + L'0';
+    savedSize = save(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME, sizeof(gMultiDimRevenue), (unsigned char*)&gMultiDimRevenue, directory);
+    if (savedSize != sizeof(gMultiDimRevenue)) 
+    {
+        logToConsole(L"Failed to save multidim revenue");
+        return false; 
+    }
+
     CHAR16 SPECTRUM_DIGEST_FILE_NAME[] = L"snapshotSpectrumDigest";
     savedSize = save(SPECTRUM_DIGEST_FILE_NAME, spectrumDigestsSizeInByte, (unsigned char*)spectrumDigests, directory);
     logToConsole(L"Saving spectrum digests");
@@ -4494,6 +4542,18 @@ static bool loadAllNodeStates()
     {
         logToConsole(L"Failed to load revenue data snapshot, starting with zero counts");
         setMem(&gEpochRevenueData, sizeof(gEpochRevenueData), 0);
+    }
+
+    MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME) / sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[0]) - 4] = system.epoch / 100 + L'0';
+    MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME) / sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[0]) - 3] = (system.epoch % 100) / 10 + L'0';
+    MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME) / sizeof(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME[0]) - 2] = system.epoch % 10 + L'0';
+    long long mdSize = load(MULTIDIM_REVENUE_SNAPSHOT_FILE_NAME, sizeof(gMultiDimRevenue), (unsigned char*)&gMultiDimRevenue, directory);
+    if (mdSize != sizeof(gMultiDimRevenue))
+    {
+        // SHADOW: gMultiDimRevenue is computed but not applied to balances, so zero+continue is safe.
+        // TODO: when applied this must return false
+        logToConsole(L"Multi dim revenue snapshot missing/mismatch (shadow mode), zeroing");
+        setMem(&gMultiDimRevenue, sizeof(gMultiDimRevenue), 0);
     }
 
     // update own computor indices
@@ -5579,6 +5639,8 @@ static void tickProcessor(void*)
                                     saveRevenueComponents(NULL);
                                     // Revenue v2 data
                                     asyncSave(REVENUE_DATA_END_OF_EPOCH_FILE_NAME, sizeof(gEpochRevenueData), (unsigned char*)&gEpochRevenueData);
+                                    // Multi-dim revenue (shadow) - for offline comparison against the additive
+                                    asyncSave(MULTIDIM_REVENUE_END_OF_EPOCH_FILE_NAME, sizeof(gMultiDimRevenue), (unsigned char*)&gMultiDimRevenue);
 
                                     // Reorder futureComputors so requalifying computors keep their index
                                     // This is needed for correct execution fee reporting across epoch boundaries

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -265,7 +265,6 @@ static bool saveContractExecFeeFiles(CHAR16* directory = NULL, bool saveAccumula
 static bool saveSystem(CHAR16* directory = NULL);
 static bool loadContractStateFiles(CHAR16* directory = NULL, bool forceLoadFromFile = false);
 static bool loadContractExecFeeFiles(CHAR16* directory = NULL, bool loadAccumulatedTime = false);
-static bool saveRevenueComponents(CHAR16* directory = NULL);
 
 #if ENABLED_LOGGING
 #define PAUSE_BEFORE_CLEAR_MEMORY 1 // Requiring operators to press F10 to clear memory (before switching epoch)
@@ -5636,7 +5635,6 @@ static void tickProcessor(void*)
                                     endEpoch();
 
                                     // Save the file of revenue. This blocking save can be called from any thread
-                                    saveRevenueComponents(NULL);
                                     // Revenue v2 data
                                     asyncSave(REVENUE_DATA_END_OF_EPOCH_FILE_NAME, sizeof(gEpochRevenueData), (unsigned char*)&gEpochRevenueData);
                                     // Multi-dim revenue (shadow) - for offline comparison against the additive
@@ -5926,17 +5924,6 @@ static bool saveSystem(CHAR16* directory)
         appendNumber(message, (__rdtsc() - beginningTick) * 1000000 / frequency, TRUE);
         appendText(message, L" microseconds).");
         logToConsole(message);
-        return true;
-    }
-    return false;
-}
-
-static bool saveRevenueComponents(CHAR16* directory)
-{
-    CHAR16* fn = CUSTOM_MINING_REVENUE_END_OF_EPOCH_FILE_NAME;
-    long long savedSize = asyncSave(fn, sizeof(gRevenueComponents), (unsigned char*)&gRevenueComponents, directory);
-    if (savedSize == sizeof(gRevenueComponents))
-    {
         return true;
     }
     return false;

--- a/src/revenue.h
+++ b/src/revenue.h
@@ -3,13 +3,13 @@
 #include "platform/memory.h"
 #include "platform/assert.h"
 #include "network_messages/common_def.h"
+#include "contracts/math_lib.h"
 #include "vote_counter.h"
 #include "public_settings.h"
 
 // Revenue V2: set to 1 to use the new revenue formula (additive bonus + sliding window + oracle)
 // set to 0 to use V1 formula (multiplicative: tx * vote * mining)
 #define USE_REVENUE_V2 1
-
 
 static unsigned long long gVoteScoreBuffer[NUMBER_OF_COMPUTORS];
 static unsigned long long gCustomMiningScoreBuffer[NUMBER_OF_COMPUTORS];
@@ -300,7 +300,6 @@ static_assert(((1ULL << VOTE_COUNTER_NUM_BIT_PER_COMP) - 1)* NUMBER_OF_COMPUTORS
 static_assert(((1ULL << VOTE_COUNTER_NUM_BIT_PER_COMP) - 1)* NUMBER_OF_COMPUTORS* MAX_NUMBER_OF_TICKS_PER_EPOCH / 2 <= 0xFFFFFFFFFFFFFFFFULL / gCustomMiningScoreScalingThreshold,
     "Max value of custom mininng score can make score overflow");
 
-
 struct RevenueComponents
 {
     unsigned long long txScore[NUMBER_OF_COMPUTORS];    // revenue score with txs
@@ -464,6 +463,22 @@ static_assert((unsigned long long)REVENUE_IPC * REVENUE_SCALE
     * (REVENUE_SCALE * REVENUE_SCALE + REVENUE_BONUS_CAP * REVENUE_SCALE) <= 0xFFFFFFFFFFFFFFFFULL,
     "V2 revenue formula intermediate can overflow u64");
 
+// TODO: create voting for this number
+static constexpr unsigned int REVENUE_DOGE_K = 4;
+static constexpr unsigned int REVENUE_CONTRACT_DIMS = contractCount;
+static constexpr unsigned int REVENUE_TX_DIM = NUMBER_OF_COMPUTORS + REVENUE_CONTRACT_DIMS + 1;
+static constexpr unsigned int m_SRC_COMPUTOR = 1;
+static constexpr unsigned int m_CONTRACT = 1;
+static constexpr unsigned int m_TRANSFER = 1;
+static constexpr unsigned int REVENUE_M_MAX = 1;
+static constexpr unsigned long long REVENUE_TX_WINDOWSUM_MAX =
+(unsigned long long)NUMBER_OF_TRANSACTIONS_PER_TICK * REVENUE_WINDOW_SIZE;
+static_assert(REVENUE_DOGE_K >= 1 && REVENUE_DOGE_K <= 4, "");
+static_assert((unsigned long long)REVENUE_IPC* REVENUE_SCALE* REVENUE_SCALE* REVENUE_SCALE
+    <= 0xFFFFFFFFFFFFFFFFULL, "IPC*S^3 overflow");
+static_assert((unsigned long long)REVENUE_TX_DIM* REVENUE_M_MAX* REVENUE_M_MAX
+    <= 0xFFFFFFFFFFFFFFFFULL / (REVENUE_TX_WINDOWSUM_MAX * REVENUE_TX_WINDOWSUM_MAX), "L2 sumsq overflow");
+
 // Struct record all data so that we can do the offline analysis
 struct EpochRevenueData
 {
@@ -593,6 +608,235 @@ static void computeRevenueV2(EpochRevenueData& rEpochReveneuData)
 
         unsigned long long numerator = M * (REVENUE_SCALE * REVENUE_SCALE + REVENUE_BONUS_CAP * E);
         rEpochReveneuData.v2Revenue[i] = (long long)(REVENUE_IPC * numerator / REVENUE_DIVISOR);
+    }
+}
+
+static unsigned int gTxObservation[REVENUE_TX_DIM];
+struct MultiDimRevenue
+{
+    // Header
+    unsigned int initialTick;
+    unsigned int totalTicks;                                        // system.tick - system.initialTick
+
+    unsigned short revenueRing[REVENUE_WINDOW_SIZE * REVENUE_TX_DIM];        // last W ticks 
+    unsigned short revenueHead[2 * REVENUE_HALF_WINDOW * REVENUE_TX_DIM];    // first 2H ticks
+    unsigned long long windowSum[REVENUE_TX_DIM];                         // running col sums
+    unsigned long long txScore[NUMBER_OF_COMPUTORS];                      // accumulated L2 TX score
+    long long revenue[NUMBER_OF_COMPUTORS];                      // final output
+};
+static MultiDimRevenue gMultiDimRevenue;
+
+static unsigned short* ringRow(unsigned int t)
+{
+    return gMultiDimRevenue.revenueRing + (unsigned long long)(t % REVENUE_WINDOW_SIZE) * REVENUE_TX_DIM;
+}
+
+static unsigned short* headRow(unsigned int t) 
+{ 
+    return gMultiDimRevenue.revenueHead + (unsigned long long)t * REVENUE_TX_DIM;
+}
+
+// per-dimension multiplier by category
+static unsigned int revenueMul(unsigned int d)
+{
+    if (d < NUMBER_OF_COMPUTORS)
+    {
+        return m_SRC_COMPUTOR;
+    }
+    if (d < NUMBER_OF_COMPUTORS + REVENUE_CONTRACT_DIMS)
+    {
+        return m_CONTRACT;
+    }
+    return m_TRANSFER;
+}
+
+// Compute the score at tickOffset and accumulate it into gMultiDimRevenue.txScore
+// windowSum is accumulated windows around tickOffset
+static void finalizeTickScore(unsigned int tickOffset, const unsigned short* observed, const unsigned long long* windowSum)
+{
+    unsigned long long sumDef = 0;
+    unsigned long long sumCap = 0;
+    for (unsigned int d = 0; d < REVENUE_TX_DIM; d++)
+    {
+        const unsigned long long ws = windowSum[d];
+        const unsigned long long wo = (unsigned long long)REVENUE_WINDOW_SIZE * observed[d];
+        const unsigned long long m = revenueMul(d);
+        const unsigned long long deficit = (wo >= ws) ? 0ULL : m * (ws - wo);
+        const unsigned long long cap = m * ws;
+        sumDef += deficit * deficit;
+        sumCap += cap * cap;
+    }
+
+    unsigned long long tickScore;
+    if (sumCap == 0)
+    {
+        tickScore = REVENUE_SCALE;
+    }
+    else
+    {
+        const unsigned long long pen = math_lib::irootK64<2>(sumDef);
+        const unsigned long long cap = math_lib::irootK64<2>(sumCap);
+        tickScore = REVENUE_SCALE - (REVENUE_SCALE * pen) / cap;
+    }
+    const unsigned int leader = (gMultiDimRevenue.initialTick + tickOffset) % NUMBER_OF_COMPUTORS;
+    gMultiDimRevenue.txScore[leader] += tickScore;
+}
+
+static void revenueOnTick(unsigned int tickOffset, unsigned int* obs)
+{
+    // slot currently holds tick (t - W)
+    unsigned short* slot = ringRow(tickOffset);
+
+    // evict the tick that currently occupies this ring slot (tick t-W), if any
+    if (tickOffset >= REVENUE_WINDOW_SIZE)
+    {
+        for (unsigned int d = 0; d < REVENUE_TX_DIM; d++) 
+        { 
+            gMultiDimRevenue.windowSum[d] -= slot[d];
+        }
+    }
+    // write this tick into the ring + windowSum (and into the frozen head for the first 2H ticks)
+    const bool inHead = (tickOffset < 2u * REVENUE_HALF_WINDOW);
+    unsigned short* h = inHead ? headRow(tickOffset) : nullptr;
+    for (unsigned int d = 0; d < REVENUE_TX_DIM; d++)
+    {
+        const unsigned short v = (unsigned short)obs[d];
+        slot[d] = v;
+        gMultiDimRevenue.windowSum[d] += v;
+        if (inHead) 
+        { 
+            h[d] = v;
+        }
+    }
+
+    // now windowSum covers ticks [t-2H, t] (W entries). Finalize the centered INTERIOR tick c = t-H.
+    if (tickOffset >= 2u * REVENUE_HALF_WINDOW)
+    {
+        const unsigned int c = tickOffset - REVENUE_HALF_WINDOW;      // interior: c in [H, N-1-H]; window [c-H,c+H]=[t-2H,t], no wrap
+        finalizeTickScore(c, ringRow(c), gMultiDimRevenue.windowSum);
+    }
+}
+
+// Get an observation at x. 
+static const unsigned short* obsAt(unsigned int x)
+{
+    return (x < 2U * REVENUE_HALF_WINDOW) ? headRow(x) : ringRow(x);
+}
+
+static unsigned long long edgeWindowSum[REVENUE_TX_DIM];
+// Function handle scoring at the ticks at the epoch boundary (tick < REVENUE_HALF_WINDOW or tick >= lastTick - REVENUE_HALF_WINDOW) 
+// which we need to do circular window wraping around
+static void scoreEpochEdgeTicks(unsigned int tickEdge)
+{
+    const unsigned int H = REVENUE_HALF_WINDOW;
+    if (tickEdge < REVENUE_WINDOW_SIZE) 
+    { 
+        return;
+    }
+
+    // Prepare the windows at tick = N - REVENUE_HALF_WINDOW
+    setMem(edgeWindowSum, sizeof(edgeWindowSum), 0);
+    for (unsigned int x = tickEdge - 2 * H; x <= tickEdge - 1; x++)
+    {
+        const unsigned short* row = ringRow(x);
+        for (unsigned int d = 0; d < REVENUE_TX_DIM; d++)
+        {
+            edgeWindowSum[d] += row[d];
+        }
+    }
+
+    // The last element of windows is circular to the first tick
+    const unsigned short* row = headRow(0);
+    for (unsigned int d = 0; d < REVENUE_TX_DIM; d++)
+    {
+        edgeWindowSum[d] += row[d];
+    }
+
+    // Slide the windows start at tick = N - REVENUE_HALF_WINDOW
+    unsigned int c = tickEdge - H;
+    for (unsigned int step = 0; step < 2u * H; step++)
+    {
+        finalizeTickScore(c, obsAt(c), edgeWindowSum);
+        // Last tick. Everything is done, sliding window don't need to be updated
+        if (step + 1u == 2u * H) 
+        { 
+            break;
+        }
+
+        // Determine the enterring and leaving data
+        const unsigned int leaving = (c >= H) ? (c - H) : (c + tickEdge - H);
+        const unsigned int entering = (c + H + 1u < tickEdge) ? (c + H + 1u) : (c + H + 1u - tickEdge);
+        const unsigned short* lv = obsAt(leaving);
+        const unsigned short* en = obsAt(entering);
+        for (unsigned int d = 0; d < REVENUE_TX_DIM; d++) 
+        { 
+            edgeWindowSum[d] = edgeWindowSum[d] - lv[d] + en[d];
+        }
+        c = (c + 1u < tickEdge) ? (c + 1u) : 0u;
+    }
+}
+
+static void computeMultiDimRevenue()
+{
+    static unsigned long long txFactor[NUMBER_OF_COMPUTORS];
+    static unsigned long long oracleFactor[NUMBER_OF_COMPUTORS];
+    static unsigned long long dogeFactor[NUMBER_OF_COMPUTORS];
+
+    // finish boundary ticks
+    scoreEpochEdgeTicks(gEpochRevenueData.totalTicks);
+    computeRevFactor(gMultiDimRevenue.txScore, REVENUE_SCALE, txFactor);
+
+    // oracle factor (READ-ONLY shared input) + epoch-GLOBAL no-activity valve (an idle factor must
+    // NOT zero all 676 -> arbitrator)
+    bool anyOracle = false;
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++) 
+    { 
+        if (gEpochRevenueData.oracleScore[i]) 
+        { 
+            anyOracle = true;
+            break; 
+        } 
+    }
+    if (anyOracle)
+    { 
+        computeRevFactor(gEpochRevenueData.oracleScore, REVENUE_SCALE, oracleFactor);
+    }
+    else 
+    { 
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++) 
+        { 
+            oracleFactor[i] = REVENUE_SCALE; 
+        } 
+    }
+
+    // DOGE factor (READ-ONLY shared input) + the SAME global valve (required by the hard gate)
+    bool anyDoge = false;
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++) 
+    { 
+        if (gEpochRevenueData.dogeMiningScore[i]) 
+        { 
+            anyDoge = true; 
+            break; 
+        } 
+    }
+    if (anyDoge) 
+    { 
+        computeRevFactor(gEpochRevenueData.dogeMiningScore, REVENUE_SCALE, dogeFactor); 
+    }
+    else 
+    {
+        for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+        {
+            dogeFactor[i] = REVENUE_SCALE;
+        } 
+    }
+
+    const unsigned long long sPowKm1 = math_lib::ipow(REVENUE_SCALE, REVENUE_DOGE_K - 1);
+    for (unsigned int i = 0; i < NUMBER_OF_COMPUTORS; i++)
+    {
+        const unsigned long long dogeRootScaled = math_lib::irootK64<REVENUE_DOGE_K>(dogeFactor[i] * sPowKm1); // [0,S]
+        const unsigned long long num = (unsigned long long)REVENUE_IPC * txFactor[i] * oracleFactor[i] * dogeRootScaled;
+        gMultiDimRevenue.revenue[i] = (long long)(num / (REVENUE_SCALE * REVENUE_SCALE * REVENUE_SCALE));
     }
 }
 

--- a/test/math_lib.cpp
+++ b/test/math_lib.cpp
@@ -117,3 +117,83 @@ TEST(TestCoreMathLib, GreatestCommonDivisor)
     EXPECT_EQ(math_lib::greatestCommonDivisor<int>(8, -12), 0);
     EXPECT_EQ(math_lib::greatestCommonDivisor<int>(-12, -18), 0);
 }
+
+template<unsigned int k>
+static unsigned long long floorRootRef(unsigned long long n)
+{
+    if (n < 2) 
+    { 
+        return n; 
+    }
+    double est;
+    if constexpr (k == 2)
+    { 
+        est = std::sqrt(static_cast<double>(n));
+    }
+    else 
+    { 
+        est = std::pow(static_cast<double>(n), 1.0 / static_cast<double>(k));
+    }
+    unsigned long long r = static_cast<unsigned long long>(est);
+    // double overshot -> down
+    while (r > 0 && !math_lib::powerLessOrEqual(r, k, n))
+    { 
+        r--; 
+    }
+    // double undershot -> up
+    while (r < 0xFFFFFFFFFFFFFFFFULL && math_lib::powerLessOrEqual(r + 1, k, n))
+    { 
+        r++; 
+    }
+    return r;
+}
+
+template<unsigned int k>
+static void expectRoot(unsigned long long n)
+{
+    EXPECT_EQ(math_lib::irootK64<k>(n), floorRootRef<k>(n)) << "k=" << k << " n=" << n;
+}
+
+TEST(TestCoreMathLib, BitLength)
+{
+    EXPECT_EQ(math_lib::bitLength(0), 0u);
+    EXPECT_EQ(math_lib::bitLength(1), 1u);
+    EXPECT_EQ(math_lib::bitLength(2), 2u);
+    EXPECT_EQ(math_lib::bitLength(3), 2u);
+    EXPECT_EQ(math_lib::bitLength(4), 3u);
+    EXPECT_EQ(math_lib::bitLength(255), 8u);
+    EXPECT_EQ(math_lib::bitLength(256), 9u);
+    EXPECT_EQ(math_lib::bitLength(1ULL << 63), 64u);
+    EXPECT_EQ(math_lib::bitLength(0xFFFFFFFFFFFFFFFFULL), 64u);
+}
+
+TEST(TestCoreMathLib, PowerLessOrEqual)
+{
+    EXPECT_TRUE(math_lib::powerLessOrEqual(2, 3, 8));      // 2^3 == 8
+    EXPECT_FALSE(math_lib::powerLessOrEqual(2, 3, 7));      // 2^3 > 7
+    EXPECT_TRUE(math_lib::powerLessOrEqual(0, 0, 5));      // 0^0 == 1
+    EXPECT_FALSE(math_lib::powerLessOrEqual(0, 0, 0));      // 0^0 == 1 > 0
+    EXPECT_TRUE(math_lib::powerLessOrEqual(0, 3, 5));      // 0^3 == 0
+    EXPECT_TRUE(math_lib::powerLessOrEqual(1, 100, 1));    // 1^100 == 1
+    EXPECT_TRUE(math_lib::powerLessOrEqual(2, 63, 0xFFFFFFFFFFFFFFFFULL));   // 2^63 <= u64max
+    EXPECT_FALSE(math_lib::powerLessOrEqual(2, 64, 0xFFFFFFFFFFFFFFFFULL));   // 2^64 > u64max (no overflow in check)
+    EXPECT_FALSE(math_lib::powerLessOrEqual(1000000, 4, 0xFFFFFFFFFFFFFFFFULL)); // 1e24 > u64max
+}
+
+TEST(TestCoreMathLib, IRootVsFloorDouble)
+{
+    const int testCount = 10;
+    unsigned long long s[testCount] = {1000, 541, 475, 9978, 1234, 45, 0, 1, 7, 65};
+    for (int i = 0; i < testCount; i++)
+    {
+        const unsigned long long n = s[i];
+        expectRoot<2>(n);
+        expectRoot<3>(n);
+        expectRoot<4>(n);
+        expectRoot<6>(n);
+        expectRoot<8>(n);
+    }
+    expectRoot<2>(0xFFFFFFFFFFFFFFFFULL);
+    expectRoot<3>(0xFFFFFFFFFFFFFFFFULL);
+    expectRoot<8>(0xFFFFFFFFFFFFFFFFULL);
+}

--- a/test/revenue.cpp
+++ b/test/revenue.cpp
@@ -4,6 +4,10 @@
 
 #include "gtest/gtest.h"
 
+#ifndef contractCount
+#define contractCount 1024
+#endif
+
 #include "../src/revenue.h"
 
 #include <algorithm>


### PR DESCRIPTION
# Multi-dimensional revenue (shadow mode)
Adds a new multi-dimensional revenue computation that runs in shadow mode alongside the existing additive revenue. It is computed and dumped for offline analysis but NOT applied to balances and NOT part of any consensus digest, so there is zero consensus impact. A future coordinated switch will be needed to actually apply it.
- asymmetric-L2 TX scoring over the per-dimension vector (676 source-computor + per-contract + 1 transfer), a circular +/-675-tick window via ring + head buffers (interior ticks finalized while streaming, edge ticks at epoch end)
- change to hard-gate formula IPC * txF * oracleF * dogeRoot / S^3).
- Cleanup: removes the now-unused custom_revenue.eoe dump.