### PR TITLE
Add OC_INVOCATION_STATUS_CHANGE log event 

### DIFF
--- a/doc/oc_protocol_spec.md
+++ b/doc/oc_protocol_spec.md
@@ -220,6 +220,21 @@ The engine MAY track, for each `(invocationId, ocPeerId)` pair, whether the bund
 This state is private to each Core node, MUST NOT enter snapshots, and MUST NOT be exposed via public RPC.
 See section 8 for delivery rules.
 
+### 5.3 Status-change logging
+
+Nodes built with `LOG_OC` enabled emit a log event of type `OC_INVOCATION_STATUS_CHANGE` (message type 16) on every consensus-status transition, i.e. on entering `PENDING_AUTH`, `AUTHORIZED`, and `TIMEOUT`.
+
+Logged payload (17 bytes, fields in order):
+
+| Field            | Type               | Description                                  |
+|------------------|--------------------|----------------------------------------------|
+| `invocationId`   | `long long`        | Invocation ID (section 2.1).                 |
+| `contractIndex`  | `unsigned int`     | Index of the invoking contract.              |
+| `interfaceIndex` | `unsigned int`     | OC interface index.                          |
+| `status`         | `unsigned char`    | The `OC_INVOCATION_STATUS_*` value entered.  |
+
+This is optional node-side event logging for external log subscribers, NOT consensus state. Delivery status (section 5.2) is never logged: it is node-local and non-deterministic. The `QuTransfer` fee burn (section 10) is logged immediately before the `PENDING_AUTH` event in the same tick, which lets subscribers attribute the burn to the invocation. If `startContractInvocation` fails and the fee is refunded, no status event is emitted.
+
 
 ## 6. QPI surface
 

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -18,7 +18,7 @@ struct Peer;
 
 #define LOG_CONTRACTS (LOG_CONTRACT_ERROR_MESSAGES | LOG_CONTRACT_WARNING_MESSAGES | LOG_CONTRACT_INFO_MESSAGES | LOG_CONTRACT_DEBUG_MESSAGES)
 
-#if LOG_SPECTRUM | LOG_UNIVERSE | LOG_CONTRACTS | LOG_CUSTOM_MESSAGES | LOG_ORACLES
+#if LOG_SPECTRUM | LOG_UNIVERSE | LOG_CONTRACTS | LOG_CUSTOM_MESSAGES | LOG_ORACLES | LOG_OC
 #define ENABLED_LOGGING 1
 #else
 #define ENABLED_LOGGING 0
@@ -59,6 +59,7 @@ struct Peer;
 #define CONTRACT_RESERVE_DEDUCTION 13
 #define ORACLE_QUERY_STATUS_CHANGE 14
 #define ORACLE_SUBSCRIBER_MESSAGE 15
+#define OC_INVOCATION_STATUS_CHANGE 16
 #define CUSTOM_MESSAGE 255
 
 #define CUSTOM_MESSAGE_OP_START_DISTRIBUTE_DIVIDENDS 6217575821008262227ULL // STA_DDIV
@@ -261,6 +262,16 @@ struct OracleSubscriberLogMessage
     unsigned int contractIndex;
     unsigned int periodInMilliseconds;    // 0 means unsubscribe
     unsigned long long firstQueryDateAndTime;
+
+    char _terminator; // Only data before "_terminator" are logged
+};
+
+struct OcInvocationStatusChange
+{
+    long long invocationId;
+    unsigned int contractIndex;
+    unsigned int interfaceIndex;
+    unsigned char status;
 
     char _terminator; // Only data before "_terminator" are logged
 };
@@ -905,6 +916,13 @@ public:
     {
 #if LOG_ORACLES
         logMessage(offsetof(OracleSubscriberLogMessage, _terminator), ORACLE_SUBSCRIBER_MESSAGE, &message);
+#endif
+    }
+
+    void logOcInvocationStatusChange(const OcInvocationStatusChange& message)
+    {
+#if LOG_OC
+        logMessage(offsetof(OcInvocationStatusChange, _terminator), OC_INVOCATION_STATUS_CHANGE, &message);
 #endif
     }
 

--- a/src/oc_core/oc_engine.h
+++ b/src/oc_core/oc_engine.h
@@ -329,6 +329,8 @@ public:
 
         ++stats.invocationCount;
 
+        logger.logOcInvocationStatusChange({ rec.invocationId, rec.contractIndex, rec.interfaceIndex, rec.status });
+
 #if !defined(NDEBUG) && !defined(NO_UEFI)
         CHAR16 dbgMsg[200];
         setText(dbgMsg, L"ocEngine.startContractInvocation(), tick ");
@@ -527,6 +529,8 @@ public:
             rec.status = OC_INVOCATION_STATUS_TIMEOUT;
             ++stats.timeoutCount;
 
+            logger.logOcInvocationStatusChange({ rec.invocationId, rec.contractIndex, rec.interfaceIndex, rec.status });
+
             // free the in-flight slot (held since creation)
             if (rec.inFlightSlot != OC_IN_FLIGHT_SLOT_NONE)
             {
@@ -670,6 +674,8 @@ public:
             {
                 rec.status = OC_INVOCATION_STATUS_AUTHORIZED;
                 ++stats.authorizedCount;
+
+                logger.logOcInvocationStatusChange({ rec.invocationId, rec.contractIndex, rec.interfaceIndex, rec.status });
             }
         }
 

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -59,6 +59,7 @@ static const unsigned char ocMachineIPs[][4] = {
 #define LOG_CONTRACT_DEBUG_MESSAGES 1
 #define LOG_CUSTOM_MESSAGES 1
 #define LOG_ORACLES 1
+#define LOG_OC 1
 #else
 #define LOG_UNIVERSE 0
 #define LOG_SPECTRUM 0
@@ -68,6 +69,7 @@ static const unsigned char ocMachineIPs[][4] = {
 #define LOG_CONTRACT_DEBUG_MESSAGES 0
 #define LOG_CUSTOM_MESSAGES 0
 #define LOG_ORACLES 0
+#define LOG_OC 0
 #endif
 
 static unsigned long long logReaderPasscodes[4] = {


### PR DESCRIPTION
Adds a new log event type (type 16) for OC invocation status transitions.