### PR TITLE
Feature/2026 07 13 oc machine plumbing

### DIFF
--- a/doc/contracts_outsourced_computations.md
+++ b/doc/contracts_outsourced_computations.md
@@ -1,6 +1,6 @@
 # Outsourced Computations from contracts
 
-Outsourced Computations (OC) let Smart Contracts push intent out of Qubic to be executed by an external Processor.
+Outsourced Computations (OC) let Smart Contracts push intent out of Qubic to be executed by an external Processor. Only contracts can invoke OC; users can only trigger it indirectly, by calling a contract that does.
 Where an Oracle Machine retrieves information from outside Qubic and makes it available on-chain, an OC carries an authorized request out of Qubic so that an external system can act on it.
 The protocol defines how requests are expressed and authorized.
 What happens at the external system is the responsibility of the Processor and the interface.

--- a/doc/contracts_outsourced_computations.md
+++ b/doc/contracts_outsourced_computations.md
@@ -1,0 +1,249 @@
+# Outsourced Computations from contracts
+
+Outsourced Computations (OC) let Smart Contracts push intent out of Qubic to be executed by an external Processor.
+Where an Oracle Machine retrieves information from outside Qubic and makes it available on-chain, an OC carries an authorized request out of Qubic so that an external system can act on it.
+The protocol defines how requests are expressed and authorized.
+What happens at the external system is the responsibility of the Processor and the interface.
+
+OC invocations are subject to a fee to avoid spam.
+The fee is burned.
+
+OC machines (the counterpart to OM nodes) are run by computor operators.
+Each operator connects their Core node to one or more OC machines via a private, out-of-band channel, mirroring the OM topology.
+
+
+## Invocation lifecycle
+
+When a contract initiates an OC invocation, the following happens:
+
+1. The fee is deducted and burned (if an error occurs during the start of the invocation, the fee is refunded),
+2. An invocation ID is generated that allows to track the invocation,
+3. The invocation parameters are pinned: they are recorded deterministically as a side effect of tick execution, so all computors see identical inputs.
+
+The call returns immediately with the invocation ID; the invoking procedure continues normally, and authorization proceeds asynchronously over the following ticks.
+
+After the invocation has been recorded, each computor independently emits an OC authorization signature transaction signing `(epoch, interfaceIndex, invocationId, paramsDigest)`.
+When 451 valid, agreeing signatures have been processed, the invocation becomes AUTHORIZED.
+If an invocation does not reach 451 signatures within `OC_INVOCATION_TIMEOUT_DEFAULT_TICKS` (3 ticks), it transitions to TIMEOUT; the fee is not refunded.
+
+Once an invocation is AUTHORIZED, each node with OC machine peers configured assembles an authorization bundle and enqueues it to all of its OC machine peers over the private channel.
+The authorization bundle is a single message containing the pinned request parameters and the 451 `(computor index, signature)` pairs.
+Everything in it derives from on-chain data (the pinned parameters and the authorization signature transactions), so a recipient can verify the signatures against the epoch's signed computor list without trusting the forwarding node.
+The OC machine performs the work against the external system.
+Because the bundle is only constructed and forwarded after the engine has confirmed 451 valid signatures, the OC machine does not need to re-verify the quorum.
+
+The protocol does not provide a return path through OC.
+If the contract needs to observe whether the work was performed, it does so via a subsequent Oracle query.
+
+
+## OC interfaces
+
+An OC interface defines the input type used to describe a unit of work: `OcRequest`.
+There is no reply type, because OC does not return information through the protocol.
+Multiple Processors may implement the same interface; multiple OC interfaces differ in their definition of `OcRequest` because they target different external systems and require different parameters.
+
+The source code of OC interfaces resides in the directory `src/oc_interfaces/` of the Qubic Core repository, with one header file per interface.
+A central definition file `src/oc_core/oc_interfaces_def.h` includes all interface headers and assigns each one a unique `OC_INTERFACE_INDEX`, exactly as `src/oracle_core/oracle_interfaces_def.h` does for OM interfaces.
+
+In Qubic contracts, OC interfaces are made available through the namespace `OCI`.
+For example, you can access the request struct type of the `Mock` interface via `OCI::Mock::OcRequest`.
+
+Each interface header defines a struct with three mandatory members:
+
+```
+struct InterfaceName
+{
+    /// Interface index, assigned in oc_interfaces_def.h
+    static constexpr uint32 ocInterfaceIndex = OC_INTERFACE_INDEX;
+
+    /// Data sent with each invocation; pinned at QPI call time
+    struct OcRequest
+    {
+        /* interface-specific fields */
+    };
+
+    /// Per-invocation fee in QU, burned when invokeOC is called
+    static sint64 getInvocationFee(const OcRequest& request);
+};
+```
+
+The size of `OcRequest` is bounded by `MAX_OC_REQUEST_SIZE`.
+The `OcRequest` struct must be deterministically serializable: every computor pins and hashes the same bytes when computing `paramsDigest`.
+
+Interfaces may also expose helper functions or constants used by contracts to build a valid `OcRequest`, in the same style as the `Price` OM interface exposes oracle identifier helpers.
+
+
+## QPI surface
+
+Contracts trigger an OC invocation through a single QPI procedure call, wrapped in a macro for symmetry with `QUERY_ORACLE`:
+
+```
+#define INVOKE_OC(OcInterface, request) qpi.__qpiInvokeOC<OcInterface>(request)
+```
+
+The internal entry point on the QPI context is:
+
+```
+template <typename OcInterface>
+inline sint64 QpiContextProcedureCall::__qpiInvokeOC(
+    const typename OcInterface::OcRequest& request
+) const;
+```
+
+Behavior:
+
+1. Validates that the calling contract index matches the QPI context and that the interface index is known.
+2. Computes the invocation fee via `OcInterface::getInvocationFee(request)` and attempts to deduct it from the contract's spectrum balance. The fee is burned (logged as a `QuTransfer` to `NULL_ID`). If the balance is insufficient, returns `-1` and the call has no other effect.
+3. Allocates a fresh `invocationId` and copies the request bytes into the engine's per-invocation storage. This is the parameter pinning step.
+4. Records the invocation in the engine; subsequent tick processing produces the authorization signature transactions as described in the lifecycle section.
+
+If an error occurs during step 3 or 4 (for example, storage exhaustion), the fee deducted in step 2 is refunded to the contract.
+This matches the fee reimbursement behavior of `QUERY_ORACLE`.
+
+Return value: the `invocationId` on success (a non-negative `sint64`), or `-1` on any failure.
+The call is non-blocking, has no notification callback, and produces no further effect on the contract's state.
+
+The consensus status of an invocation (pending authorization, authorized, or timed out) can be polled with `qpi.getOcInvocationStatus(invocationId)`, which returns one of the `OC_INVOCATION_STATUS_*` constants.
+To observe whether the external work happened, the contract issues an Oracle query against an interface that reports the relevant external state.
+
+
+## Mock OC interface
+
+The implementation ships an OC interface named `Mock`, analogous to the OM `Mock` interface. Authorized `Mock` invocations are forwarded to a mock interface service that verifies the computor signatures and publishes the received invocations.
+
+```
+// src/oc_interfaces/Mock.h
+using namespace QPI;
+
+/**
+* OC interface "Mock".
+*
+* The mock interface accepts an arbitrary 64-bit value as request payload. OC machines
+* forward the authorization bundle to a mock interface service that verifies the computor
+* signatures and publishes the received invocations.
+*/
+struct Mock
+{
+    /// OC interface index
+    static constexpr uint32 ocInterfaceIndex = OC_INTERFACE_INDEX;
+
+    /// OC request data / input to the OC machine
+    struct OcRequest
+    {
+        /// Arbitrary value forwarded to the mock interface service
+        uint64 value;
+    };
+
+    /// Return invocation fee; constant for the mock
+    static sint64 getInvocationFee(const OcRequest& request)
+    {
+        return 10;
+    }
+};
+```
+
+Registration in `src/oc_core/oc_interfaces_def.h`:
+
+```
+#define OC_INTERFACE_INDEX 0
+#include "oc_interfaces/Mock.h"
+#undef OC_INTERFACE_INDEX
+
+constexpr struct {
+    unsigned long long requestSize;
+} ocInterfaces[] = {
+    DEFINE_OC_INTERFACE(Mock),
+};
+```
+
+A contract using the mock interface:
+
+```
+struct MockTriggerContract : public ContractBase
+{
+protected:
+    sint64 _lastInvocationId;
+
+public:
+    struct TriggerOC_input
+    {
+        uint64 value;
+    };
+
+    struct TriggerOC_output
+    {
+        sint64 invocationId;
+    };
+
+    struct TriggerOC_locals
+    {
+        OCI::Mock::OcRequest request;
+    };
+
+    PUBLIC_PROCEDURE_WITH_LOCALS(TriggerOC)
+    {
+        // Zero-initialize the request so padding bytes hashed into paramsDigest
+        // are deterministic across all computors. Mirrors the OM reply convention
+        // (see core_om_network_messages.h: "replies must be set all-0 before
+        // setting member data, making sure that alignment/padding bytes are
+        // initialized with 0"). setMemory is the contract-safe zero-init helper
+        // (contracts cannot call the core setMem directly).
+        setMemory(locals.request, 0);
+        locals.request.value = input.value;
+        output.invocationId = INVOKE_OC(OCI::Mock, locals.request);
+        state._lastInvocationId = output.invocationId;
+    }
+};
+```
+
+Test plan for the mock:
+
+1. A test SC procedure calls `INVOKE_OC(OCI::Mock, request)` with a known value. The test verifies that the contract's QU balance decreased by the invocation fee and the return value is a valid `invocationId`.
+2. Tick processing produces 451 `OcAuthSignatureTransaction` entries; the engine status of the invocation transitions to `OC_INVOCATION_STATUS_AUTHORIZED`.
+3. An OC machine peer receives the authorization bundle on the private channel and forwards the raw bundle bytes to the mock interface service.
+4. The mock interface service verifies the computor signatures, deduplicates by `invocationId`, and publishes the invocation with `request.value`, confirming end-to-end flow.
+
+The mock interface is the baseline test used to exercise new OC interfaces and should be wired into the test target alongside the OM Mock tests.
+
+
+## Transactions
+
+OC introduces one new transaction type:
+
+`OcAuthSignatureTransaction` is emitted by a computor to sign an authorization for one or more invocations.
+The transaction prefix is followed by one or more items, each carrying `(invocationId, interfaceIndex, epoch, paramsDigest, signature)`.
+The engine deduplicates by signer pubkey and counts agreeing signatures per invocation.
+On the 451st signature for a given invocation, the invocation transitions to AUTHORIZED.
+
+
+## Network channel
+
+Forwarding authorized invocations from a Core node to its OC machine peer uses the same private out-of-band connection pattern as OM.
+The connection is outgoing from the Core node, permanently kept open, and the OC machine implements IP whitelisting to accept only its configured Core nodes.
+
+The message sent on this channel carries the authorization bundle: the pinned parameters and the 451 computor signatures with their signer indices.
+The bundle is constructed by the Core node only after the engine has confirmed 451 valid signatures, so the OC machine can act on it directly without re-checking the quorum.
+OC machines retrieve the signed computor list for the bundle's issuing epoch via the standard peer protocol when they need it for external verification (for example, when forwarding signatures to a verifier contract on another chain).
+
+
+## Cross-epoch maintenance
+
+OC authorizations are bound to the computor set that signed them.
+For interfaces whose external state depends on a fixed signer set (for example, a Bitcoin multisig wallet whose script lists the computors' public keys), continuity across epochs requires explicit operational housekeeping.
+Before the active computor set rotates, an OC invocation is used to move the external state to a configuration controlled by the new set.
+For Bitcoin this means moving funds from the current multisig address to a new one with the incoming signers.
+Without this step, the external state is permanently inaccessible from the new epoch.
+
+For external systems that can validate the Qubic computor list for the bundle's issuing epoch dynamically at the time the action is performed, no per-epoch migration is required.
+
+OC interfaces should document which model they require and, where migration is needed, expose an interface-specific invocation for performing it.
+
+
+## Constraints on interface design
+
+OC does not deduplicate at the protocol level.
+Because every computor that has configured an OC machine peer for an interface independently forwards each authorized invocation, an authorized invocation may be acted upon by every running OC machine for that interface.
+The external system must tolerate this.
+
+External systems with natural deduplication satisfy the constraint: Bitcoin (UTXO consumption), Ethereum and other EVM chains (account nonces), HTTP APIs with idempotency keys.
+External systems without natural deduplication (general-purpose HTTP POST endpoints, real-world fulfillment that does not check for duplicate orders) do not satisfy the constraint and should not be exposed through OC.

--- a/doc/oc_protocol_spec.md
+++ b/doc/oc_protocol_spec.md
@@ -1,0 +1,469 @@
+# Outsourced Computations Protocol Specification
+
+This document specifies the on-chain protocol for Outsourced Computations (OC).
+Conceptual background, rationale, and usage examples are in `contracts_outsourced_computations.md`.
+This document defines wire formats, state transitions, normative requirements, and constants.
+
+
+## 1. Constants
+
+| Name                   | Value                            | Notes                                                          |
+|------------------------|----------------------------------|----------------------------------------------------------------|
+| `NUMBER_OF_COMPUTORS`  | 676                              | Defined in `network_messages/common_def.h`.                    |
+| `QUORUM`               | 451                              | `NUMBER_OF_COMPUTORS * 2 / 3 + 1`.                             |
+| `SIGNATURE_SIZE`       | 64                               | Bytes per SchnorrQ (FourQ) signature.                          |
+| `MAX_INPUT_SIZE`       | 1024                             | Maximum bytes for any transaction input payload.               |
+| `MAX_OC_REQUEST_SIZE`  | `MAX_INPUT_SIZE - 16`            | Mirrors `MAX_ORACLE_QUERY_SIZE`. Equals 1008.                  |
+| `MIN_OC_INVOCATION_FEE`| 10                               | Minimum value `getInvocationFee` may return. Mirrors `MIN_ORACLE_QUERY_FEE`. |
+| `OC_INVOCATION_TIMEOUT_DEFAULT_TICKS` | 3                  | Maximum number of ticks an invocation may remain in `PENDING_AUTHORIZATION` before transitioning to `TIMEOUT`. |
+| `MAX_OC_INVOCATIONS_PER_EPOCH` | `2^21` (2,097,152)      | Maximum invocations recorded per epoch (section 3.3). Mirrors OM's `MAX_ORACLE_QUERIES`. |
+| `MAX_OC_IN_FLIGHT_INVOCATIONS` | 1024                    | Maximum invocations unresolved at any moment (section 3.1.1). Mirrors OM's `MAX_SIMULTANEOUS_ORACLE_QUERIES`. |
+| OC authorization tx `inputType` | 13                      | `OcAuthSignatureTransactionPrefix::transactionType()` in `oc_core/oc_transactions.h`. |
+| `OC_MACHINE_INVOCATION` | 192                             | `NetworkMessageType` for the Core-to-OC-machine channel (section 8). |
+
+
+## 2. Identifiers
+
+### 2.1 Invocation ID
+
+An `invocationId` is a 64-bit signed integer assigned by the OC engine when `__qpiInvokeOC` succeeds.
+It MUST be derived from the issuing tick and a per-tick sequence counter, following the OM `getNewNonTxQueryId` convention:
+
+```
+invocationId = (sint64(system.tick) << 31) | indexInTick
+```
+
+where `indexInTick` is a per-tick counter starting from `NUMBER_OF_TRANSACTIONS_PER_TICK` (which guarantees no collision with transaction-derived IDs in the same name space).
+
+Because `system.tick` increases monotonically across epoch boundaries, this scheme produces globally unique, monotonically increasing IDs without per-epoch reset.
+This mirrors `OracleEngine::getNewNonTxQueryId` in `oracle_core/oracle_engine.h`.
+
+### 2.2 Parameters digest
+
+The `paramsDigest` is a 32-byte K12 hash over the exact bytes of the pinned `OcRequest`.
+The hash input MUST be the raw `OcRequest` struct as laid out in memory, of length equal to the interface's declared `requestSize`.
+Implementations MUST zero-initialize the request buffer in the engine's per-invocation storage before copying `OcRequest` bytes into it.
+Contract authors MUST zero-initialize their local `OcRequest` value before assigning any field, to ensure deterministic padding bytes across all computors executing the same contract code.
+
+### 2.3 Authorization message
+
+The message a computor signs is the K12 hash of the concatenation:
+
+```
+authMessage = K12(
+    "QUBIC_OC_AUTH" ||           // 13 bytes, ASCII, no terminator
+    uint16_le(epoch) ||          // 2 bytes
+    uint16_le(interfaceIndex) || // 2 bytes
+    sint64_le(invocationId) ||   // 8 bytes
+    paramsDigest                 // 32 bytes
+)
+```
+
+The domain separator prefix `"QUBIC_OC_AUTH"` ensures signatures over OC authorizations cannot be replayed as signatures over any other Qubic message type.
+The `epoch` field binds a signature to its issuing epoch.
+
+
+## 3. OC engine state
+
+The OC engine mirrors `OracleEngine` in `oracle_core/oracle_engine.h`.
+It owns per-invocation state, processes authorization signature transactions, and forwards authorized bundles to OC machine peers.
+
+### 3.1 Invocation record
+
+The engine MUST maintain one record per active invocation containing at least:
+
+| Field             | Type                          | Description                                                          |
+|-------------------|-------------------------------|----------------------------------------------------------------------|
+| `invocationId`    | `sint64`                      | ID assigned at QPI call time (section 2.1).                          |
+| `epoch`           | `uint16`                      | Epoch in which the invocation was recorded.                          |
+| `contractIndex`   | `uint16`                      | Calling contract index.                                              |
+| `interfaceIndex`  | `uint16`                      | OC interface index.                                                  |
+| `paramsOffset`    | `uint32`                      | Offset into the engine's request storage buffer.                     |
+| `paramsSize`      | `uint16`                      | Equals `OCI::ocInterfaces[interfaceIndex].requestSize`.              |
+| `paramsDigest`    | `m256i`                       | K12 over the pinned bytes (section 2.2).                             |
+| `status`          | `uint8`                       | One of the consensus status constants in section 5.                  |
+| `creationTick`    | `uint32`                      | Tick in which the invocation was recorded.                           |
+| `agreeingSigs`    | `uint16`                      | Count of distinct valid signatures observed for `paramsDigest`.      |
+| `signedBy`        | bitmap `[NUMBER_OF_COMPUTORS]`| One bit per computor index; set when that computor's signature has been counted. |
+| `signatures`      | `uint8[QUORUM][SIGNATURE_SIZE]` | The first `QUORUM` distinct valid signatures, indexed by their order of acceptance. |
+| `signerIndices`   | `uint16[QUORUM]`              | Computor index in `broadcastedComputors` for the signature at the same position. |
+
+The `signatures` and `signerIndices` arrays are populated as valid signatures arrive.
+Once `agreeingSigs == QUORUM`, both arrays are full and form the authorization bundle delivered to OC machines (section 8).
+Signatures arriving after the QUORUM threshold MUST be discarded by the signature processing rules in section 7.1 (the array bounds make appending past `signatures[QUORUM - 1]` an out-of-bounds write).
+
+### 3.1.1 Record size
+
+The fields above sum to approximately 30 KB per record, dominated by the 451-signature bundle (~28.8 KB).
+An engine sized for thousands of concurrent invocations per epoch therefore needs tens to hundreds of MB of fixed allocation for the invocation table alone.
+
+The specification does not prescribe a particular layout.
+Implementations MAY adopt either or both of the following storage optimizations, as long as the externally-visible behavior of section 7.1 (signature counting and quorum transition) and section 8 (delivery) is preserved:
+
+- **Discard the bundle after a single delivery attempt.** As soon as the bundle has been enqueued once for the configured OC peers, the engine frees `signatures` and `signerIndices` and retains only metadata. The record's `status` remains `AUTHORIZED`. This is fire-once-and-forget: delivery is a best-effort broadcast to whichever OC peers are currently connected, with no per-peer receipt tracking and no re-delivery (see section 8.2). Re-delivery after restart is likewise impossible from engine state alone; see section 12.
+- **Split bundle storage from metadata.** Hold the bundle bytes in a separate `bundleStorage` buffer (the same split OM uses between `queryStorage` and `OracleReplyState`), with each invocation record referencing its bundle by offset. A small bundle pool can then serve a large metadata table without paying ~30 KB per slot.
+
+The reference implementation in `oc_core/oc_engine.h` adopts both, following the split OM uses between the 72-byte `OracleQueryMetadata` and the pooled `OracleReplyState`:
+
+- The per-epoch `OcInvocationRecord` is 64 bytes and holds only identity, digest, offsets, and status.
+- All per-computor tracking (the accumulating signature bundle, the `signedBy`/`scheduledBy` bitmaps, and `agreeingSigs`) lives in a pooled `OcInFlightAuthState` (~30 KB) of `MAX_OC_IN_FLIGHT_INVOCATIONS = 1024` slots (~30 MB total), referenced from the record only while the invocation is unresolved.
+- The slot is allocated when the invocation is recorded and freed on timeout or after the single delivery attempt. Because slot state is derived purely from tick processing, allocation and release are deterministic across all nodes.
+- If the pool is exhausted, `startContractInvocation` rejects the invocation (returns `-1`, and the fee is refunded per section 6.3). The pool size therefore acts as deterministic admission control bounding the number of concurrently unresolved invocations; it does not bound the per-epoch total, since slots recycle within `OC_INVOCATION_TIMEOUT_DEFAULT_TICKS + 1` ticks.
+
+### 3.2 Per-epoch lifetime
+
+Invocation records and their pinned request payloads MUST be retained across all ticks of the epoch in which they were created.
+At `beginEpoch`, the engine MUST discard all records from the previous epoch, mirroring the behavior of `OracleEngine::beginEpoch`.
+
+Invocations created near the end of an epoch may not reach quorum before the boundary and are dropped without delivery; the OM engine code acknowledges the same limitation.
+A seamless transition mechanism that carries `PENDING_AUTHORIZATION` records into the next epoch with renewed timeout is not part of this specification.
+
+### 3.3 Per-invocation request storage
+
+The engine MUST allocate a contiguous buffer for pinned `OcRequest` payloads, provisioned as a total byte budget rather than `MAX_OC_REQUEST_SIZE` per record (the same approach as OM's `ORACLE_QUERY_STORAGE_SIZE`).
+The reference implementation budgets an average of 256 bytes per invocation: `256 * MAX_OC_INVOCATIONS_PER_EPOCH = 536,870,912` bytes (512 MiB).
+Since request sizes are fixed per interface, the effective invocation capacity depends on the interface mix; `startContractInvocation` rejects (with fee refund) when either the record-count cap or the byte budget is exhausted, whichever is hit first.
+
+Pinned bytes MUST NOT be mutated after the invocation has been recorded.
+
+
+## 4. Transactions
+
+### 4.1 `OcAuthSignatureTransaction`
+
+A single `OcAuthSignatureTransaction` carries one or more authorization signatures from the issuing computor.
+Each item in the transaction signs exactly one invocation, but a single transaction MAY carry items for multiple distinct invocations.
+
+Wire layout, following the `Transaction` header in `network_messages/transactions.h`:
+
+```
++-------------------------------+
+| Transaction header (80 bytes) |   sourcePublicKey, destinationPublicKey,
+|                               |   amount, tick, inputType, inputSize
++-------------------------------+
+| inputSize bytes payload:      |
+|   uint16 itemCount            |
+|   uint16 _padding (= 0)       |
+|   N x OcAuthSignatureItem     |
++-------------------------------+
+| SIGNATURE_SIZE bytes outer    |
+| transaction signature         |
++-------------------------------+
+```
+
+`OcAuthSignatureItem` layout (112 bytes):
+
+```
+struct OcAuthSignatureItem {
+    sint64 invocationId;        // 8 bytes
+    uint16 interfaceIndex;      // 2 bytes
+    uint16 epoch;               // 2 bytes
+    uint8  _padding[4];         // 4 bytes, MUST be zero
+    uint8  paramsDigest[32];    // 32 bytes
+    uint8  signature[64];       // 64 bytes, full SchnorrQ signature
+};
+static_assert(sizeof(OcAuthSignatureItem) == 112);
+```
+
+Constraints:
+
+- `inputType` MUST equal 13 (`OcAuthSignatureTransactionPrefix::transactionType()`, see section 1).
+- `inputSize` MUST equal `4 + 112 * itemCount`.
+- `itemCount` MUST be in `[1, (MAX_INPUT_SIZE - 4) / 112] = [1, 9]`.
+- `sourcePublicKey` MUST be a public key listed in the current epoch's `broadcastedComputors`.
+- `destinationPublicKey` MUST be `NULL_ID` (zero).
+- `amount` MUST be 0.
+- The `signature` field of each item MUST be the SchnorrQ signature over `authMessage` (section 2.3) computed using the issuing computor's private key.
+- The transaction's outer signature MUST be valid over the standard transaction digest.
+
+
+## 5. Status machine
+
+The engine maintains two distinct status concepts:
+
+- **Consensus status** is part of the invocation record and consistent across all nodes processing the same tick stream. It is exposed through public query APIs.
+- **Delivery status** is node-local bookkeeping for tracking which OC peers have received the bundle from this node. It is NOT consensus state and MUST NOT be exposed through any public query API. It MUST NOT be included in snapshots.
+
+### 5.1 Consensus status
+
+```
+                         +-------------------------+
+   __qpiInvokeOC()  ---> | PENDING_AUTHORIZATION   |
+                         +-------------------------+
+                              |              |
+              QUORUM sigs     |              |   timeout
+              counted         v              v
+                         +-----------+   +---------+
+                         | AUTHORIZED|   | TIMEOUT |
+                         +-----------+   +---------+
+```
+
+Status constants (in the namespace and pattern of `ORACLE_QUERY_STATUS_*`):
+
+| Constant                              | Value | Description                                                                 |
+|---------------------------------------|-------|-----------------------------------------------------------------------------|
+| `OC_INVOCATION_STATUS_UNKNOWN`        | 0     | Invocation ID not found.                                                    |
+| `OC_INVOCATION_STATUS_PENDING_AUTH`   | 1     | Recorded; waiting for `QUORUM` authorization signatures.                    |
+| `OC_INVOCATION_STATUS_AUTHORIZED`     | 2     | `QUORUM` signatures counted; bundle eligible for delivery to OC peers.      |
+| `OC_INVOCATION_STATUS_TIMEOUT`        | 3     | Authorization did not reach quorum before `OC_INVOCATION_TIMEOUT_DEFAULT_TICKS`. |
+
+Transition rules:
+
+- `UNKNOWN -> PENDING_AUTH` on successful `__qpiInvokeOC`.
+- `PENDING_AUTH -> AUTHORIZED` when `agreeingSigs >= QUORUM`. The transition MUST be atomic with respect to additional signature processing.
+- `PENDING_AUTH -> TIMEOUT` when `currentTick - creationTick >= OC_INVOCATION_TIMEOUT_DEFAULT_TICKS`.
+- No transitions out of `AUTHORIZED` or `TIMEOUT`.
+
+### 5.2 Delivery status (node-local)
+
+The engine MAY track, for each `(invocationId, ocPeerId)` pair, whether the bundle has been successfully enqueued on that peer's outgoing connection.
+This state is private to each Core node, MUST NOT enter snapshots, and MUST NOT be exposed via public RPC.
+See section 8 for delivery rules.
+
+
+## 6. QPI surface
+
+### 6.1 Public macro
+
+```
+#define INVOKE_OC(OcInterface, request) qpi.__qpiInvokeOC<OcInterface>(request)
+```
+
+### 6.2 Internal entry point
+
+```
+template <typename OcInterface>
+inline sint64 QpiContextProcedureCall::__qpiInvokeOC(
+    const typename OcInterface::OcRequest& request
+) const;
+```
+
+### 6.3 Behavior
+
+The implementation MUST perform the following steps in order:
+
+1. Compile-time checks via `static_assert`:
+   - `sizeof(OcInterface::OcRequest) <= MAX_OC_REQUEST_SIZE`.
+   - `OcInterface::ocInterfaceIndex < OCI::ocInterfacesCount`.
+   - `OCI::ocInterfaces[OcInterface::ocInterfaceIndex].requestSize == sizeof(OcInterface::OcRequest)`.
+2. Validate that `_currentContractIndex < MAX_NUMBER_OF_CONTRACTS`. On failure: return `-1`.
+3. Compute `fee = OcInterface::getInvocationFee(request)`. If `fee < MIN_OC_INVOCATION_FEE`: return `-1`.
+4. Attempt `decreaseEnergy(contractSpectrumIdx, fee)`. On failure: return `-1`. On success: log a `QuTransfer` from the contract ID to `NULL_ID` of `fee` QU.
+5. Call the engine's `startContractInvocation(contractIndex, interfaceIndex, &request, sizeof(request))`. On failure: refund `fee` to the contract via `engine.refundFees(_currentContractId, fee)` and return `-1`.
+6. Return the `invocationId` assigned by the engine (non-negative).
+
+The call MUST be non-blocking.
+The call MUST NOT register a notification callback.
+The call MUST NOT mutate the calling contract's state.
+
+### 6.4 Engine entry point
+
+```
+sint64 OcEngine::startContractInvocation(
+    uint16_t contractIndex,
+    uint16_t interfaceIndex,
+    const void* requestData,
+    uint16_t requestSize);
+```
+
+The implementation MUST:
+
+1. Acquire the engine lock.
+2. Validate `contractIndex < MAX_NUMBER_OF_CONTRACTS`, `interfaceIndex < OCI::ocInterfacesCount`, `requestSize == OCI::ocInterfaces[interfaceIndex].requestSize`. On failure: release lock and return `-1`.
+3. Allocate a new invocation record. On failure (record-count cap or request byte budget exhausted): release lock and return `-1`.
+4. Allocate an in-flight auth-state slot for the invocation (section 3.1.1). On failure (pool exhausted): release lock and return `-1`.
+5. Zero-initialize the per-invocation storage region at `paramsOffset`.
+6. Copy `requestData[0 .. requestSize)` into the per-invocation storage at `paramsOffset`.
+7. Compute `paramsDigest = K12(pinnedBytes[0 .. requestSize))`.
+8. Initialize the record with `status = OC_INVOCATION_STATUS_PENDING_AUTH`, `creationTick = system.tick`, `agreeingSigs = 0`, `signedBy = 0`, `signatures = 0`, `signerIndices = 0`.
+9. Release the lock.
+10. Return `invocationId`.
+
+### 6.5 Status query
+
+Contracts poll the consensus status of an invocation through the QPI function-call context:
+
+```
+inline uint8 QpiContextFunctionCall::getOcInvocationStatus(sint64 invocationId) const;
+```
+
+It returns one of the `OC_INVOCATION_STATUS_*` constants of section 5.1, or `OC_INVOCATION_STATUS_UNKNOWN` if the `invocationId` is not found (including invocations from previous epochs, whose records were dropped at `beginEpoch`).
+Only the consensus status is exposed; node-local delivery status (section 5.2) is not reachable from this or any other public API.
+
+
+## 7. Signature processing
+
+### 7.1 On transaction execution
+
+When a tick contains an `OcAuthSignatureTransaction`, for each contained `OcAuthSignatureItem` the engine MUST:
+
+1. Locate the invocation record with the matching `invocationId`. If none exists, or its `epoch` does not match the item's `epoch`: discard the item.
+2. If `record.status != OC_INVOCATION_STATUS_PENDING_AUTH` or `record.agreeingSigs >= QUORUM`: discard the item. This guards against appending signatures after the bundle is complete or the invocation has timed out.
+3. Verify that `item.interfaceIndex == record.interfaceIndex` and `item.paramsDigest == record.paramsDigest`. On mismatch: discard the item.
+4. Determine the computor index `c` for `sourcePublicKey` in the issuing epoch's `broadcastedComputors` (the epoch in `record.epoch`, which equals `item.epoch` after step 1). If `sourcePublicKey` is not a computor in that epoch: discard the item.
+5. If `record.signedBy[c] == 1`: discard the item (duplicate).
+6. Recompute `authMessage` per section 2.3 using the record's authoritative `epoch`, `interfaceIndex`, `invocationId`, `paramsDigest`.
+7. Verify the SchnorrQ signature `item.signature` against `authMessage` under `sourcePublicKey`. On failure: discard the item.
+8. Set `record.signedBy[c] = 1`. Increment `record.agreeingSigs`. Append `item.signature` to `record.signatures[agreeingSigs - 1]` and `c` to `record.signerIndices[agreeingSigs - 1]`.
+9. If `record.agreeingSigs == QUORUM`:
+   - Set `record.status = OC_INVOCATION_STATUS_AUTHORIZED`.
+   - The bundle is now complete and eligible for delivery (section 8).
+
+The engine MUST process items in order within the transaction.
+
+### 7.2 On own QPI invocation
+
+After `startContractInvocation` returns successfully, each computor MUST schedule an `OcAuthSignatureTransaction` for the invocation in a subsequent tick (mirroring `getReplyCommitTransaction` for OM).
+The scheduling SHOULD batch multiple invocations into a single transaction up to the `itemCount` limit to reduce tick weight.
+
+A computor MUST NOT emit a signature for any invocation it has not itself executed in tick processing.
+A computor MUST NOT emit more than one signature per `(invocationId, ownPublicKey)` pair.
+
+
+## 8. Delivery to OC machines
+
+When an invocation transitions to `AUTHORIZED`, each Core node that has at least one OC machine peer configured (`ocMachineIPs` in `private_settings.h`) MUST construct an `OcMachineInvocation` message containing the full authorization bundle and enqueue it on every connected OC machine peer.
+Delivery is not filtered by `interfaceIndex` on the Core side: the OC machine dispatches by `interfaceIndex` and ignores invocations for interfaces it does not serve.
+
+`OcMachineInvocation` wire format:
+
+```
+struct OcMachineInvocation {
+    static constexpr uint8 type();   // NetworkMessageType::OC_MACHINE_INVOCATION = 192
+
+    sint64 invocationId;             // 8 bytes
+    uint16 epoch;                    // 2 bytes
+    uint16 interfaceIndex;           // 2 bytes
+    uint16 requestSize;              // 2 bytes
+    uint16 signatureCount;           // 2 bytes; MUST equal QUORUM
+    // followed by: requestSize bytes of pinned OcRequest payload
+    // followed by: signatureCount x SignerEntry
+};
+
+struct SignerEntry {
+    uint16 computorIndex;            // 2 bytes; index into the epoch's computor list
+    uint8  signature[64];            // 64 bytes, SchnorrQ signature over authMessage
+};
+static_assert(sizeof(SignerEntry) == 66);
+```
+
+The OC machine receives the request bytes followed by the `signatureCount` signer entries.
+The `(computorIndex, signature)` pairs collectively form the authorization bundle that an external verifier or relayer can validate against the Qubic computor list for `OcMachineInvocation.epoch`, when an interface requires such external validation.
+
+The signed computor list itself is not transmitted in `OcMachineInvocation`.
+OC machines retrieve the `broadcastedComputors` for `OcMachineInvocation.epoch` via the standard peer protocol (the same mechanism any Qubic-aware client uses).
+This keeps the per-invocation message size bounded and avoids duplicating the computor-list signature data on every invocation.
+
+The OC machine MAY rely on the bundle being correct without re-verifying signatures itself, because the Core node only constructs and sends the bundle after the engine has confirmed `QUORUM` valid signatures.
+For external verifiers (such as smart contracts on another chain), re-verification is expected and the included signatures and computor indices are sufficient.
+
+### 8.1 Transport size
+
+`OcMachineInvocation` is transmitted only over the private out-of-band channel from a Core node to its configured OC machine peers.
+It is NOT broadcast through the public peer network and is NOT subject to the standard transaction or `BroadcastMessage` payload size limits (`MAX_INPUT_SIZE = 1024`).
+
+The maximum message size, in bytes, is:
+
+```
+16 + MAX_OC_REQUEST_SIZE + QUORUM * sizeof(SignerEntry)
+= 16 + 1008 + 451 * 66
+= 30,790 bytes
+```
+
+The 16 bytes are the fixed header fields (`invocationId`, `epoch`, `interfaceIndex`, `requestSize`, `signatureCount`, including alignment).
+Implementations of the OC machine channel MUST accept messages up to at least this size.
+
+### 8.2 Delivery rules
+
+Delivery is fire-once-and-forget. When an invocation transitions to `AUTHORIZED`, the node enqueues the bundle exactly once, and it is pushed to every OC machine peer that is connected at that moment. There is no per-peer receipt tracking and no re-delivery:
+
+- The bundle is enqueued once per invocation and then the auth state (the only copy of the signatures) is freed.
+- A peer that is disconnected at that moment does not receive the invocation and will not receive it later, even if it reconnects. If no OC peer is connected at all, the enqueue is retried a bounded number of times (waiting for any peer to become ready) and then dropped.
+- The reference implementation therefore delivers to the subset of configured OC peers that happen to be connected when the invocation is authorized; it does not guarantee delivery to every configured peer.
+
+Because a contract obligates every OC machine for the interface to act, and external effects are required to be idempotent (see `contracts_outsourced_computations.md`), a single connected peer acting on the bundle is sufficient for the external effect. Interfaces that need stronger delivery guarantees must build them at the interface layer (for example, by having the contract re-issue the invocation).
+
+There is no response message defined for `OcMachineInvocation`.
+The protocol provides no return channel from the OC machine through this transport.
+
+
+## 9. Interface declaration
+
+Each OC interface MUST be declared as a `struct` in a header file in `src/oc_interfaces/` with the following mandatory members:
+
+```
+struct InterfaceName
+{
+    static constexpr uint32 ocInterfaceIndex = OC_INTERFACE_INDEX;
+
+    struct OcRequest {
+        /* fields */
+    };
+
+    static sint64 getInvocationFee(const OcRequest& request);
+};
+```
+
+Constraints:
+
+- `sizeof(OcRequest)` MUST be `<= MAX_OC_REQUEST_SIZE`.
+- `OcRequest` MUST be a trivially-copyable, standard-layout struct.
+- `getInvocationFee` MUST return a value `>= MIN_OC_INVOCATION_FEE`.
+- `getInvocationFee` MUST be deterministic: equal inputs MUST produce equal outputs, and the function MUST NOT read any global state.
+
+Each interface MUST be registered in `src/oc_core/oc_interfaces_def.h` with a unique sequential `OC_INTERFACE_INDEX` starting at 0.
+
+
+## 10. Fee handling
+
+The OC invocation fee is burned.
+The Core node MUST log the burn as a `QuTransfer` from the calling contract's ID to `NULL_ID`.
+The fee MUST NOT be added to the contract's execution reserve.
+
+If `__qpiInvokeOC` fails after the fee has been deducted, the fee MUST be refunded to the contract via `engine.refundFees(_currentContractId, fee)`.
+If `__qpiInvokeOC` fails before the fee deduction, no refund is required.
+
+
+## 11. Cross-epoch behavior
+
+The engine retains invocation records throughout the epoch in which they were created and discards them at `beginEpoch` of the next epoch.
+This matches OM's behavior in `OracleEngine::beginEpoch`.
+
+Within an epoch:
+
+- Signatures with an `epoch` field not matching the current epoch MUST be discarded during signature processing.
+- An invocation that fails to reach quorum before the configured timeout transitions to `TIMEOUT` and the fee is not refunded (the fee was burned at QPI call time and represents the cost of the attempted authorization).
+
+Across an epoch boundary:
+
+- Invocations that reached `AUTHORIZED` before the boundary remain valid externally: the bundle's signatures verify against the corresponding epoch's computor list, which remains queryable.
+- Invocations in `PENDING_AUTHORIZATION` at the boundary are dropped. Contracts that need delivery guarantees near epoch boundaries SHOULD re-issue the invocation in the new epoch.
+
+OC interfaces whose external state binds to the active computor set (for example, a Bitcoin multisig wallet) MUST document their cross-epoch migration procedure.
+The protocol provides no automatic migration mechanism but does not prevent interfaces from defining one.
+
+
+## 12. Snapshot and restore
+
+The OC engine MUST include the following in node snapshots:
+
+- All invocation records, including pinned request payloads, consensus status, and the `signedBy` bitmap.
+- For each record whose bundle is still retained at snapshot time, the accumulated signatures and signer indices. Implementations that adopt the discard-after-delivery optimization of section 3.1.1 MAY omit the bundle for records whose bundle has been freed; the metadata MUST still be included.
+- The per-tick sequence counter state used by invocation ID derivation (section 2.1), so that subsequent ID assignments after restart match a node that has not restarted.
+
+The OC engine MUST NOT include node-local delivery state (the per-peer delivery bookkeeping of section 5.2) in snapshots.
+
+On snapshot load:
+
+- The engine reconstructs the invocation table such that subsequent signature processing produces results identical to a node that has not restarted.
+- Delivery state is empty after load.
+- For `AUTHORIZED` invocations whose bundle was retained in the snapshot (i.e. delivery had not yet been attempted before the snapshot), the node SHOULD treat them as candidates for delivery to its configured OC peers.
+- For `AUTHORIZED` invocations whose bundle was already discarded before the snapshot, the node cannot construct an `OcMachineInvocation` and MUST skip re-delivery. The bundle is freed after the single fire-once delivery attempt, so a restart cannot re-attempt a delivery that was already attempted; whether that attempt reached every configured peer is not tracked, consistent with the best-effort semantics of section 8.2.
+- A node MAY skip re-delivery of any `AUTHORIZED` invocation, relying on either other Core nodes to deliver or the receiving OC machine to deduplicate by `invocationId`. External deduplication (required by the constraints in `contracts_outsourced_computations.md`) ensures at-most-once external effect across all redundant deliveries.
+
+
+## 13. Open items
+
+- Whether signature aggregation (BLS or similar) is worth pursuing to reduce per-invocation tx weight.
+- Scaling beyond ~2M invocations per epoch requires amortizing the per-invocation quorum cost, e.g. per-tick batch authorization: computors sign one Merkle root over all invocations created in a tick, and the bundle becomes 451 signatures per tick plus a Merkle path per invocation. This changes the authorization transaction format and the OC machine protocol; not needed at the current cap.
+- Whether a seamless cross-epoch transition mechanism for `PENDING_AUTHORIZATION` records is desired.

--- a/src/Qubic.vcxproj
+++ b/src/Qubic.vcxproj
@@ -115,6 +115,7 @@
     <ClInclude Include="oracle_interfaces\DogeShareValidation.h" />
     <ClInclude Include="oracle_interfaces\Mock.h" />
     <ClInclude Include="oracle_interfaces\Price.h" />
+    <ClInclude Include="oc_core\core_oc_network_messages.h" />
     <ClInclude Include="platform\assert.h" />
     <ClInclude Include="platform\concurrency.h" />
     <ClInclude Include="four_q.h" />

--- a/src/Qubic.vcxproj.filters
+++ b/src/Qubic.vcxproj.filters
@@ -388,6 +388,9 @@
     <ClInclude Include="platform\virtual_memory.h">
       <Filter>platform</Filter>
     </ClInclude>
+    <ClInclude Include="oc_core\core_oc_network_messages.h">
+      <Filter>oc_core</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="platform">
@@ -431,6 +434,9 @@
     </Filter>
     <Filter Include="oracle_core">
       <UniqueIdentifier>{a42dd6f2-617c-4fbc-b3ec-f51975e5c447}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="oc_core">
+      <UniqueIdentifier>{632d0d96-29d2-4b1d-bb23-7f055e7d32b1}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -24,7 +24,13 @@
 #define DISSEMINATION_MULTIPLIER 6
 #define NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS 8
 #define NUMBER_OF_OM_NODE_CONNECTIONS (sizeof(oracleMachineIPs) / sizeof(oracleMachineIPs[0]))
-#define NUMBER_OF_OUTGOING_CONNECTIONS (NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS + NUMBER_OF_OM_NODE_CONNECTIONS)
+#define NUMBER_OF_OC_MACHINE_CONNECTIONS (sizeof(ocMachineIPs) / sizeof(ocMachineIPs[0]))
+// Outgoing slot layout: [0, REGULAR) regular peers, [REGULAR, REGULAR+OM) OM machines,
+// [REGULAR+OM, REGULAR+OM+OC) OC machines.
+#define NUMBER_OF_OUTGOING_CONNECTIONS (NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS + NUMBER_OF_OM_NODE_CONNECTIONS + NUMBER_OF_OC_MACHINE_CONNECTIONS)
+// First outgoing-slot index of the OM and OC machine regions.
+#define FIRST_OM_NODE_CONNECTION_INDEX NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS
+#define FIRST_OC_MACHINE_CONNECTION_INDEX (NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS + NUMBER_OF_OM_NODE_CONNECTIONS)
 #define NUMBER_OF_INCOMING_CONNECTIONS 88
 #define MAX_NUMBER_OF_PUBLIC_PEERS 1024
 #define REQUEST_QUEUE_BUFFER_SIZE 1073741824
@@ -40,6 +46,12 @@ static constexpr unsigned int ORACLE_MACHINE_CONNECTION_TIMEOUT_SECS = 15; // Co
 static constexpr unsigned int ORACLE_MACHINE_TRANSMITING_TIMEOUT_SECS = 30; // Transmitting timeout to OM
 static constexpr unsigned int ORACLE_MACHINE_GRACEFULL_CLOSE_RETIRES = 3; // Gracefull close retries for connecting attemp to OM
 static constexpr unsigned long long OM_RECONNECT_COOLDOWN_SECS = 0;
+
+// OC machine setting (mirrors the OM settings above)
+static constexpr unsigned int OC_MACHINE_CONNECTION_TIMEOUT_SECS = 15; // Config timeout for connecting attempt to OC machine
+static constexpr unsigned int OC_MACHINE_TRANSMITING_TIMEOUT_SECS = 30; // Transmitting timeout to OC machine
+static constexpr unsigned int OC_MACHINE_GRACEFULL_CLOSE_RETIRES = 3; // Graceful close retries for connecting attempt to OC machine
+static constexpr unsigned long long OC_RECONNECT_COOLDOWN_SECS = 0;
 
 static_assert((NUMBER_OF_INCOMING_CONNECTIONS / NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS) >= 11, "Number of incoming connections must be x11+ number of outgoing connections to keep healthy network");
 
@@ -76,6 +88,13 @@ struct Peer
     unsigned long long omTransmitStartTime;
     unsigned long long lastOMCloseTime;
 
+    // Indicate the peer is an OC machine connection type which is a subtype of outgoing connection.
+    // Mirrors the OM fields above; connectionStartTime is shared (set on connect for either kind).
+    BOOLEAN isOcMachine;
+    unsigned long long lastOcActivityTime;
+    unsigned long long ocTransmitStartTime;
+    unsigned long long lastOcCloseTime;
+
     // Extra data to determine if this peer is a fullnode
     // Note: an **active fullnode** is a peer that is able to reply valid tick data, tick vote to this node after getting requested
     // If a peer is an active fullnode, it will receive more requests from this node than others, as well as longer alive connection time.
@@ -94,6 +113,11 @@ struct Peer
     bool isOracleMachineNode() const
     {
         return isOMNode;
+    }
+
+    bool isOcMachineNode() const
+    {
+        return isOcMachine;
     }
 
     // store a dejavu number into local list
@@ -139,6 +163,11 @@ struct Peer
         omTransmitStartTime = 0;
         lastOMCloseTime = 0;
 
+        isOcMachine = FALSE;
+        lastOcActivityTime = 0;
+        ocTransmitStartTime = 0;
+        lastOcCloseTime = 0;
+
         dataToTransmitSize = 0;
         lastActiveTick = 0;
         trackRequestedCounter = 0;
@@ -166,6 +195,9 @@ static PublicPeer publicPeers[MAX_NUMBER_OF_PUBLIC_PEERS];
 static volatile char omPeersLock = 0;
 static unsigned int numberOfOMPeers = 0;
 IPv4Address omIPv4Address[NUMBER_OF_OM_NODE_CONNECTIONS];
+
+static unsigned int numberOfOcPeers = 0;
+IPv4Address ocIPv4Address[NUMBER_OF_OC_MACHINE_CONNECTIONS];
 
 static unsigned long long* dejavu0 = NULL;
 static unsigned long long* dejavu1 = NULL;
@@ -249,6 +281,11 @@ static void closePeer(Peer* peer, int closeGracefullyRetries = 0)
                 // Track close time for OM nodes to enable reconnection cooldown
                 peer->lastOMCloseTime = __rdtsc();
             }
+            else if (peer->isOcMachineNode())
+            {
+                // Track close time for OC machine nodes to enable reconnection cooldown
+                peer->lastOcCloseTime = __rdtsc();
+            }
 
             EFI_STATUS status = EFI_SUCCESS;
             // Decide to close gracefully with Close()
@@ -300,9 +337,11 @@ static void closePeer(Peer* peer, int closeGracefullyRetries = 0)
                 ASSERT(numberOfAcceptedIncommingConnection >= 0);
             }
 
-            // Save OM close time before reset
+            // Save OM/OC close time before reset
             unsigned long long savedOMCloseTime = peer->lastOMCloseTime;
+            unsigned long long savedOcCloseTime = peer->lastOcCloseTime;
             bool wasOMNode = peer->isOracleMachineNode();
+            bool wasOcMachine = peer->isOcMachineNode();
             unsigned int peerIndex = (unsigned int)(peer - peers);
 
             peer->reset();
@@ -311,18 +350,25 @@ static void closePeer(Peer* peer, int closeGracefullyRetries = 0)
             {
                 peer->lastOMCloseTime = savedOMCloseTime;
                 peer->isOMNode = TRUE;
-                peer->address = omIPv4Address[peerIndex - NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS];
+                peer->address = omIPv4Address[peerIndex - FIRST_OM_NODE_CONNECTION_INDEX];
+            }
+            else if (wasOcMachine)
+            {
+                peer->lastOcCloseTime = savedOcCloseTime;
+                peer->isOcMachine = TRUE;
+                peer->address = ocIPv4Address[peerIndex - FIRST_OC_MACHINE_CONNECTION_INDEX];
             }
         }
     }
 }
 
-// Closes all peer connections; optionally includes Oracle Machine nodes.
-static void closeAllPeers(bool closeOM = false)
+// Closes all peer connections; optionally includes the persistent machine-node connections
+// (Oracle Machine and OC machine), which are otherwise kept open for low latency.
+static void closeAllPeers(bool closeMachineNodes = false)
 {
     for (unsigned int i = 0; i < NUMBER_OF_OUTGOING_CONNECTIONS + NUMBER_OF_INCOMING_CONNECTIONS; i++)
     {
-        if (closeOM || !peers[i].isOracleMachineNode())
+        if (closeMachineNodes || (!peers[i].isOracleMachineNode() && !peers[i].isOcMachineNode()))
         {
             closePeer(&peers[i]);
         }
@@ -520,6 +566,51 @@ static void pushToOracleMachineNodes(RequestResponseHeader* requestResponseHeade
     addDebugMessage(::message);
 #endif
 
+}
+
+
+// Push a message (an OcMachineInvocation) to all connected OC machine peers.
+// Mirrors pushToOracleMachineNodes. Re-enqueues for retry if no OC peer is ready yet.
+static void pushToOcMachineNodes(RequestResponseHeader* requestResponseHeader)
+{
+    if (NUMBER_OF_OC_MACHINE_CONNECTIONS > 0)
+    {
+        bool pushedToAny = false;
+        unsigned short numberOfSuitablePeers = 0;
+
+        unsigned int currentDejavu = requestResponseHeader->dejavu();
+        if (OM_RETRY_COUNT(currentDejavu) > OM_MAX_RETRIES)
+        {
+            requestResponseHeader->setDejavu(currentDejavu & 0x00FFFFFF);
+        }
+
+        for (unsigned int i = 0; i < NUMBER_OF_OUTGOING_CONNECTIONS + NUMBER_OF_INCOMING_CONNECTIONS && numberOfSuitablePeers < NUMBER_OF_OC_MACHINE_CONNECTIONS; i++)
+        {
+            if (peers[i].isOcMachineNode())
+            {
+                if (peers[i].tcp4Protocol
+                    && peers[i].isConnectedAccepted
+                    && !peers[i].isClosing)
+                {
+                    push(&peers[i], requestResponseHeader);
+                    numberOfSuitablePeers++;
+                    pushedToAny = true;
+                }
+            }
+        }
+
+        // Re-enqueue if no OC peer was ready.
+        if (!pushedToAny)
+        {
+            unsigned int retryCount = OM_RETRY_COUNT(requestResponseHeader->dejavu());
+            if (retryCount < OM_MAX_RETRIES)
+            {
+                requestResponseHeader->setDejavu(
+                    OM_SET_RETRY_COUNT(requestResponseHeader->dejavu(), retryCount + 1));
+                enqueueResponse((Peer*)2, requestResponseHeader);
+            }
+        }
+    }
 }
 
 
@@ -734,6 +825,10 @@ static bool peerConnectionNewlyEstablished(unsigned int i)
                     if (peers[i].isOracleMachineNode())
                     {
                         peers[i].lastOMActivityTime = __rdtsc();
+                    }
+                    else if (peers[i].isOcMachineNode())
+                    {
+                        peers[i].lastOcActivityTime = __rdtsc();
                     }
                 }
             }
@@ -1000,6 +1095,19 @@ static void processTransmittedData(unsigned int i, unsigned int salt)
             }
         }
 
+        // Same treatment for OC machine peers: close when transmitting is stuck
+        if (peers[i].isOcMachineNode() && peers[i].isTransmitting && peers[i].ocTransmitStartTime > 0)
+        {
+            unsigned long long elapsedSecs = (__rdtsc() - peers[i].ocTransmitStartTime) / frequency;
+            if (elapsedSecs > OC_MACHINE_TRANSMITING_TIMEOUT_SECS)
+            {
+                peers[i].isTransmitting = FALSE;
+                peers[i].ocTransmitStartTime = 0; // mark as invalid
+                closePeer(&peers[i]);
+                return;  // Exit early
+            }
+        }
+
         // check if transmission is completed
         if (peers[i].transmitToken.CompletionToken.Status != -1)
         {
@@ -1027,6 +1135,10 @@ static void processTransmittedData(unsigned int i, unsigned int salt)
                     if (peers[i].isOracleMachineNode())
                     {
                         peers[i].lastOMActivityTime = __rdtsc();
+                    }
+                    else if (peers[i].isOcMachineNode())
+                    {
+                        peers[i].lastOcActivityTime = __rdtsc();
                     }
                 }
             }
@@ -1067,6 +1179,10 @@ static void transmitData(unsigned int i, unsigned int salt)
                     {
                         peers[i].omTransmitStartTime = __rdtsc();
                     }
+                    else if (peers[i].isOcMachineNode())
+                    {
+                        peers[i].ocTransmitStartTime = __rdtsc();
+                    }
                 }
             }
         }
@@ -1095,8 +1211,9 @@ static void peerReconnectIfInactive(unsigned int i, unsigned short port)
     EFI_STATUS status;
     if (!peers[i].tcp4Protocol)
     {
-        // Save OM close time before reset (for cooldown to work)
+        // Save OM/OC close time before reset (for cooldown to work)
         unsigned long long savedOMCloseTime = peers[i].lastOMCloseTime;
+        unsigned long long savedOcCloseTime = peers[i].lastOcCloseTime;
 
         peers[i].reset();
         // peer slot without active connection
@@ -1106,11 +1223,33 @@ static void peerReconnectIfInactive(unsigned int i, unsigned short port)
             bool experimentSetting = false;
             // outgoing connection:
             peers[i].isIncommingConnection = FALSE;
-            // Check if this slot is for OM node
-            if (i >= NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS)
+            // Slot layout: [0,REGULAR) regular, [REGULAR,REGULAR+OM) OM, [REGULAR+OM,...) OC
+            if (i >= FIRST_OC_MACHINE_CONNECTION_INDEX)
+            {
+                // OC machine slot
+                peers[i].isOcMachine = TRUE;
+                peers[i].address = ocIPv4Address[i - FIRST_OC_MACHINE_CONNECTION_INDEX];
+
+                // Restore OC close time for cooldown check
+                peers[i].lastOcCloseTime = savedOcCloseTime;
+
+                // Mark it as failure
+                peers[i].connectAcceptToken.CompletionToken.Status = -1;
+
+                // Reconnection cooldown: prevent rapid reconnect cycles of the OC machine
+                if (peers[i].lastOcCloseTime > 0)
+                {
+                    unsigned long long elapsedSecs = (__rdtsc() - peers[i].lastOcCloseTime) / frequency;
+                    if (elapsedSecs < OC_RECONNECT_COOLDOWN_SECS)
+                    {
+                        return;  // Still in cooldown, don't attempt reconnection yet
+                    }
+                }
+            }
+            else if (i >= FIRST_OM_NODE_CONNECTION_INDEX)
             {
                 peers[i].isOMNode = TRUE;
-                peers[i].address = omIPv4Address[i - NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS];
+                peers[i].address = omIPv4Address[i - FIRST_OM_NODE_CONNECTION_INDEX];
 
                 // Restore OM close time for cooldown check
                 peers[i].lastOMCloseTime = savedOMCloseTime;
@@ -1132,6 +1271,7 @@ static void peerReconnectIfInactive(unsigned int i, unsigned short port)
             else
             {
                 peers[i].isOMNode = FALSE;
+                peers[i].isOcMachine = FALSE;
                 // randomly select public peer and try to connect if we do not
                 // yet have an outgoing connection to it
                 peers[i].address = publicPeers[random(numberOfPublicPeers)].address;
@@ -1164,7 +1304,7 @@ static void peerReconnectIfInactive(unsigned int i, unsigned short port)
                         else
                         {
                             peers[i].isConnectingAccepting = TRUE;
-                            if (peers[i].isOracleMachineNode())
+                            if (peers[i].isOracleMachineNode() || peers[i].isOcMachineNode())
                             {
                                 peers[i].connectionStartTime = __rdtsc();
                             }

--- a/src/network_core/peers.h
+++ b/src/network_core/peers.h
@@ -44,13 +44,13 @@
 // OM related setting
 static constexpr unsigned int ORACLE_MACHINE_CONNECTION_TIMEOUT_SECS = 15; // Config timout for connecting attemp to OM
 static constexpr unsigned int ORACLE_MACHINE_TRANSMITING_TIMEOUT_SECS = 30; // Transmitting timeout to OM
-static constexpr unsigned int ORACLE_MACHINE_GRACEFULL_CLOSE_RETIRES = 3; // Gracefull close retries for connecting attemp to OM
+static constexpr unsigned int ORACLE_MACHINE_GRACEFUL_CLOSE_RETRIES = 3; // Graceful close retries for connecting attempt to OM
 static constexpr unsigned long long OM_RECONNECT_COOLDOWN_SECS = 0;
 
 // OC machine setting (mirrors the OM settings above)
 static constexpr unsigned int OC_MACHINE_CONNECTION_TIMEOUT_SECS = 15; // Config timeout for connecting attempt to OC machine
 static constexpr unsigned int OC_MACHINE_TRANSMITING_TIMEOUT_SECS = 30; // Transmitting timeout to OC machine
-static constexpr unsigned int OC_MACHINE_GRACEFULL_CLOSE_RETIRES = 3; // Graceful close retries for connecting attempt to OC machine
+static constexpr unsigned int OC_MACHINE_GRACEFUL_CLOSE_RETRIES = 3; // Graceful close retries for connecting attempt to OC machine
 static constexpr unsigned long long OC_RECONNECT_COOLDOWN_SECS = 0;
 
 static_assert((NUMBER_OF_INCOMING_CONNECTIONS / NUMBER_OF_REGULAR_OUTGOING_CONNECTIONS) >= 11, "Number of incoming connections must be x11+ number of outgoing connections to keep healthy network");
@@ -60,6 +60,10 @@ static volatile bool listOfPeersIsStatic = false;
 #define OM_RETRY_COUNT(dejavu) ((dejavu) >> 24)
 #define OM_SET_RETRY_COUNT(dejavu, count) (((dejavu) & 0x00FFFFFF) | ((count) << 24))
 #define OM_MAX_RETRIES 3
+
+#define OC_RETRY_COUNT(dejavu) ((dejavu) >> 24)
+#define OC_SET_RETRY_COUNT(dejavu, count) (((dejavu) & 0x00FFFFFF) | ((count) << 24))
+#define OC_MAX_RETRIES 3
 
 struct Peer
 {
@@ -579,7 +583,7 @@ static void pushToOcMachineNodes(RequestResponseHeader* requestResponseHeader)
         unsigned short numberOfSuitablePeers = 0;
 
         unsigned int currentDejavu = requestResponseHeader->dejavu();
-        if (OM_RETRY_COUNT(currentDejavu) > OM_MAX_RETRIES)
+        if (OC_RETRY_COUNT(currentDejavu) > OC_MAX_RETRIES)
         {
             requestResponseHeader->setDejavu(currentDejavu & 0x00FFFFFF);
         }
@@ -602,11 +606,11 @@ static void pushToOcMachineNodes(RequestResponseHeader* requestResponseHeader)
         // Re-enqueue if no OC peer was ready.
         if (!pushedToAny)
         {
-            unsigned int retryCount = OM_RETRY_COUNT(requestResponseHeader->dejavu());
-            if (retryCount < OM_MAX_RETRIES)
+            unsigned int retryCount = OC_RETRY_COUNT(requestResponseHeader->dejavu());
+            if (retryCount < OC_MAX_RETRIES)
             {
                 requestResponseHeader->setDejavu(
-                    OM_SET_RETRY_COUNT(requestResponseHeader->dejavu(), retryCount + 1));
+                    OC_SET_RETRY_COUNT(requestResponseHeader->dejavu(), retryCount + 1));
                 enqueueResponse((Peer*)2, requestResponseHeader);
             }
         }

--- a/src/network_messages/network_message_type.h
+++ b/src/network_messages/network_message_type.h
@@ -53,6 +53,7 @@ enum NetworkMessageType : unsigned char
     RESPOND_REVENUE_DATA = 71,
     ORACLE_MACHINE_QUERY = 190, // only on communication channel Core node <-> OM node
     ORACLE_MACHINE_REPLY = 191, // only on communication channel Core node <-> OM node
+    OC_MACHINE_INVOCATION = 192, // only on communication channel Core node <-> OC machine
     REQUEST_TX_STATUS = 201, // tx addon only
     RESPOND_TX_STATUS = 202, // tx addon only
     SPECIAL_COMMAND = 255,

--- a/src/oc_core/core_oc_network_messages.h
+++ b/src/oc_core/core_oc_network_messages.h
@@ -1,0 +1,51 @@
+// Defines messages used in the "private" communication channel between core and OC machine node.
+// These are used as the payload together with RequestResponseHeader.
+//
+// The connection between OC machine node and core node is an outgoing connection of the core, permanently kept open.
+// The OC machine node implements whitelisting of IPs, only allowing a specific set of core nodes to connect.
+//
+// Mirrors core_om_network_messages.h.
+
+#pragma once
+
+#include "network_messages/common_def.h"
+
+
+// Single (computor index, signature) pair in an OcMachineInvocation authorization bundle.
+struct SignerEntry
+{
+    unsigned short computorIndex;            // index into the issuing epoch's computor list
+    unsigned char signature[SIGNATURE_SIZE]; // 64 bytes; SchnorrQ over authMessage
+};
+
+static_assert(sizeof(SignerEntry) == 66, "SignerEntry must be exactly 66 bytes.");
+
+
+// Message sent from Core Node to OC machine Node when an invocation transitions to AUTHORIZED.
+// Carries the pinned OcRequest payload followed by QUORUM SignerEntries.
+//
+// Wire layout:
+//     OcMachineInvocation header (fixed)
+//     unsigned char requestData[requestSize]
+//     SignerEntry signers[signatureCount]
+//
+// Transmitted ONLY over the private out-of-band channel. Not subject to MAX_INPUT_SIZE.
+// Maximum size: 16 + MAX_OC_REQUEST_SIZE + QUORUM * sizeof(SignerEntry) ≈ 30,790 bytes.
+struct OcMachineInvocation
+{
+    /// Type to be used in RequestResponseHeader
+    static constexpr unsigned char type()
+    {
+        return NetworkMessageType::OC_MACHINE_INVOCATION;
+    }
+
+    long long invocationId;          // 8 bytes
+    unsigned short epoch;            // 2 bytes
+    unsigned short interfaceIndex;   // 2 bytes
+    unsigned short requestSize;      // 2 bytes
+    unsigned short signatureCount;   // 2 bytes; MUST equal QUORUM
+    // followed by: requestSize bytes of pinned OcRequest payload
+    // followed by: signatureCount x SignerEntry
+};
+
+static_assert(sizeof(OcMachineInvocation) == 16, "OcMachineInvocation header must be exactly 16 bytes.");

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -33,6 +33,14 @@ static const unsigned char oracleMachineIPs[][4] = {
      {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
 };
 
+// Enter static IPs of one or multiple OC (Outsourced Computation) machine node(s). This node will connect to these
+// and keep the connection open to forward authorized OC invocation bundles. The OC machine nodes also need to
+// whitelist the IP of this core node. At least one entry is required (an empty array does not compile); point it
+// at a loopback/unreachable address if this node should not forward OC bundles.
+static const unsigned char ocMachineIPs[][4] = {
+     {127, 0, 0, 1}, // REMOVE THIS ENTRY AND REPLACE IT WITH YOUR OWN IP ADDRESSES
+};
+
 #define ENABLE_QUBIC_LOGGING_EVENT 0 // turn on logging events
 
 // Virtual memory settings for logging

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -6360,6 +6360,17 @@ static bool initialize()
         }
     }
 
+    if (NUMBER_OF_OC_MACHINE_CONNECTIONS > 0)
+    {
+        logToConsole(L"Populating OC machine node ...");
+        numberOfOcPeers = 0;
+        for (unsigned int i = 0; i < NUMBER_OF_OC_MACHINE_CONNECTIONS; i++)
+        {
+            const IPv4Address& peer_ip = *reinterpret_cast<const IPv4Address*>(ocMachineIPs[i]);
+            copyMem(&ocIPv4Address[numberOfOcPeers++], &peer_ip, sizeof(IPv4Address));
+        }
+    }
+
     logToConsole(L"Init TCP...");
     if (!initTcp4(PORT))
         return false;
@@ -7497,8 +7508,8 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
 
                 for (unsigned int i = 0; i < NUMBER_OF_OUTGOING_CONNECTIONS + NUMBER_OF_INCOMING_CONNECTIONS; i++)
                 {
-                    // handle new connections. For Oracle Machine, not need the ExchangePublicPeers
-                    if (peerConnectionNewlyEstablished(i) && !peers[i].isOracleMachineNode())
+                    // handle new connections. For Oracle Machine and OC machine, not need the ExchangePublicPeers
+                    if (peerConnectionNewlyEstablished(i) && !peers[i].isOracleMachineNode() && !peers[i].isOcMachineNode())
                     {
                         // new connection established:
                         // prepare and send ExchangePublicPeers message
@@ -7573,7 +7584,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                     {
                         if (ORACLE_MACHINE_CONNECTION_TIMEOUT_SECS > 0
                             && peers[i].connectionStartTime > 0
-                            && peers[i].isConnectingAccepting 
+                            && peers[i].isConnectingAccepting
                             && ((__rdtsc() - peers[i].connectionStartTime) / frequency > ORACLE_MACHINE_CONNECTION_TIMEOUT_SECS))
                         {
                             closePeer(&peers[i], ORACLE_MACHINE_GRACEFULL_CLOSE_RETIRES);
@@ -7588,6 +7599,26 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             ((__rdtsc() - peers[i].lastOMActivityTime) / frequency > OM_INACTIVITY_TIMEOUT_SECS))
                         {
                             closePeer(&peers[i], ORACLE_MACHINE_GRACEFULL_CLOSE_RETIRES);
+                        }
+                    }
+                    else if (peers[i].isOcMachineNode())
+                    {
+                        // Mirror the OM connection lifecycle handling for OC machine peers.
+                        if (OC_MACHINE_CONNECTION_TIMEOUT_SECS > 0
+                            && peers[i].connectionStartTime > 0
+                            && peers[i].isConnectingAccepting
+                            && ((__rdtsc() - peers[i].connectionStartTime) / frequency > OC_MACHINE_CONNECTION_TIMEOUT_SECS))
+                        {
+                            closePeer(&peers[i], OC_MACHINE_GRACEFULL_CLOSE_RETIRES);
+                        }
+
+                        const unsigned long long OC_INACTIVITY_TIMEOUT_SECS = 120 - (i % 5) * 15;
+                        if (peers[i].isConnectedAccepted &&
+                            !peers[i].isClosing &&
+                            peers[i].lastOcActivityTime > 0 &&
+                            ((__rdtsc() - peers[i].lastOcActivityTime) / frequency > OC_INACTIVITY_TIMEOUT_SECS))
+                        {
+                            closePeer(&peers[i], OC_MACHINE_GRACEFULL_CLOSE_RETIRES);
                         }
                     }
 
@@ -7736,6 +7767,10 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                         else if (responseQueueElements[responseQueueElementTail].peer == (Peer*)1)
                         {
                             pushToOracleMachineNodes(responseHeader);
+                        }
+                        else if (responseQueueElements[responseQueueElementTail].peer == (Peer*)2)
+                        {
+                            pushToOcMachineNodes(responseHeader);
                         }
                         else
                         {

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -7587,7 +7587,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             && peers[i].isConnectingAccepting
                             && ((__rdtsc() - peers[i].connectionStartTime) / frequency > ORACLE_MACHINE_CONNECTION_TIMEOUT_SECS))
                         {
-                            closePeer(&peers[i], ORACLE_MACHINE_GRACEFULL_CLOSE_RETIRES);
+                            closePeer(&peers[i], ORACLE_MACHINE_GRACEFUL_CLOSE_RETRIES);
                         }
 
                         // inactivity timeout between 1 and 2 minutes (depending on peer index to reduce risk of
@@ -7598,7 +7598,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             peers[i].lastOMActivityTime > 0 &&
                             ((__rdtsc() - peers[i].lastOMActivityTime) / frequency > OM_INACTIVITY_TIMEOUT_SECS))
                         {
-                            closePeer(&peers[i], ORACLE_MACHINE_GRACEFULL_CLOSE_RETIRES);
+                            closePeer(&peers[i], ORACLE_MACHINE_GRACEFUL_CLOSE_RETRIES);
                         }
                     }
                     else if (peers[i].isOcMachineNode())
@@ -7609,7 +7609,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             && peers[i].isConnectingAccepting
                             && ((__rdtsc() - peers[i].connectionStartTime) / frequency > OC_MACHINE_CONNECTION_TIMEOUT_SECS))
                         {
-                            closePeer(&peers[i], OC_MACHINE_GRACEFULL_CLOSE_RETIRES);
+                            closePeer(&peers[i], OC_MACHINE_GRACEFUL_CLOSE_RETRIES);
                         }
 
                         const unsigned long long OC_INACTIVITY_TIMEOUT_SECS = 120 - (i % 5) * 15;
@@ -7618,7 +7618,7 @@ EFI_STATUS efi_main(EFI_HANDLE imageHandle, EFI_SYSTEM_TABLE* systemTable)
                             peers[i].lastOcActivityTime > 0 &&
                             ((__rdtsc() - peers[i].lastOcActivityTime) / frequency > OC_INACTIVITY_TIMEOUT_SECS))
                         {
-                            closePeer(&peers[i], OC_MACHINE_GRACEFULL_CLOSE_RETIRES);
+                            closePeer(&peers[i], OC_MACHINE_GRACEFUL_CLOSE_RETRIES);
                         }
                     }
 


### PR DESCRIPTION
This PR adds the network-layer groundwork for Outsourced Computation (OC) — the outbound counterpart to Oracle machines: where an OM brings external data into Qubic, an OC machine carries computor-authorized intent out of Qubic to act on an external system (e.g. a bridge). Full protocol spec is included under doc/.

Concepts introduced:

  - OC machine peer type — a new class of private outgoing connection, mirroring the Oracle Machine one: ocMachineIPs in private_settings.h, dedicated outgoing slots, own connect/monitor/timeout/cooldown lifecycle.
  ExchangePublicPeers is not sent on machine connections.
  - Wire format — OcMachineInvocation (invocation header + pinned request payload + 451 SignerEntry computor signatures) and reservation of network message type 192 for it.
  - Delivery plumbing — pushToOcMachineNodes() with a new (Peer*)2 dispatch sentinel (0 = random peers, 1 = OM, 2 = OC).
  - Documentation — doc/oc_protocol_spec.md (normative wire formats, state machine, constants) and doc/contracts_outsourced_computations.md (contract-author guide).

Nothing here is consensus-relevant and no epoch guards are needed: no new messages are sent or handled (the delivery path has no producer yet), transaction processing and digests are untouched. The OC engine, INVOKE_OC QPI, and transaction type that make this plumbing live follow in a second PR.
