### PR TITLE
Pulse Fixes

### DIFF
--- a/src/contracts/Pulse.h
+++ b/src/contracts/Pulse.h
@@ -1330,24 +1330,27 @@ public:
 	 * Deposits QHeart into the contract for automatic ticket purchases.
 	 * @param amount QHeart amount to reserve for auto participation.
 	 * @param desiredTickets Number of tickets to buy per draw.
-	 * @param buyNow When true, tries to buy immediately if selling is open.
+	 * @param buyNow When true, tries to buy immediately if selling is open and uses the invocation reward to pay for random-ticket entropy.
 	 * @return Status code describing the result.
 	 */
 	PUBLIC_PROCEDURE_WITH_LOCALS(DepositAutoParticipation)
 	{
-		if (qpi.invocationReward() > 0)
-		{
-			qpi.transfer(qpi.invocator(), qpi.invocationReward());
-		}
-
 		if (state.get().autoParticipants.population() >= state.get().autoParticipants.capacity())
 		{
+			if (qpi.invocationReward() > 0)
+			{
+				qpi.transfer(qpi.invocator(), qpi.invocationReward());
+			}
 			output.returnCode = EReturnCode::AUTO_PARTICIPANTS_FULL;
 			return;
 		}
 
 		if (input.amount <= 0 || input.desiredTickets <= 0)
 		{
+			if (qpi.invocationReward() > 0)
+			{
+				qpi.transfer(qpi.invocator(), qpi.invocationReward());
+			}
 			output.returnCode = EReturnCode::INVALID_VALUE;
 			return;
 		}
@@ -1364,6 +1367,10 @@ public:
 		locals.totalPrice = smul(state.get().ticketPrice, static_cast<sint64>(input.desiredTickets));
 		if (input.amount < locals.totalPrice)
 		{
+			if (qpi.invocationReward() > 0)
+			{
+				qpi.transfer(qpi.invocator(), qpi.invocationReward());
+			}
 			output.returnCode = EReturnCode::TICKET_INVALID_PRICE;
 			return;
 		}
@@ -1387,6 +1394,10 @@ public:
 				output.returnCode = EReturnCode::SUCCESS;
 				return;
 			}
+		}
+		else if (qpi.invocationReward() > 0)
+		{
+			qpi.transfer(qpi.invocator(), qpi.invocationReward());
 		}
 
 		state.get().autoParticipants.get(qpi.invocator(), locals.entry);


### PR DESCRIPTION
Submission #20 by emmanuelsundayewah@gmail.com
Title: PULSE Double-Refunds the Same Invocation Reward Through Internal Public Procedure Call
Target: https://github.com/qubic/core
Vulnerability Type: Blockchain
Category: Smart Contract
Severity: Critical
Description:
PULSE refunds qpi.invocationReward() at the start of DepositAutoParticipation.
When buyNow is true and ticket selling is open, DepositAutoParticipation internally calls BuyRandomTickets through CALL. The QPI CALL macro invokes the current contract procedure without changing the invocation reward, so BuyRandomTickets sees the same external invocation reward and refunds it again.
A normal user can attach QU once, receive that same attached QU back from DepositAutoParticipation, and then receive it a second time from BuyRandomTickets. The second refund is paid from PULSE’s existing native QU balance.
Link: https://gist.github.com/Ewah437/53745e5b89602800c06b5a26e628e8cc
Affected Asset: https://github.com/qubic/core/blob/main/src/contracts/Pulse.h