### PR TITLE
Optimize vote signing

### DIFF
--- a/src/Qubic.vcxproj
+++ b/src/Qubic.vcxproj
@@ -93,6 +93,7 @@
     <ClInclude Include="network_messages\system_info.h" />
     <ClInclude Include="network_messages\tick.h" />
     <ClInclude Include="network_messages\transactions.h" />
+    <ClInclude Include="optimizations\opt_parallel_sign_votes.h" />
     <ClInclude Include="oracle_core\core_om_network_messages.h" />
     <ClInclude Include="oracle_core\net_msg_impl.h" />
     <ClInclude Include="oracle_core\oracle_engine.h" />

--- a/src/Qubic.vcxproj.filters
+++ b/src/Qubic.vcxproj.filters
@@ -430,6 +430,9 @@
     <ClInclude Include="oc_interfaces\Mock.h">
       <Filter>oc_interfaces</Filter>
     </ClInclude>
+    <ClInclude Include="optimizations\opt_parallel_sign_votes.h">
+      <Filter>optimizations</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="platform">
@@ -485,6 +488,9 @@
     </Filter>
     <Filter Include="oc_interfaces">
       <UniqueIdentifier>{804c1cd3-c9f7-4f71-bc5e-a66907c4d63f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="optimizations">
+      <UniqueIdentifier>{0eb1ebbd-eb65-4fa4-a7e0-954f4d753a51}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/four_q.h
+++ b/src/four_q.h
@@ -1876,6 +1876,71 @@ static void signWithRandomK(const unsigned char* subseed, const unsigned char* p
     }
 }
 
+// Completes the second half of the signature[32..64]. Since the vote signing PoW only checks the first half
+// of the signature[0..32], the second half only needs to be computed once using the r that passed the PoW check. 
+// kConst is K12(subseed,32); r is the winning rOut (consumed, modified in place exactly as signWithRandomK does);
+// signature[0..32] = the winning encode(R); messageDigest is the same digest passed to signWithRandomK_incremental.
+static void signWithRandomK_finishHalf(const unsigned char* kConst, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned long long* r, unsigned char* signature)
+{
+    // h = K12(encode(R) || publicKey || messageDigest) exactly as in signWithRandomK
+    unsigned char h[64], temp[32 + 64];
+    *((m256i*)temp) = *((m256i*)signature);
+    *((m256i*)(temp + 32)) = *((m256i*)publicKey);
+    *((m256i*)(temp + 64)) = *((m256i*)messageDigest);
+    KangarooTwelve(temp, 32 + 64, h, 64);
+    Montgomery_multiply_mod_order(r, Montgomery_Rprime, r);
+    Montgomery_multiply_mod_order(r, ONE, r);
+    Montgomery_multiply_mod_order((unsigned long long*)h, Montgomery_Rprime, (unsigned long long*)h);
+    Montgomery_multiply_mod_order((unsigned long long*)h, ONE, (unsigned long long*)h);
+    Montgomery_multiply_mod_order((unsigned long long*)kConst, Montgomery_Rprime, (unsigned long long*)(signature + 32));
+    Montgomery_multiply_mod_order((unsigned long long*)h, Montgomery_Rprime, (unsigned long long*)h);
+    Montgomery_multiply_mod_order((unsigned long long*)(signature + 32), (unsigned long long*)h, (unsigned long long*)(signature + 32));
+    Montgomery_multiply_mod_order((unsigned long long*)(signature + 32), ONE, (unsigned long long*)(signature + 32));
+    if (_subborrow_u64(_subborrow_u64(_subborrow_u64(_subborrow_u64(0, r[0], ((unsigned long long*)signature)[4], &((unsigned long long*)signature)[4]), r[1], ((unsigned long long*)signature)[5], &((unsigned long long*)signature)[5]), r[2], ((unsigned long long*)signature)[6], &((unsigned long long*)signature)[6]), r[3], ((unsigned long long*)signature)[7], &((unsigned long long*)signature)[7]))
+    {
+        _addcarry_u64(_addcarry_u64(_addcarry_u64(_addcarry_u64(0, ((unsigned long long*)signature)[4], CURVE_ORDER_0, &((unsigned long long*)signature)[4]), ((unsigned long long*)signature)[5], CURVE_ORDER_1, &((unsigned long long*)signature)[5]), ((unsigned long long*)signature)[6], CURVE_ORDER_2, &((unsigned long long*)signature)[6]), ((unsigned long long*)signature)[7], CURVE_ORDER_3, &((unsigned long long*)signature)[7]);
+    }
+}
+
+// Incremental vote signing PoW. The PoW score is fully determined by encode(r*G) but calculating
+// the ecc_mul_fixed for each signWithRandomK try is expensive. Searching r sequentially (random r0, then r0+1, r0+2, ...)
+// makes each step a significantly cheaper point addition R_{i+1}=R_i+G (eccadd).
+// gIncrSignG is G in eccadd-precomp form, built once by initIncrementalSignG() at boot.
+static point_extproj_precomp_t gIncrSignG;
+
+static void initIncrementalSignG()
+{
+    unsigned long long one[8] = { 1,0,0,0,0,0,0,0 };
+    point_t Gaff; ecc_mul_fixed(one, Gaff);
+    point_extproj_t Gext; point_setup(Gaff, Gext);
+    R1_to_R2(Gext, gIncrSignG);
+}
+
+static void signWithRandomK_incremental(const unsigned char* subseed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature, unsigned int target)
+{
+    unsigned char kConst[32];
+    KangarooTwelve((unsigned char*)subseed, 32, kConst, 32);
+    unsigned char rndKAndMsg[64];                                            // r0 = K12(randomK || msg)
+    for (int j = 0; j < 32; j += 8) _rdrand64_step((unsigned long long*)(rndKAndMsg + j));
+    *((m256i*)(rndKAndMsg + 32)) = *((m256i*)messageDigest);
+    unsigned long long base[8];
+    KangarooTwelve(rndKAndMsg, 64, (unsigned char*)base, 64);
+    point_t R0aff; ecc_mul_fixed(base, R0aff);                               // R0 = base * G (one full mul)
+    point_extproj_t Rext; point_setup(R0aff, Rext);
+    unsigned long long offset = 0;
+    while (true)                                                             // R_i = R0 + offset * G
+    {
+        point_extproj_t cpy; copyMem(cpy, Rext, sizeof(point_extproj_t));    // eccnorm mutates z -> work on a copy
+        point_t Raff; eccnorm(cpy, Raff); encode(Raff, signature);           // signature[0..32] = encode(R_i)
+        if (_byteswap_ulong(((unsigned int*)signature)[0]) <= target) break; // break loop if PoW target met
+        eccadd(gIncrSignG, Rext); offset++;                                  // Rext += G  -> R_{i+1}
+    }
+    unsigned long long r[8]; copyMem(r, base, sizeof(r));                    // winning nonce r = base + offset
+    unsigned long long carry = offset;
+    for (int j = 0; j < 8 && carry; j++) { unsigned long long old = r[j]; r[j] += carry; carry = (r[j] < old) ? 1ull : 0ull; }
+    signWithRandomK_finishHalf(kConst, publicKey, messageDigest, r, signature);
+}
+
 static bool verify(const unsigned char* publicKey, const unsigned char* messageDigest, const unsigned char* signature)
 { // SchnorrQ signature verification
   // It verifies the signature Signature of a message MessageDigest of size 32 in bytes

--- a/src/four_q.h
+++ b/src/four_q.h
@@ -1916,7 +1916,7 @@ static void initIncrementalSignG()
     R1_to_R2(Gext, gIncrSignG);
 }
 
-static void signWithRandomK_incremental(const unsigned char* subseed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature, unsigned int target)
+static void signWithRandomK_incremental(const unsigned char* subseed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature, unsigned int target, volatile int* done = nullptr)
 {
     unsigned char kConst[32];
     KangarooTwelve((unsigned char*)subseed, 32, kConst, 32);
@@ -1928,7 +1928,7 @@ static void signWithRandomK_incremental(const unsigned char* subseed, const unsi
     point_t R0aff; ecc_mul_fixed(base, R0aff);                               // R0 = base * G (one full mul)
     point_extproj_t Rext; point_setup(R0aff, Rext);
     unsigned long long offset = 0;
-    while (true)                                                             // R_i = R0 + offset * G
+    while (!done || !*done)                                                  // R_i = R0 + offset * G
     {
         point_extproj_t cpy; copyMem(cpy, Rext, sizeof(point_extproj_t));    // eccnorm mutates z -> work on a copy
         point_t Raff; eccnorm(cpy, Raff); encode(Raff, signature);           // signature[0..32] = encode(R_i)

--- a/src/optimizations/opt_parallel_sign_votes.h
+++ b/src/optimizations/opt_parallel_sign_votes.h
@@ -1,0 +1,185 @@
+#pragma once
+
+// Parallel signTickVote with STRAGGLER RACING:
+//
+// signTickVote is a mandatory proof-of-work retry loop: signWithRandomK + verify until the
+// signature score < TARGET_TICK_VOTE_SIGNATURE.
+//
+// This optimization splits the sign tasks one-per-index across the request-processor pool. 
+// The makespan is TAIL-BOUND: each index is a SEQUENTIAL PoW loop, so the
+// slowest single index (the worst geometric draw over all tries) is ground by ONE core
+// alone while the others go idle. Adding cores cannot speed one sequential signature.
+//
+// Hence, idle workers have to RACE the in-flight stragglers. A signature is valid as soon as ANY
+// random-K attempt passes the difficulty, and ANY valid signature is consensus-acceptable — so
+// many cores can attempt the SAME index concurrently with different random K and the first valid
+// one wins. Once a core finishes its owned task and finds nothing unclaimed, it picks an
+// in-flight (not-done) index and races it.
+//
+// SAFETY (consensus-critical):
+//  * Each racer signs into its OWN stack scratch buffer; only the winner of an atomic done-CAS
+//    copies its scratch into the real signature slot -> no torn writes.
+//  * completedCount is incremented exactly once per index (by the done-CAS winner) -> waitAll's
+//    barrier is exact.
+//  * The race loop bails the moment `done` is set (another core won this index) -> losers stop
+//    promptly, no wasted grind into the next round.
+//  * A `generation` counter (bumped each dispatch) guards the commit: a worker only writes +
+//    counts if the generation is unchanged since it started -> an impossibly-late straggler from a
+//    previous round can never corrupt the next round's slot. (The pool dispatches once per tick,
+//    ~hundreds of ms apart, so this is belt-and-suspenders.)
+//
+// Disable via USE_PARALLEL_SIGN_VOTES in private_settings.h. The serial signTickVote() path
+// (USE_PARALLEL_SIGN_VOTES=0, and the inline fallback) is unchanged.
+
+#include "../platform/concurrency.h"
+#include "../network_messages/common_def.h"
+
+struct ParallelSignVoteTasks
+{
+    // One entry per own-computor-index for the current tick. Worker copies out everything it
+    // needs before claiming; no race on the inputs after publish.
+    struct alignas(64) Task
+    {
+        const unsigned char* subseed;
+        const unsigned char* publicKey;
+        const unsigned char* messageDigest;
+        unsigned char* signature;   // winner writes the final signature here
+        volatile int claimed;   // 0 = no owner yet, 1 = an owner has taken it
+        volatile int done;      // 0 = in progress, 1 = a valid signature has been committed
+    };
+
+    // Racing sign function: attempt random-K signatures until one is valid (writes it to outSig
+    // and returns true) OR `done` is observed set by another core (returns false, bail). Defined
+    // in qubic.cpp where verifyTickVoteSignature / signWithRandomK are in scope.
+    typedef bool (*SignFunc)(const unsigned char* subseed,
+                             const unsigned char* publicKey,
+                             const unsigned char* messageDigest,
+                             unsigned char* outSig,
+                             volatile int* done);
+
+    static constexpr int MAX_TASKS = NUMBER_OF_COMPUTORS;
+
+    Task tasks[MAX_TASKS];
+    int taskCount = 0;
+    volatile int completedCount{0};
+    volatile bool active{false};
+    volatile unsigned int generation{0};
+    SignFunc func = nullptr;
+
+    void init(SignFunc f)
+    {
+        func = f;
+        for (int i = 0; i < MAX_TASKS; i++)
+        {
+            tasks[i].subseed = nullptr;
+            tasks[i].publicKey = nullptr;
+            tasks[i].messageDigest = nullptr;
+            tasks[i].signature = nullptr;
+            tasks[i].claimed = 0;
+            tasks[i].done = 0;
+        }
+        taskCount = 0;
+        completedCount = 0;
+        active = false;
+        generation = 0;
+    }
+
+    // Sign one index (as owner or as a racer). Winner of the done-CAS commits the signature and
+    // counts it; losers/bailers do nothing. Generation-guarded so a stale worker can never write
+    // into a later round.
+    void processTask(int i, bool isTicker)
+    {
+        const unsigned int myGen = generation;
+        unsigned char scratch[SIGNATURE_SIZE];
+        if (func(tasks[i].subseed, tasks[i].publicKey, tasks[i].messageDigest, scratch, &tasks[i].done))
+        {
+            if (generation == myGen)
+            {
+                if (_InterlockedCompareExchange((long*)&tasks[i].done, 1, 0) == 0)
+                {
+                    copyMem(tasks[i].signature, scratch, SIGNATURE_SIZE);
+                    _InterlockedExchangeAdd((long*)&completedCount, 1);
+                    (void)isTicker;
+                }
+            }
+        }
+    }
+
+    // Ticker: publish all tasks for this tick.
+    void dispatchAll(int n)
+    {
+        _InterlockedExchangeAdd((long*)&generation, 1);
+        for (int i = 0; i < n; i++)
+        {
+            tasks[i].claimed = 0;
+            tasks[i].done = 0;
+        }
+        completedCount = 0;
+        taskCount = n;
+        active = true;
+    }
+
+    // Request processor: do one unit of sign work. Owns an unclaimed index if one is free,
+    // otherwise RACES an in-flight straggler. Returns true if it did (or attempted) work.
+    bool tryProcessOne()
+    {
+        if (!active) return false;
+        const int n = taskCount;
+        // Phase 1: become the owner of an unclaimed index.
+        for (int i = 0; i < n; i++)
+        {
+            if (_InterlockedCompareExchange((long*)&tasks[i].claimed, 1, 0) == 0)
+            {
+                processTask(i, false);
+                return true;
+            }
+        }
+        // Phase 2: every index has an owner — collapse the tail by racing an in-flight one.
+        for (int i = 0; i < n; i++)
+        {
+            if (tasks[i].done == 0)
+            {
+                processTask(i, false);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Ticker: take any unclaimed indices, then help race in-flight stragglers until all done.
+    void waitAll()
+    {
+        const int n = taskCount;
+        for (int i = 0; i < n; i++)
+        {
+            if (_InterlockedCompareExchange((long*)&tasks[i].claimed, 1, 0) == 0)
+            {
+                processTask(i, true);
+            }
+        }
+        while (completedCount < n)
+        {
+            int straggler = -1;
+            for (int i = 0; i < n; i++)
+            {
+                if (tasks[i].done == 0)
+                {
+                    straggler = i;
+                    break;
+                }
+            }
+            if (straggler >= 0)
+            {
+                processTask(straggler, true);
+            }
+            else
+            {
+                _mm_pause();
+            }
+        }
+        active = false;
+        taskCount = 0;
+    }
+};
+
+static ParallelSignVoteTasks parallelSignVotes;

--- a/src/private_settings.h
+++ b/src/private_settings.h
@@ -43,6 +43,8 @@ static const unsigned char ocMachineIPs[][4] = {
 
 #define ENABLE_QUBIC_LOGGING_EVENT 0 // turn on logging events
 
+#define USE_PARALLEL_SIGN_VOTES 1
+
 // Virtual memory settings for logging
 #define LOG_BUFFER_PAGE_SIZE 300000000ULL
 #define PMAP_LOG_PAGE_SIZE 30000000ULL

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5254,7 +5254,7 @@ static bool signTickVoteRacing(const unsigned char* subseed, const unsigned char
 {
     PROFILE_SCOPE();
 
-    if (done) return false; // skip starting if another core already won
+    if (*done) return false; // skip starting if another core already won
     signWithRandomK_incremental(subseed, publicKey, messageDigest, outSig, TARGET_TICK_VOTE_SIGNATURE);
     return true;
 }

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -90,6 +90,10 @@
 #include "qpi/impl/qpi_mining_impl.h"
 #include "revenue.h"
 
+#if USE_PARALLEL_SIGN_VOTES
+#include "optimizations/opt_parallel_sign_votes.h"
+#endif
+
 ////////// Qubic \\\\\\\\\\
 
 #define CONTRACT_STATES_DEPTH 10 // Is derived from MAX_NUMBER_OF_CONTRACTS (=N)
@@ -1891,6 +1895,14 @@ static void requestProcessor(void* ProcedureArgument)
             END_WAIT_WHILE();
             _InterlockedDecrement(&epochTransitionWaitingRequestProcessors);
         }
+
+#if USE_PARALLEL_SIGN_VOTES
+        // Pull pending signTickVote tasks dispatched by broadcastTickVotes().
+        // Cheap fast-path when nothing pending, otherwise loop until pool empty.
+        while (parallelSignVotes.tryProcessOne())
+        {
+        }
+#endif
 
         // try to compute a solution if any is queued and this thread is assigned to compute solution
         if (solutionProcessorFlags[processorNumber])
@@ -5230,9 +5242,90 @@ static void signTickVote(const unsigned char* subseed, const unsigned char* publ
     return;
 }
 
+#if USE_PARALLEL_SIGN_VOTES
+// Racing variant for parallelSignVotes straggler-racing. Same mandatory PoW (signWithRandomK + verify until
+// score < TARGET_TICK_VOTE_SIGNATURE), but writes into the caller's scratch buffer and BAILS the moment
+// `done` is observed set — i.e. another core already produced a valid signature for this same index.
+// Returns true with a valid signature in outSig, or false if it bailed. The pool's processTask() commits
+// outSig into the real slot only if it wins the done-CAS, so concurrent racers on one index never tear the
+// signature and exactly one valid signature is kept. Any valid signature is consensus-acceptable,
+// so racing different random K across cores is safe.
+static bool signTickVoteRacing(const unsigned char* subseed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* outSig, volatile int* done)
+{
+    PROFILE_SCOPE();
+
+    if (done) return false; // skip starting if another core already won
+    signWithRandomK_incremental(subseed, publicKey, messageDigest, outSig, TARGET_TICK_VOTE_SIGNATURE);
+    return true;
+}
+#endif
+
 // broadcast all tickVotes from all IDs in this node
 static void broadcastTickVotes()
 {
+#if USE_PARALLEL_SIGN_VOTES
+    // Parallelize the per-own-index signing across the request-processor pool.
+    // Phase 1 (prepare BroadcastTick + per-index K12 hashing) and
+    // Phase 3 (enqueueResponse) stay sequential on the ticker;
+    // Phase 2 (signTickVote) is dispatched as independent tasks.
+    // Each task writes to its own perIndexBroadcastTick[i].signature so workers don't race.
+    static BroadcastTick perIndexBroadcastTick[NUMBER_OF_COMPUTORS];
+    static unsigned char perIndexDigest[NUMBER_OF_COMPUTORS][32];
+
+    const unsigned int n = numberOfOwnComputorIndices;
+
+    // Phase 1: prepare data for each index (sequential, cheap K12 hashes).
+    for (unsigned int i = 0; i < n; i++)
+    {
+        BroadcastTick& bt = perIndexBroadcastTick[i];
+        copyMem(&bt.tick, &etalonTick, sizeof(Tick));
+        bt.tick.computorIndex = ownComputorIndices[i] ^ BroadcastTick::type();
+        bt.tick.epoch = system.epoch;
+        m256i saltedData[2];
+        saltedData[0] = computorPublicKeys[ownComputorIndicesMapping[i]];
+        saltedData[1].m256i_u32[0] = resourceTestingDigest;
+        KangarooTwelve(saltedData, 32 + sizeof(resourceTestingDigest), &bt.tick.saltedResourceTestingDigest, sizeof(bt.tick.saltedResourceTestingDigest));
+
+        saltedData[1] = etalonTick.saltedSpectrumDigest;
+        KangarooTwelve64To32(saltedData, &bt.tick.saltedSpectrumDigest);
+
+        saltedData[1] = etalonTick.saltedUniverseDigest;
+        KangarooTwelve64To32(saltedData, &bt.tick.saltedUniverseDigest);
+
+        saltedData[1] = etalonTick.saltedComputerDigest;
+        KangarooTwelve64To32(saltedData, &bt.tick.saltedComputerDigest);
+
+        saltedData[1] = m256i::zero();
+        saltedData[1].m256i_u32[0] = etalonTick.saltedTransactionBodyDigest;
+        KangarooTwelve(saltedData, 32 + sizeof(etalonTick.saltedTransactionBodyDigest), &bt.tick.saltedTransactionBodyDigest, sizeof(bt.tick.saltedTransactionBodyDigest));
+
+        KangarooTwelve(&bt.tick, sizeof(Tick) - SIGNATURE_SIZE, perIndexDigest[i], 32);
+        bt.tick.computorIndex ^= BroadcastTick::type();
+
+        // Wire up this task: sign(subseed, publicKey, digest) -> signature
+        parallelSignVotes.tasks[i].subseed = computorSubseeds[ownComputorIndicesMapping[i]].m256i_u8;
+        parallelSignVotes.tasks[i].publicKey = computorPublicKeys[ownComputorIndicesMapping[i]].m256i_u8;
+        parallelSignVotes.tasks[i].messageDigest = perIndexDigest[i];
+        parallelSignVotes.tasks[i].signature = bt.tick.signature;
+    }
+
+    // Phase 2: dispatch all signing work to the request-processor pool.
+    if (n > 0)
+    {
+        parallelSignVotes.dispatchAll((int)n);
+        parallelSignVotes.waitAll();
+    }
+
+    // Phase 3: enqueue broadcast for each prepared+signed BroadcastTick.
+    for (unsigned int i = 0; i < n; i++)
+    {
+        enqueueResponse(NULL, sizeof(BroadcastTick), BroadcastTick::type(), 0, &perIndexBroadcastTick[i]);
+        // NOTE: here we don't copy these votes to memory, instead we wait other nodes echoing these votes back because:
+        // - if own votes don't get echoed back, that indicates this node has internet/topo issue, and need to reissue vote (F9)
+        // - all votes need to be processed in a single place of code (for further handling)
+        // - all votes are treated equally (own votes and their votes)
+    }
+#else
     BroadcastTick broadcastTick;
     copyMem(&broadcastTick.tick, &etalonTick, sizeof(Tick));
     for (unsigned int i = 0; i < numberOfOwnComputorIndices; i++)
@@ -5269,6 +5362,7 @@ static void broadcastTickVotes()
         // - all votes need to be processed in a single place of code (for further handling)
         // - all votes are treated equally (own votes and their votes)
     }
+#endif
 }
 
 // count the votes of current tick (system.tick) and compare it with etalonTick
@@ -6290,6 +6384,12 @@ static bool initialize()
         logToConsole(L"gProfilingDataCollector.init() failed!");
         return false;
     }
+#endif
+
+#if USE_PARALLEL_SIGN_VOTES
+    // Register the per-index worker for the sign-vote task pool.
+    // Request processors pick up tasks during broadcastTickVotes().
+    parallelSignVotes.init(&signTickVoteRacing);
 #endif
 
     setMem(&tickTicks, sizeof(tickTicks), 0);

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5226,13 +5226,8 @@ static void signTickVote(const unsigned char* subseed, const unsigned char* publ
 {
     PROFILE_SCOPE();
 
-    signWithRandomK(subseed, publicKey, messageDigest, signature);
-    bool isOk = verifyTickVoteSignature(publicKey, messageDigest, signature, false);
-    while (!isOk)
-    {
-        signWithRandomK(subseed, publicKey, messageDigest, signature);
-        isOk = verifyTickVoteSignature(publicKey, messageDigest, signature, false);
-    }
+    signWithRandomK_incremental(subseed, publicKey, messageDigest, signature, TARGET_TICK_VOTE_SIGNATURE);
+    return;
 }
 
 // broadcast all tickVotes from all IDs in this node
@@ -6280,6 +6275,9 @@ static bool initialize()
 #if defined (__AVX512F__)
     initAVX512FourQConstants();
 #endif
+
+    // Precalc for vote signing: build G's eccadd-precomp once (needs FourQ constants above)
+    initIncrementalSignG();
 
     if (!initSpecialEntities())
         return false;

--- a/src/qubic.cpp
+++ b/src/qubic.cpp
@@ -5255,7 +5255,7 @@ static bool signTickVoteRacing(const unsigned char* subseed, const unsigned char
     PROFILE_SCOPE();
 
     if (*done) return false; // skip starting if another core already won
-    signWithRandomK_incremental(subseed, publicKey, messageDigest, outSig, TARGET_TICK_VOTE_SIGNATURE);
+    signWithRandomK_incremental(subseed, publicKey, messageDigest, outSig, TARGET_TICK_VOTE_SIGNATURE, done);
     return true;
 }
 #endif

--- a/test/fourq.cpp
+++ b/test/fourq.cpp
@@ -693,3 +693,28 @@ TEST(TestFourQ, TestVerifyRejectsNetworkForgeries)
             << " FORGERY ACCEPTED for vector " << i << " -- the fix is NOT working";
     }
 }
+
+TEST(TestFourQ, SignTickVoteIncrementalPassesVerify)
+{
+#if defined (__AVX512F__)
+    initAVX512FourQConstants();
+#endif
+
+    initIncrementalSignG();  // build G's eccadd-precomp once (needs FourQ constants above)
+
+    unsigned char subseed[32], privateKey[32], publicKey[32], msg[32];
+    for (int i = 0; i < 32; i++) { subseed[i] = (unsigned char)(0x5A + i); msg[i] = (unsigned char)(0xA5 - i); }
+    getPrivateKey(subseed, privateKey);
+    getPublicKey(privateKey, publicKey);
+
+    constexpr unsigned long long TARGET_TICK_VOTE_SIGNATURE = 0x07FFFFFFU; // around 32 signing operations per ID
+
+    for (int it = 0; it < 100; it++)
+    {
+        unsigned char m2[32], s2[64];
+        for (int i = 0; i < 32; i++) m2[i] = (unsigned char)(msg[i] ^ (unsigned char)(it * 7 + i));
+        signWithRandomK_incremental(subseed, publicKey, m2, s2, TARGET_TICK_VOTE_SIGNATURE);
+        EXPECT_TRUE(verify(publicKey, m2, s2));
+        EXPECT_LE(_byteswap_ulong(((unsigned int*)s2)[0]), TARGET_TICK_VOTE_SIGNATURE);
+    }
+}


### PR DESCRIPTION
This PR adds two optimizations to vote signing:

1.) Incremental signing PoW: The vote signing PoW score is fully determined by `encode(r * G)` but calculating the `ecc_mul_fixed` for each signWithRandomK try is expensive. Searching r sequentially (random `r0`, then `r0+1`, `r0+2`, ...) makes each step a significantly cheaper point addition `R_{i+1}=R_i+G` (`eccadd`). Additionally, since the vote signing PoW only checks the first half of the `signature[0..32]`, the second half only needs to be computed once using the r that passed the PoW check.

2.) Parallel vote signing: `broadcastTickVotes` parallelizes signing tasks across the available request processors, yielding a significant speed-up when running multiple computor IDs on one node. This optimization can be toggles via setting `USE_PARALLEL_SIGN_VOTES` to 0/1 in `private_settings.h`.