### PR TITLE
Add lastUpdateTick to RANDOM so miner clients can detect failed txs

### DIFF
--- a/src/contracts/Random.h
+++ b/src/contracts/Random.h
@@ -78,6 +78,11 @@ public:
 		Array<uint32, 32> collateralTier;      // collateral tier of slot k
 		Array<uint64, 32> lockedCollateral;    // collateral currently locked for slot k
 		Array<uint8, 32> contributedToEntropy; // 1 if slot k's reveal was mixed into entropy this cycle
+		// Tick of slot k's last accepted RevealAndCommit call. A client that submitted
+		// a tx targeting tick T can compare this to T after the fact: equal means the
+		// tx was accepted; anything earlier means it was rejected (wrong preimage,
+		// same-tick resubmit, stream full, etc.) and the attached amount was refunded.
+		Array<uint32, 32> lastUpdateTick;
 	};
 
 	struct GetProviderStatus_locals
@@ -110,6 +115,10 @@ public:
 		bit_4096 revealedThisTickFlags;
 		// Cleared each END_TICK; set when reveal is XOR'd into entropy. BuyEntropy uses for trustee verification.
 		bit_4096 contributedToEntropyFlags;
+		// Tick of the last RevealAndCommit call accepted for this slot. Never touched
+		// on a rejected call, so it is a durable, tick-precise signal off-chain clients
+		// can use (via GetProviderStatus) to tell whether a submitted tx took effect.
+		Array<uint32, RANDOM_MAX_PROVIDERS> lastUpdateTick;
 	};
 
 	PUBLIC_FUNCTION(Fees)
@@ -141,6 +150,7 @@ public:
 					output.stream.set(locals.count, locals.s);
 					output.collateralTier.set(locals.count, static_cast<uint32>(state.get().collateralTiers.get(locals.index)));
 					output.lockedCollateral.set(locals.count, state.get().lockedCollateralAmounts.get(locals.index));
+					output.lastUpdateTick.set(locals.count, state.get().lastUpdateTick.get(locals.index));
 					output.contributedToEntropy.set(locals.count, 0);
 					if (state.get().contributedToEntropyFlags.get(locals.index))
 					{
@@ -295,6 +305,7 @@ private:
 			state.mut().commits.set(locals.index, id::zero()); // leaving marker: enrolled providers always keep a non-zero commit
 			state.mut().revealOrCommitFlags.set(locals.index, 1);
 			state.mut().revealedThisTickFlags.set(locals.index, 1);
+			state.mut().lastUpdateTick.set(locals.index, qpi.tick());
 
 			return;
 		}
@@ -340,6 +351,7 @@ private:
 
 			state.mut().revealOrCommitFlags.set(locals.index, 1);
 			state.mut().revealedThisTickFlags.set(locals.index, 1);
+			state.mut().lastUpdateTick.set(locals.index, qpi.tick());
 
 			return;
 		}
@@ -374,6 +386,7 @@ private:
 
 		state.mut().revealOrCommitFlags.set(locals.index, 1);
 		state.mut().revealedThisTickFlags.set(locals.index, 0);
+		state.mut().lastUpdateTick.set(locals.index, qpi.tick());
 
 		state.mut().populations.set(locals.stream, locals.i + 1);
 	}
@@ -447,6 +460,7 @@ private:
 					state.mut().revealOrCommitFlags.set(locals.index, state.get().revealOrCommitFlags.get(locals.lastIndex));
 					state.mut().revealedThisTickFlags.set(locals.index, state.get().revealedThisTickFlags.get(locals.lastIndex));
 					state.mut().contributedToEntropyFlags.set(locals.index, state.get().contributedToEntropyFlags.get(locals.lastIndex));
+					state.mut().lastUpdateTick.set(locals.index, state.get().lastUpdateTick.get(locals.lastIndex));
 				}
 				state.mut().providers.set(locals.lastIndex, id::zero());
 				state.mut().collateralTiers.set(locals.lastIndex, 0);
@@ -456,6 +470,7 @@ private:
 				state.mut().revealOrCommitFlags.set(locals.lastIndex, 0);
 				state.mut().revealedThisTickFlags.set(locals.lastIndex, 0);
 				state.mut().contributedToEntropyFlags.set(locals.lastIndex, 0);
+				state.mut().lastUpdateTick.set(locals.lastIndex, 0);
 
 				state.mut().populations.set(locals.stream, state.get().populations.get(locals.stream) - 1);
 			}
@@ -511,6 +526,7 @@ private:
 						state.mut().revealOrCommitFlags.set(locals.index, state.get().revealOrCommitFlags.get(locals.lastIndex));
 						state.mut().revealedThisTickFlags.set(locals.index, state.get().revealedThisTickFlags.get(locals.lastIndex));
 						state.mut().contributedToEntropyFlags.set(locals.index, state.get().contributedToEntropyFlags.get(locals.lastIndex));
+						state.mut().lastUpdateTick.set(locals.index, state.get().lastUpdateTick.get(locals.lastIndex));
 					}
 					state.mut().providers.set(locals.lastIndex, id::zero());
 					state.mut().collateralTiers.set(locals.lastIndex, 0);
@@ -520,6 +536,7 @@ private:
 					state.mut().revealOrCommitFlags.set(locals.lastIndex, 0);
 					state.mut().revealedThisTickFlags.set(locals.lastIndex, 0);
 					state.mut().contributedToEntropyFlags.set(locals.lastIndex, 0);
+					state.mut().lastUpdateTick.set(locals.lastIndex, 0);
 
 					state.mut().populations.set(locals.stream, state.get().populations.get(locals.stream) - 1);
 				}
@@ -549,6 +566,7 @@ private:
 					state.mut().revealOrCommitFlags.set(locals.index, state.get().revealOrCommitFlags.get(locals.lastIndex));
 					state.mut().revealedThisTickFlags.set(locals.index, state.get().revealedThisTickFlags.get(locals.lastIndex));
 					state.mut().contributedToEntropyFlags.set(locals.index, state.get().contributedToEntropyFlags.get(locals.lastIndex));
+					state.mut().lastUpdateTick.set(locals.index, state.get().lastUpdateTick.get(locals.lastIndex));
 				}
 				state.mut().providers.set(locals.lastIndex, id::zero());
 				state.mut().collateralTiers.set(locals.lastIndex, 0);
@@ -558,6 +576,7 @@ private:
 				state.mut().revealOrCommitFlags.set(locals.lastIndex, 0);
 				state.mut().revealedThisTickFlags.set(locals.lastIndex, 0);
 				state.mut().contributedToEntropyFlags.set(locals.lastIndex, 0);
+				state.mut().lastUpdateTick.set(locals.lastIndex, 0);
 
 				state.mut().populations.set(locals.stream, state.get().populations.get(locals.stream) - 1);
 			}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
   # contract_qvault.cpp
   # contract_qx.cpp
   contract_qraffle.cpp
+  contract_random.cpp
   contract_vottunbridge.cpp
   # kangaroo_twelve.cpp
   m256.cpp

--- a/test/contract_random.cpp
+++ b/test/contract_random.cpp
@@ -865,10 +865,12 @@ TEST(ContractRandom, SameTickCommitAndRevealIsRejected)
     QPI::bit_4096 zero; zero.setAll(0);
 
     // Tx 1: first-commit. Registers the provider and sets revealOrCommitFlags=1.
+    const uint32 commitTick = r.tick();
     increaseEnergy(provider, collateral);
     r.revealAndCommit(provider, zero, commit1, collateral);
     ASSERT_EQ(r.state()->populations.get(stream), 1u);
     ASSERT_TRUE(r.state()->commits.get(index) == commit1);
+    ASSERT_EQ(r.state()->lastUpdateTick.get(index), commitTick);
 
     // Tx 2 (same tick): attempt to reveal the preimage of commit1 immediately.
     // Must be rejected — provider must not be able to pick the preimage after
@@ -886,6 +888,9 @@ TEST(ContractRandom, SameTickCommitAndRevealIsRejected)
         << "same-tick reveal must not set the revealed flag";
     EXPECT_TRUE(r.state()->commits.get(index) == commit1)
         << "same-tick reveal must not overwrite the existing commit";
+    EXPECT_EQ(r.state()->lastUpdateTick.get(index), commitTick)
+        << "a rejected same-tick reveal must not advance lastUpdateTick — a client "
+           "polling GetProviderStatus can tell this resubmission did not take effect";
 
     // After END_TICK the provider is still enrolled (they committed legitimately).
     r.endTick();
@@ -894,6 +899,7 @@ TEST(ContractRandom, SameTickCommitAndRevealIsRejected)
 
     // Tick T+3: the normal reveal must now succeed.
     r.setTick(r.tick() + 3);
+    const uint32 revealTick = r.tick();
     increaseEnergy(provider, collateral);
     const long long before2 = getBalance(provider);
 
@@ -903,6 +909,8 @@ TEST(ContractRandom, SameTickCommitAndRevealIsRejected)
         << "legitimate reveal at T+3 must refund prior collateral (net zero)";
     EXPECT_EQ(r.state()->revealedThisTickFlags.get(index), 1)
         << "legitimate reveal at T+3 must set the revealed flag";
+    EXPECT_EQ(r.state()->lastUpdateTick.get(index), revealTick)
+        << "the accepted reveal at T+3 must advance lastUpdateTick";
 }
 
 // C1: when at least one reveal lands in a round, a no-show provider's stake is
@@ -1209,4 +1217,151 @@ TEST(ContractRandom, NoShowInTierDoesNotLockOutOtherProviders)
         }
     }
     EXPECT_TRUE(found) << "good provider must still be in the pool";
+}
+
+// ---------------------------------------------------------------------------
+// lastUpdateTick: a durable, tick-precise signal so an off-chain client can tell
+// whether a submitted RevealAndCommit tx actually took effect. It is stamped
+// with the current tick on every accepted call and left untouched on rejection,
+// so a client that remembers which tick it submitted in can compare afterwards
+// via GetProviderStatus -- no wallet-balance monitoring required.
+// ---------------------------------------------------------------------------
+
+TEST(ContractRandom, GetProviderStatusReportsLastUpdateTickOnSuccess)
+{
+    ContractTestingRandom r;
+    const uint8 tier = 2;
+    const sint64 collateral = collateralForTier(tier);
+    const uint32 firstTick = r.tick();
+
+    id provider = getUser(1);
+    QPI::bit_4096 zero; zero.setAll(0);
+    auto reveal1 = makeReveal(1);
+
+    increaseEnergy(provider, collateral);
+    r.revealAndCommit(provider, zero, commitOf(reveal1), collateral);
+
+    auto st1 = r.getProviderStatus(provider);
+    ASSERT_EQ(st1.count, 1u);
+    EXPECT_EQ(st1.lastUpdateTick.get(0), firstTick)
+        << "an accepted first-commit must stamp lastUpdateTick with the current tick";
+
+    r.endTick();
+    r.setTick(r.tick() + 3);
+    const uint32 secondTick = r.tick();
+    increaseEnergy(provider, collateral);
+    r.revealAndCommit(provider, reveal1, commitOf(makeReveal(2)), collateral);
+
+    auto st2 = r.getProviderStatus(provider);
+    ASSERT_EQ(st2.count, 1u);
+    EXPECT_EQ(st2.lastUpdateTick.get(0), secondTick)
+        << "an accepted reveal+recommit must advance lastUpdateTick to the new tick";
+}
+
+TEST(ContractRandom, WrongPreimageRevealDoesNotAdvanceLastUpdateTick)
+{
+    ContractTestingRandom r;
+    const uint8 tier = 2;
+    const sint64 collateral = collateralForTier(tier);
+    const uint32 stream = r.tick() % 3;
+    const uint32 index = stream * RANDOM_STREAM_CAPACITY + 0;
+
+    id provider = getUser(1);
+    QPI::bit_4096 zero; zero.setAll(0);
+    auto reveal1 = makeReveal(1);
+    auto wrongReveal = makeReveal(999); // does not hash to commitOf(reveal1)
+
+    const uint32 commitTick = r.tick();
+    increaseEnergy(provider, collateral);
+    r.revealAndCommit(provider, zero, commitOf(reveal1), collateral);
+    r.endTick();
+
+    r.setTick(r.tick() + 3);
+    increaseEnergy(provider, collateral);
+    const long long before = getBalance(provider);
+
+    r.revealAndCommit(provider, wrongReveal, commitOf(makeReveal(2)), collateral);
+
+    EXPECT_EQ(getBalance(provider), before)
+        << "wrong-preimage reveal must be refunded in full";
+    EXPECT_EQ(r.state()->lastUpdateTick.get(index), commitTick)
+        << "a rejected wrong-preimage reveal must leave lastUpdateTick at the last accepted tick";
+
+    auto st = r.getProviderStatus(provider);
+    ASSERT_EQ(st.count, 1u);
+    EXPECT_EQ(st.lastUpdateTick.get(0), commitTick)
+        << "client-visible status must also show the tx did not take effect";
+}
+
+TEST(ContractRandom, DuplicateFirstCommitDoesNotAdvanceLastUpdateTick)
+{
+    ContractTestingRandom r;
+    const uint8 tier = 2;
+    const sint64 collateral = collateralForTier(tier);
+    const uint32 stream = r.tick() % 3;
+    const uint32 index = stream * RANDOM_STREAM_CAPACITY + 0;
+
+    id provider = getUser(1);
+    QPI::bit_4096 zero; zero.setAll(0);
+    const id commit1 = commitOf(makeReveal(1));
+
+    const uint32 commitTick = r.tick();
+    increaseEnergy(provider, collateral);
+    r.revealAndCommit(provider, zero, commit1, collateral);
+    ASSERT_EQ(r.state()->populations.get(stream), 1u);
+
+    // Same tick: provider tries to first-commit again without revealing first.
+    increaseEnergy(provider, collateral);
+    const long long before = getBalance(provider);
+
+    r.revealAndCommit(provider, zero, commitOf(makeReveal(2)), collateral);
+
+    EXPECT_EQ(getBalance(provider), before)
+        << "a duplicate first-commit from an already-registered provider must be refunded";
+    EXPECT_EQ(r.state()->lastUpdateTick.get(index), commitTick)
+        << "a rejected duplicate first-commit must not advance lastUpdateTick";
+    EXPECT_TRUE(r.state()->commits.get(index) == commit1)
+        << "the original commit must be untouched";
+}
+
+// lastUpdateTick must survive END_TICK's swap-delete relocation: when a slot is
+// evicted, the last active slot in the stream is moved into the freed index, and
+// every per-slot field -- including lastUpdateTick -- must move with it.
+TEST(ContractRandom, LastUpdateTickSurvivesSwapDeleteRelocation)
+{
+    ContractTestingRandom r;
+    const uint8 tier = 2;
+    const sint64 collateral = collateralForTier(tier);
+    const uint32 stream = r.tick() % 3;
+
+    id bad  = getUser(1); // index 0: will no-show and get evicted
+    id good = getUser(2); // index 1: will be swap-deleted into index 0
+
+    QPI::bit_4096 zero; zero.setAll(0);
+    auto goodReveal1 = makeReveal(11);
+    auto badReveal1  = makeReveal(21);
+
+    increaseEnergy(bad, collateral);
+    increaseEnergy(good, collateral);
+    r.revealAndCommit(bad,  zero, commitOf(badReveal1),  collateral);
+    r.revealAndCommit(good, zero, commitOf(goodReveal1), collateral);
+    r.endTick();
+    ASSERT_EQ(r.state()->populations.get(stream), 2u);
+
+    // good reveals (advancing its lastUpdateTick); bad is a no-show.
+    r.setTick(r.tick() + 3);
+    const uint32 revealTick = r.tick();
+    increaseEnergy(good, collateral);
+    r.revealAndCommit(good, goodReveal1, commitOf(makeReveal(12)), collateral);
+    r.endTick();
+
+    // bad's slot (index 0) was evicted; good must have been swap-deleted into it.
+    ASSERT_EQ(r.state()->populations.get(stream), 1u);
+    EXPECT_TRUE(r.state()->providers.get(stream * RANDOM_STREAM_CAPACITY + 0) == good)
+        << "the surviving provider must have been relocated to the freed slot";
+
+    auto st = r.getProviderStatus(good);
+    ASSERT_EQ(st.count, 1u);
+    EXPECT_EQ(st.lastUpdateTick.get(0), revealTick)
+        << "lastUpdateTick must survive swap-delete relocation, not reset to 0";
 }


### PR DESCRIPTION
RevealAndCommit rejects invalid/stale calls silently (refund only, no signal), so an off-chain client had no way to tell whether a submitted tx actually took effect. lastUpdateTick stamps the tick of the last accepted RevealAndCommit per provider slot, surfaced via GetProviderStatus: a client compares it to the tick it submitted in to tell acceptance from rejection.