### PR TITLE
fix(qRWA): catch up missed payout after network downtime

### DIFF
--- a/src/contracts/qRWA.h
+++ b/src/contracts/qRWA.h
@@ -32,6 +32,7 @@ constexpr uint64 QRWA_PAYOUT_HOUR_POOL_D = 15;      // MLM Water     | Friday 15
 constexpr uint64 QRWA_PAYOUT_MINUTE = 0;             // Trigger at :00
 constexpr uint64 QRWA_CHECK_DAY_OF_WEEK = 1;         // 1=Friday only
 constexpr uint64 QRWA_MIN_PAYOUT_INTERVAL_MS = 518400000ULL; // 6 days (6 * 86400000)
+constexpr uint64 QRWA_PAYOUT_OVERDUE_MS = 691200000ULL; // 8 days. Catch-up: if a scheduled payout is missed (e.g. network halt over the Friday window), fire on the next tick instead of skipping a full week
 constexpr uint64 QRWA_MIN_REVENUE_THRESHOLD = 1000ULL; // skip distribution if pool revenue below this
 
 // STATUS CODES for Procedures
@@ -2015,6 +2016,47 @@ public:
                             locals.poolDReady = 1;
                         }
                     }
+                }
+            }
+
+            // Catch-up after downtime.
+            // The schedule above only matches when a tick lands inside the scheduled
+            // weekday/hour window. If the network is halted across that window (e.g. a
+            // restart that spans the Friday payout), the payout is otherwise skipped for a
+            // whole week and the accumulated revenue is later distributed against a newer
+            // shareholder snapshot. When a pool is overdue and still has revenue to pay out,
+            // fire on the next available tick regardless of weekday/hour. The distribution
+            // below updates mLastPayoutTimePool*, so each missed slot is caught up only once.
+            if (state.get().mLastPayoutTimePoolA.getYear() != 0 && state.get().mRevenuePoolA >= QRWA_MIN_REVENUE_THRESHOLD)
+            {
+                locals.durationMicros = state.get().mLastPayoutTimePoolA.durationMicrosec(locals.now);
+                if (div<uint64>(locals.durationMicros, 1000) >= QRWA_PAYOUT_OVERDUE_MS)
+                {
+                    locals.poolAReady = 1;
+                }
+            }
+            if (state.get().mLastPayoutTimePoolB.getYear() != 0 && state.get().mRevenuePoolB >= QRWA_MIN_REVENUE_THRESHOLD)
+            {
+                locals.durationMicros = state.get().mLastPayoutTimePoolB.durationMicrosec(locals.now);
+                if (div<uint64>(locals.durationMicros, 1000) >= QRWA_PAYOUT_OVERDUE_MS)
+                {
+                    locals.poolBReady = 1;
+                }
+            }
+            if (state.get().mLastPayoutTimePoolC.getYear() != 0 && state.get().mDedicatedRevenuePool >= QRWA_MIN_REVENUE_THRESHOLD)
+            {
+                locals.durationMicros = state.get().mLastPayoutTimePoolC.durationMicrosec(locals.now);
+                if (div<uint64>(locals.durationMicros, 1000) >= QRWA_PAYOUT_OVERDUE_MS)
+                {
+                    locals.poolCReady = 1;
+                }
+            }
+            if (state.get().mLastPayoutTimePoolD.getYear() != 0 && state.get().mPoolDRevenuePool >= QRWA_MIN_REVENUE_THRESHOLD)
+            {
+                locals.durationMicros = state.get().mLastPayoutTimePoolD.durationMicrosec(locals.now);
+                if (div<uint64>(locals.durationMicros, 1000) >= QRWA_PAYOUT_OVERDUE_MS)
+                {
+                    locals.poolDReady = 1;
                 }
             }
         }

--- a/test/contract_qrwa.cpp
+++ b/test/contract_qrwa.cpp
@@ -702,6 +702,63 @@ TEST(ContractQRWA, Payout_FullDistribution)
     EXPECT_EQ(divBalances.poolAQrwaDividend, 50000 - (qrwaPerShare * NUMBER_OF_COMPUTORS)); // Dust
 }
 
+// Network downtime over the scheduled payout window must not eat a payout.
+// The schedule only matches Friday at the pool hour. If the network is halted across
+// that window the slot is missed, and with the old code the next run only happens the
+// following Friday. The catch-up path pays out on the next tick once a pool is overdue,
+// even on a non-Friday.
+TEST(ContractQRWA, Payout_CatchUpAfterDowntime)
+{
+    ContractTestingQRWA qrwa;
+
+    // Issue QMINE and distribute. No mid-epoch transfers, so begin == end and the
+    // payout math is independent of the sale-eligibility rules.
+    qrwa.issueAsset(QMINE_ISSUER, QMINE_ASSET.assetName, 1000000);
+    increaseEnergy(HOLDER_A, 1000000);
+    increaseEnergy(HOLDER_B, 1000000);
+    qrwa.transferAsset(QMINE_ISSUER, HOLDER_A, QMINE_ASSET, 200000);
+    qrwa.transferAsset(QMINE_ISSUER, HOLDER_B, QMINE_ASSET, 300000);
+    // QMINE_ISSUER keeps 500000. mTotalQmineBeginEpoch = 1,000,000
+
+    qrwa.beginEpoch();
+
+    const id QRWA_SH = id::randomValue();
+    std::vector<std::pair<m256i, unsigned int>> qrwaContractShares{ {QRWA_SH, NUMBER_OF_COMPUTORS} };
+    qrwa.issueContractSharesHelper(QRWA_CONTRACT_INDEX, qrwaContractShares);
+
+    qrwa.sendToMany(ADMIN_ADDRESS, id(QRWA_CONTRACT_INDEX, 0, 0, 0), 1000000); // Pool A revenue
+    qrwa.endEpoch();
+
+    // Per holder: 1M revenue - 50% fees = 500k, QMINE share = 90% = 450k.
+    // A: 200k/1M * 450k = 90,000   B: 300k/1M * 450k = 135,000
+    const sint64 payoutA = 90000;
+    const sint64 payoutB = 135000;
+
+    // First payout on the scheduled Friday.
+    etalonTick.year = 25; etalonTick.month = 11; etalonTick.day = 7; // Friday
+    etalonTick.hour = 12; etalonTick.minute = 1; etalonTick.second = 0;
+    qrwa.resetPayoutTime();
+    qrwa.endTick();
+
+    EXPECT_EQ(getBalance(HOLDER_A), 1000000 + payoutA);
+    EXPECT_EQ(getBalance(HOLDER_B), 1000000 + payoutB);
+    EXPECT_TRUE(qrwa.getState()->mLastPayoutTimePoolA.getYear() != 0);
+
+    // New revenue for the next cycle.
+    qrwa.sendToMany(ADMIN_ADDRESS, id(QRWA_CONTRACT_INDEX, 0, 0, 0), 1000000);
+
+    // The scheduled Friday is missed (network was down). It is now Sunday, more than
+    // 8 days after the last payout. The old code would wait for the next Friday;
+    // the catch-up pays out now.
+    etalonTick.year = 25; etalonTick.month = 11; etalonTick.day = 16; // Sunday, +9 days
+    etalonTick.hour = 13; etalonTick.minute = 0; etalonTick.second = 0;
+    qrwa.endTick();
+
+    EXPECT_EQ(getBalance(HOLDER_A), 1000000 + payoutA * 2);
+    EXPECT_EQ(getBalance(HOLDER_B), 1000000 + payoutB * 2);
+    EXPECT_EQ(qrwa.getDividendBalances().revenuePoolA, 0u);
+}
+
 TEST(ContractQRWA, Payout_SnapshotLogic)
 {
     ContractTestingQRWA qrwa;


### PR DESCRIPTION
(network restart fixes)

pool payouts are scheduled by UTC time Friday, one hour per pool. The `END_TICK`
gate only matches when a tick actually lands inside that hour:

`if (now.getHour() == QRWA_PAYOUT_HOUR_POOL_A && now.getMinute() >= QRWA_PAYOUT_MINUTE)`